### PR TITLE
Remove unused variables

### DIFF
--- a/lib/ex_phone_number/extraction.ex
+++ b/lib/ex_phone_number/extraction.ex
@@ -91,7 +91,7 @@ defmodule ExPhoneNumber.Extraction do
   def maybe_strip_extension(number) do
     case Regex.run(Patterns.extn_pattern, number, return: :index) do
       [{index, _} | tail] ->
-        {phone_number_head, phone_number_tail} = String.split_at(number, index)
+        {phone_number_head, _} = String.split_at(number, index)
         if is_viable_phone_number?(phone_number_head) do
           {match_index, match_length} = Enum.find(tail, fn {match_index, match_length} ->
             if match_index > 0 do
@@ -169,7 +169,7 @@ defmodule ExPhoneNumber.Extraction do
     case Regex.run(pattern, number, return: :index) do
       [{index, match_length} | _tail] ->
         if index == 0 do
-          {number_head, number_tail} = String.split_at(number, match_length)
+          {_, number_tail} = String.split_at(number, match_length)
           matches = Regex.run(Patterns.capturing_digit_pattern, number_tail)
           match_is_nil = is_nil(matches)
           capture = if match_is_nil, do: "", else: Enum.at(matches, 1)

--- a/lib/ex_phone_number/metadata/phone_metadata.ex
+++ b/lib/ex_phone_number/metadata/phone_metadata.ex
@@ -291,12 +291,11 @@ defmodule ExPhoneNumber.Metadata.PhoneMetadata do
         Map.merge(%NumberFormat{}, number_format)
       else
         intl_number_format = %NumberFormat{pattern: number_format.pattern, leading_digits_pattern: number_format.leading_digits_pattern}
-        intl_number_format =
-          if number_format.intl_format == Values.description_default_pattern do
-            intl_number_format
-          else
-            Map.merge(intl_number_format, %{format: number_format.intl_format})
-          end
+        if number_format.intl_format == Values.description_default_pattern do
+          intl_number_format
+        else
+          Map.merge(intl_number_format, %{format: number_format.intl_format})
+        end
       end
 
     unless is_nil_or_empty?(intl_number_format.format) do

--- a/lib/ex_phone_number/parsing.ex
+++ b/lib/ex_phone_number/parsing.ex
@@ -67,7 +67,7 @@ defmodule ExPhoneNumber.Parsing do
 
     results_tuple =
       if :ok == elem(results_tuple, 0) do
-        {_, national_number, region_code} = results_tuple
+        {_, national_number, _} = results_tuple
         phone_number = if keep_raw_input, do: %PhoneNumber{raw_input: number_to_parse}, else: %PhoneNumber{}
         {ext, national_number} = maybe_strip_extension(national_number)
         phone_number = if not is_nil_or_empty?(ext), do: %{phone_number | extension: ext}, else: phone_number


### PR DESCRIPTION
to silence warnings