### PR TITLE
Use parentheses to remove the ambiguity of zero-arity-function calls

### DIFF
--- a/lib/ex_phone_number/constants/patterns.ex
+++ b/lib/ex_phone_number/constants/patterns.ex
@@ -18,54 +18,54 @@ defmodule ExPhoneNumber.Constants.Patterns do
 
   def plus_chars(), do: "+\uFF0B"
 
-  def plus_chars_pattern(), do: ~r/[#{plus_chars}]+/u
+  def plus_chars_pattern(), do: ~r/[#{plus_chars()}]+/u
 
-  def leading_plus_chars_pattern(), do: ~r/^[#{plus_chars}]+/u
+  def leading_plus_chars_pattern(), do: ~r/^[#{plus_chars()}]+/u
 
-  def separator_pattern(), do: ~r/[#{valid_punctuation}]+/u
+  def separator_pattern(), do: ~r/[#{valid_punctuation()}]+/u
 
-  def capturing_digit_pattern(), do: ~r/([#{valid_digits}])/u
+  def capturing_digit_pattern(), do: ~r/([#{valid_digits()}])/u
 
-  def valid_start_char_pattern(), do: ~r/[#{plus_chars}#{valid_digits}]/u
+  def valid_start_char_pattern(), do: ~r/[#{plus_chars()}#{valid_digits()}]/u
 
   def second_number_start_pattern(), do: ~r/[\\\/] *x/u
 
-  def unwanted_end_char_pattern(), do: ~r/[^#{valid_digits}#{valid_alpha}#]+$/u
+  def unwanted_end_char_pattern(), do: ~r/[^#{valid_digits()}#{valid_alpha()}#]+$/u
 
   def valid_alpha_phone_pattern(), do: ~r/(?:.*?[A-Za-z]){3}.*/u
 
-  def min_length_phone_number_pattern(), do: "[" <> valid_digits <> "]{" <> Integer.to_string(Values.min_length_for_nsn) <> "}"
+  def min_length_phone_number_pattern(), do: "[" <> valid_digits() <> "]{" <> Integer.to_string(Values.min_length_for_nsn) <> "}"
 
   def valid_phone_number() do
-    "[" <> plus_chars <> "]*(?:[" <>
-      valid_punctuation <>
+    "[" <> plus_chars() <> "]*(?:[" <>
+      valid_punctuation() <>
       Values.star_sign <> "]*[" <>
-      valid_digits <> "]){3,}[" <>
-      valid_punctuation <>
+      valid_digits() <> "]){3,}[" <>
+      valid_punctuation() <>
       Values.star_sign <>
-      valid_alpha <>
-      valid_digits <> "]*"
+      valid_alpha() <>
+      valid_digits() <> "]*"
   end
 
   def default_extn_prefix(), do: " ext. "
 
-  def capturing_extn_digits(), do: "([" <> valid_digits <> "]{1,7})"
+  def capturing_extn_digits(), do: "([" <> valid_digits() <> "]{1,7})"
 
   def extn_patterns_for_parsing() do
     Values.rfc3966_extn_prefix <>
-    capturing_extn_digits <> "|" <>
+    capturing_extn_digits() <> "|" <>
     "[ \u00A0\\t,]*" <>
     "(?:e?xt(?:ensi(?:o\u0301?|\u00F3))?n?|\uFF45?\uFF58\uFF54\uFF4E?|" <>
     "[,x\uFF58#\uFF03~\uFF5E]|int|anexo|\uFF49\uFF4E\uFF54)" <>
     "[:\\.\uFF0E]?[ \u00A0\\t,-]*" <>
-    capturing_extn_digits <> "#?|" <>
-    "[- ]+([" <> valid_digits <> "]{1,5})#"
+    capturing_extn_digits() <> "#?|" <>
+    "[- ]+([" <> valid_digits() <> "]{1,5})#"
   end
 
-  def extn_pattern(), do: ~r/(?:#{extn_patterns_for_parsing})$/iu
+  def extn_pattern(), do: ~r/(?:#{extn_patterns_for_parsing()})$/iu
 
   def valid_phone_number_pattern() do
-    ~r/^#{min_length_phone_number_pattern}$|^#{valid_phone_number}(?:#{extn_patterns_for_parsing})?$/iu
+    ~r/^#{min_length_phone_number_pattern()}$|^#{valid_phone_number()}(?:#{extn_patterns_for_parsing()})?$/iu
   end
 
   def non_digits_pattern(), do: ~r/\D+/u

--- a/lib/ex_phone_number/metadata.ex
+++ b/lib/ex_phone_number/metadata.ex
@@ -77,7 +77,7 @@ defmodule ExPhoneNumber.Metadata do
 
   def get_for_region_code(nil), do: nil
   def get_for_region_code(region_code) do
-    region_code_to_metadata_map[String.upcase(region_code)]
+    region_code_to_metadata_map()[String.upcase(region_code)]
   end
 
   def get_for_region_code_or_calling_code(calling_code, region_code) do
@@ -105,12 +105,12 @@ defmodule ExPhoneNumber.Metadata do
   end
 
   def get_region_code_for_country_code(country_code) when is_number(country_code) do
-    region_codes = country_code_to_region_code_map[country_code]
+    region_codes = country_code_to_region_code_map()[country_code]
    if is_nil(region_codes) do
       Values.unknown_region
     else
       main_country = Enum.find(region_codes, fn(region_code) ->
-        metadata = region_code_to_metadata_map[region_code]
+        metadata = region_code_to_metadata_map()[region_code]
         if is_nil(metadata) do
           false
         else
@@ -127,7 +127,7 @@ defmodule ExPhoneNumber.Metadata do
 
   def get_region_code_for_number(nil), do: nil
   def get_region_code_for_number(%PhoneNumber{} = phone_number) do
-    regions = country_code_to_region_code_map[phone_number.country_code]
+    regions = country_code_to_region_code_map()[phone_number.country_code]
     if is_nil(regions) do
       nil
     else
@@ -145,15 +145,15 @@ defmodule ExPhoneNumber.Metadata do
   end
 
   def get_region_codes_for_country_code(country_code) when is_number(country_code) do
-    List.wrap(country_code_to_region_code_map[country_code])
+    List.wrap(country_code_to_region_code_map()[country_code])
   end
 
   def get_supported_regions() do
-    Enum.filter(Map.keys(region_code_to_metadata_map), fn(key) -> Integer.parse(key) == :error end)
+    Enum.filter(Map.keys(region_code_to_metadata_map()), fn(key) -> Integer.parse(key) == :error end)
   end
 
   def get_supported_global_network_calling_codes() do
-    region_codes_as_strings = Enum.filter(Map.keys(region_code_to_metadata_map), fn(key) -> Integer.parse(key) != :error end)
+    region_codes_as_strings = Enum.filter(Map.keys(region_code_to_metadata_map()), fn(key) -> Integer.parse(key) != :error end)
     Enum.map(region_codes_as_strings, fn(calling_code) ->
       {number, _} = Integer.parse(calling_code)
       number
@@ -167,27 +167,27 @@ defmodule ExPhoneNumber.Metadata do
 
   def is_nanpa_country?(nil), do: false
   def is_nanpa_country?(region_code) when is_binary(region_code) do
-    String.upcase(region_code) in country_code_to_region_code_map[Values.nanpa_country_code]
+    String.upcase(region_code) in country_code_to_region_code_map()[Values.nanpa_country_code]
   end
 
   def is_supported_global_network_calling_code?(calling_code) when is_number(calling_code) do
-    not is_nil(region_code_to_metadata_map[Integer.to_string(calling_code)])
+    not is_nil(region_code_to_metadata_map()[Integer.to_string(calling_code)])
   end
   def is_supported_global_network_calling_code?(_), do: false
 
   def is_supported_region?(region_code) when is_binary(region_code) do
-    not is_nil(region_code_to_metadata_map[String.upcase(region_code)])
+    not is_nil(region_code_to_metadata_map()[String.upcase(region_code)])
   end
   def is_supported_region?(_), do: false
 
   def is_valid_country_code?(nil), do: false
   def is_valid_country_code?(country_code) when is_number(country_code) do
-    not is_nil(country_code_to_region_code_map[country_code])
+    not is_nil(country_code_to_region_code_map()[country_code])
   end
 
   def is_valid_region_code?(nil), do: false
   def is_valid_region_code?(region_code) when is_binary(region_code) do
-    Integer.parse(region_code) == :error and not is_nil(region_code_to_metadata_map[String.upcase(region_code)])
+    Integer.parse(region_code) == :error and not is_nil(region_code_to_metadata_map()[String.upcase(region_code)])
   end
 
   defp find_matching_region_code([], _), do: nil

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule ExPhoneNumber.Mixfile do
      start_permanent: Mix.env == :prod,
      test_coverage: [tool: ExCoveralls],
      preferred_cli_env: ["coveralls": :test, "coveralls.detail": :test, "coveralls.post": :test],
-     deps: deps]
+     deps: deps()]
   end
 
   def application do


### PR DESCRIPTION
Fixes Elixir 1.4 warnings.