### PR TITLE
warning(mix.exs): Unnecessarily quoted keyword

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@ defmodule ExPhoneNumber.Mixfile do
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      test_coverage: [tool: ExCoveralls],
-     preferred_cli_env: ["coveralls": :test, "coveralls.travis": :test],
+     preferred_cli_env: [coveralls: :test, "coveralls.travis": :test],
      deps: deps(),
      package: package(),
      description: description(),


### PR DESCRIPTION
Fixes the following warning output when compiling

    warning: found quoted keyword "coveralls" but the quotes are not required. 
    Note that keywords are always atoms, even when quoted, and quotes should only be used to 
    introduce keywords with foreign characters in them

 