### PR TITLE
Update the Google lib phone number to 8.11.1

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExPhoneNumber.Mixfile do
   use Mix.Project
 
-  @version "0.2.0"
+  @version "0.3.0"
 
   def project do
     [

--- a/resources/PhoneNumberMetadata.xml
+++ b/resources/PhoneNumberMetadata.xml
@@ -44,7 +44,7 @@
        phones.
 
      See also:
-       https://github.com/googlei18n/libphonenumber/blob/master/FAQ.md#unsupported
+       https://github.com/google/libphonenumber/blob/master/FAQ.md#unsupported
      -->
 
 <!DOCTYPE phoneNumberMetadata [
@@ -100,7 +100,7 @@
 
 <phoneNumberMetadata>
   <territories>
-    <!-- Ascension Island -->
+    <!-- Ascension Island (AC) -->
     <!-- http://www.itu.int/oth/T02020000AF/en -->
     <territory id="AC" countryCode="247" internationalPrefix="00">
       <generalDesc>
@@ -122,14 +122,20 @@
         <exampleNumber>40123</exampleNumber>
         <nationalNumberPattern>4\d{4}</nationalNumberPattern>
       </mobile>
+      <!-- Omit '00' as a prefix since that's the IDD prefix. -->
       <uan>
         <possibleLengths national="6"/>
         <exampleNumber>542011</exampleNumber>
-        <nationalNumberPattern>[01589]\d{5}</nationalNumberPattern>
+        <nationalNumberPattern>
+          (?:
+            0[1-9]|
+            [1589]\d
+          )\d{4}
+        </nationalNumberPattern>
       </uan>
     </territory>
 
-    <!-- Andorra -->
+    <!-- Andorra (AD) -->
     <!-- http://www.itu.int/oth/T0202000005/en -->
     <territory id="AD" countryCode="376" internationalPrefix="00">
       <availableFormats>
@@ -189,7 +195,7 @@
       </premiumRate>
     </territory>
 
-    <!-- United Arab Emirates -->
+    <!-- United Arab Emirates (AE) -->
     <!-- http://www.itu.int/oth/T02020000DC/en -->
     <territory id="AE" countryCode="971" internationalPrefix="00" nationalPrefix="0">
       <availableFormats>
@@ -207,12 +213,12 @@
           </leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
-        <numberFormat pattern="(\d{2})(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>5</leadingDigits>
-          <format>$1 $2 $3</format>
-        </numberFormat>
         <numberFormat pattern="(\d{3})(\d)(\d{5})">
           <leadingDigits>[479]</leadingDigits>
+          <format>$1 $2 $3</format>
+        </numberFormat>
+        <numberFormat pattern="(\d{2})(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>5</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
       </availableFormats>
@@ -263,12 +269,12 @@
       </uan>
     </territory>
 
-    <!-- Afghanistan -->
+    <!-- Afghanistan (AF) -->
     <!-- http://www.itu.int/oth/T0202000001/en -->
     <territory id="AF" countryCode="93" internationalPrefix="00" nationalPrefix="0">
       <availableFormats>
         <numberFormat pattern="(\d{3})(\d{4})">
-          <leadingDigits>[2-9]</leadingDigits>
+          <leadingDigits>[1-9]</leadingDigits>
           <format>$1 $2</format>
           <intlFormat>NA</intlFormat>
         </numberFormat>
@@ -294,23 +300,18 @@
       </fixedLine>
       <!-- 731 range is supported based on user report. -->
       <mobile>
-        <possibleLengths national="9"/>
+        <possibleLengths national="9" localOnly="7"/>
         <exampleNumber>701234567</exampleNumber>
-        <nationalNumberPattern>
-          7(?:
-            [014-9]\d|
-            2[89]|
-            3[01]
-          )\d{6}
-        </nationalNumberPattern>
+        <nationalNumberPattern>7\d{8}</nationalNumberPattern>
       </mobile>
     </territory>
 
-    <!-- Antigua and Barbuda -->
+    <!-- Antigua & Barbuda (AG) -->
     <!-- Calling code and formatting shared with 'US' -->
     <!-- http://www.itu.int/oth/T0202000008/en -->
     <territory id="AG" countryCode="1" leadingDigits="268" internationalPrefix="011"
-               nationalPrefix="1">
+               nationalPrefix="1" nationalPrefixForParsing="1|([457]\d{6})$"
+               nationalPrefixTransformRule="268$1">
       <generalDesc>
         <nationalNumberPattern>
           (?:
@@ -402,11 +403,12 @@
       </voip>
     </territory>
 
-    <!-- Anguilla -->
+    <!-- Anguilla (AI) -->
     <!-- Calling code and formatting shared with 'US' -->
     <!-- http://www.itu.int/oth/T0202000007/en -->
     <territory id="AI" countryCode="1" leadingDigits="264" internationalPrefix="011"
-               nationalPrefix="1">
+               nationalPrefix="1" nationalPrefixForParsing="1|([2457]\d{6})$"
+               nationalPrefixTransformRule="264$1">
       <generalDesc>
         <nationalNumberPattern>
           (?:
@@ -482,7 +484,7 @@
       </personalNumber>
     </territory>
 
-    <!-- Albania -->
+    <!-- Albania (AL) -->
     <!-- http://www.itu.int/oth/T0202000002/en -->
     <territory id="AL" countryCode="355" internationalPrefix="00" nationalPrefix="0"
                mobileNumberPortableRegion="true">
@@ -519,16 +521,14 @@
       <generalDesc>
         <nationalNumberPattern>
           (?:
-            (?:
-              [2-58]|
-              6\d
-            )\d\d|
-            700
-          )\d{5}|
-          (?:
-            8\d{2,3}|
+            700\d\d|
             900
-          )\d{3}
+          )\d{3}|
+          8\d{5,7}|
+          (?:
+            [2-5]|
+            6\d
+          )\d{7}
         </nationalNumberPattern>
       </generalDesc>
       <fixedLine>
@@ -547,14 +547,17 @@
           )\d{4}
         </nationalNumberPattern>
       </fixedLine>
-      <!-- More specific prefixes from the 1.NumraAlokuar.rar file linked from the ITU doc. -->
+      <!-- More specific prefixes from the 1.NumraAlokuar.rar file linked from the ITU doc.
+           Though 677 is mentioned as unallocated in
+           http://akep.al/images/stories/AKEP/plani-numracionit/1.NumraAlokuar.rar,
+           adding support for 67[7-9] based on carrier doc. -->
       <mobile>
         <possibleLengths national="9"/>
-        <exampleNumber>662123456</exampleNumber>
+        <exampleNumber>672123456</exampleNumber>
         <nationalNumberPattern>
           6(?:
-            [689][2-9]|
-            7[2-6]
+            [78][2-9]|
+            9\d
           )\d{6}
         </nationalNumberPattern>
       </mobile>
@@ -583,7 +586,7 @@
       </personalNumber>
     </territory>
 
-    <!-- Armenia -->
+    <!-- Armenia (AM) -->
     <!-- We think the national dialling prefix is 0 - it seems this was a change in 2005 (or 2008)
          along with the new city codes. However, their official document makes no mention of it,
          websites disagree, and we are not sure if the change has actually been made. -->
@@ -593,6 +596,17 @@
     <territory id="AM" countryCode="374" internationalPrefix="00" nationalPrefix="0"
                mobileNumberPortableRegion="true">
       <availableFormats>
+        <numberFormat pattern="(\d{3})(\d{2})(\d{3})" nationalPrefixFormattingRule="$NP $FG">
+          <leadingDigits>[89]0</leadingDigits>
+          <format>$1 $2 $3</format>
+        </numberFormat>
+        <numberFormat pattern="(\d{3})(\d{5})" nationalPrefixFormattingRule="($NP$FG)">
+          <leadingDigits>
+            2|
+            3[12]
+          </leadingDigits>
+          <format>$1 $2</format>
+        </numberFormat>
         <numberFormat pattern="(\d{2})(\d{6})" nationalPrefixFormattingRule="($NP$FG)">
           <leadingDigits>
             1|
@@ -600,21 +614,9 @@
           </leadingDigits>
           <format>$1 $2</format>
         </numberFormat>
-        <numberFormat pattern="(\d{3})(\d{5})" nationalPrefixFormattingRule="($NP$FG)">
-          <leadingDigits>[23]</leadingDigits>
-          <format>$1 $2</format>
-        </numberFormat>
         <numberFormat pattern="(\d{2})(\d{6})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>
-            [4-7]|
-            88|
-            9[13-9]
-          </leadingDigits>
+          <leadingDigits>[3-9]</leadingDigits>
           <format>$1 $2</format>
-        </numberFormat>
-        <numberFormat pattern="(\d{3})(\d{2})(\d{3})" nationalPrefixFormattingRule="$NP $FG">
-          <leadingDigits>[89]</leadingDigits>
-          <format>$1 $2 $3</format>
         </numberFormat>
       </availableFormats>
       <generalDesc>
@@ -635,7 +637,7 @@
         <nationalNumberPattern>
           (?:
             (?:
-              1[0-2]|
+              1[0-25]|
               47
             )\d|
             2(?:
@@ -656,6 +658,7 @@
         <exampleNumber>77123456</exampleNumber>
         <nationalNumberPattern>
           (?:
+            33|
             4[1349]|
             55|
             77|
@@ -695,7 +698,7 @@
       </voip>
     </territory>
 
-    <!-- Angola -->
+    <!-- Angola (AO) -->
     <!-- http://www.itu.int/oth/T0202000006/en -->
     <territory id="AO" countryCode="244" internationalPrefix="00">
       <availableFormats>
@@ -731,7 +734,7 @@
       </mobile>
     </territory>
 
-    <!-- Argentina -->
+    <!-- Argentina (AR) -->
     <!-- The national prefix for parsing here consists of a 0 (optional), followed by the area code
          (which is captured, so that it can be retained), followed by 15, which is the mobile token,
          which will be stripped if present. We expect the following combinations: 0AC15 and AC15
@@ -839,358 +842,517 @@
                          9[124]
                        )
                      )
-                   )?15
+                   )15
                  )?"
-               nationalPrefixTransformRule="9$1" nationalPrefixFormattingRule="$NP$FG"
-               mobileNumberPortableRegion="true">
+               nationalPrefixTransformRule="9$1" mobileNumberPortableRegion="true">
       <availableFormats>
-        <numberFormat pattern="(\d{3})(\d{3})(\d{4})">
-          <leadingDigits>[68]</leadingDigits>
-          <format>$1-$2-$3</format>
-        </numberFormat>
-        <!-- Format local numbers in two groups. The leading digits are 2-9 since the ITU document
-             says that the digit zero and one will not be present at the start of the subscriber
-             number (which starts with an "Exchange characteristic"). -->
-        <numberFormat pattern="(\d{2})(\d{4})" nationalPrefixFormattingRule="$FG">
-          <leadingDigits>[2-9]</leadingDigits>
-          <format>$1-$2</format>
-          <intlFormat>NA</intlFormat>
-        </numberFormat>
-        <numberFormat pattern="(\d{3})(\d{4})" nationalPrefixFormattingRule="$FG">
-          <leadingDigits>[2-9]</leadingDigits>
-          <format>$1-$2</format>
-          <intlFormat>NA</intlFormat>
-        </numberFormat>
-        <numberFormat pattern="(\d{4})(\d{4})" nationalPrefixFormattingRule="$FG">
-          <leadingDigits>[2-9]</leadingDigits>
-          <format>$1-$2</format>
-          <intlFormat>NA</intlFormat>
-        </numberFormat>
-        <numberFormat pattern="(\d)(\d{2})(\d{4})(\d{4})">
-          <leadingDigits>911</leadingDigits>
-          <format>$2 15-$3-$4</format>
-          <intlFormat>$1 $2 $3-$4</intlFormat>
-        </numberFormat>
-        <!-- The regular expressions below were generated semi-automatically from data extracted
-             from the XLS spreadsheet downloaded from the "Númeración Geográfica" link cited
-             above. Each pattern captures all 3-3-4 prefixes for its length, but may also capture
-             some 4-2-4 cases.
-
-             In cases where a range contains both 3-3-4 and 4-2-4 prefixes, the most commonly used
-             one should be considered the default.
-             * If there are more distinct 4-2-4 prefixes, then the regular expression should
-               INCLUDE only the explicitly mentioned 3-3-4 prefixes.
-             * If there are more distinct 3-3-4 prefixes, then the regular expression should
-               EXCLUDE only the explicitly mentioned 4-2-4 prefixes.
-             This should help maximize the chances of new ranges automatically being assigned to
-             the right form.
-
-             In the final (most specific) regular expression, the few remaining ambiguous cases
-             are decided by comparing usage counts. Any manual edits to these expressions not
-             reflected in the XLS spreadsheet must be clearly called out below:
-
-             Added Manually as 3-3-4 format:
-             * 2981 (General Roca, Río Negro) : Numbers found online suggest 3-3-4
-
-             See also:
-             https://github.com/googlei18n/libphonenumber/issues/611
-             https://github.com/googlei18n/libphonenumber/issues/559 -->
-        <!-- Note that some patterns appear as both 3 and 4 digit area codes. In these cases
-             (to avoid going to 6 digits of discrimination) we simply pick the one with the
-             most uses. Patterns excluded from this expression will be treated as 4-2-4:
-             - XXXX (usage count as 3-digit code:usage count as 4-digit code)
-             - 2646 (7:15)   - excluded
-             - 3435 (39:63)  - excluded
-             - 3454 (90:48)
-             - 3455 (13:94)  - excluded
-             - 3456 (3:93)   - excluded
-             - 3584 (143:65)
-             - 3585 (21:42)  - excluded
-             - 3854 (115:73)
-             - 3855 (76:40)
-             - 3856 (19:44)  - excluded
-             - 3876 (56:99)  - excluded
-             - 3885 (120:45)
-             - 3886 (3:137)  - excluded -->
-        <!-- If the leading digits below are modified, copy the most specific expression into the
-             section below, minus the leading '9' (everything else is auto-generated). We go to
-             6-digit precision on a case-by-case basis (e.g. 9343). -->
-        <numberFormat pattern="(\d)(\d{3})(\d{3})(\d{4})">
-          <leadingDigits>
-            9(?:
-              2[2-4689]|
-              3[3-8]
-            )
-          </leadingDigits>
-          <leadingDigits>
-            9(?:
-              2(?:
-                2[013]|
-                3[067]|
-                49|
-                6[01346]|
-                8|
-                9[147-9]
-              )|
-              3(?:
-                36|
-                4[1-358]|
-                5[138]|
-                6|
-                7[069]|
-                8[013578]
-              )
-            )
-          </leadingDigits>
-          <leadingDigits>
-            9(?:
-              2(?:
-                2(?:
-                  0[013-9]|
-                  [13]
-                )|
-                3(?:
-                  0[013-9]|
-                  [67]
-                )|
-                49|
-                6(?:
-                  [0136]|
-                  4[0-59]
-                )|
-                8|
-                9(?:
-                  [19]|
-                  44|
-                  7[013-9]|
-                  8[14]
-                )
-              )|
-              3(?:
-                36|
-                4(?:
-                  [12]|
-                  3[4-6]|
-                  [58]4
-                )|
-                5(?:
-                  1|
-                  3[0-24-689]|
-                  8[46]
-                )|
-                6|
-                7[069]|
-                8(?:
-                  [01]|
-                  34|
-                  [578][45]
-                )
-              )
-            )
-          </leadingDigits>
-          <leadingDigits>
-            9(?:
-              2(?:
-                2(?:
-                  0[013-9]|
-                  [13]
-                )|
-                3(?:
-                  0[013-9]|
-                  [67]
-                )|
-                49|
-                6(?:
-                  [0136]|
-                  4[0-59]
-                )|
-                8|
-                9(?:
-                  [19]|
-                  44|
-                  7[013-9]|
-                  8[14]
-                )
-              )|
-              3(?:
-                36|
-                4(?:
-                  [12]|
-                  3(?:
-                    4|
-                    5[014]|
-                    6[1-39]
-                  )|
-                  [58]4
-                )|
-                5(?:
-                  1|
-                  3[0-24-689]|
-                  8[46]
-                )|
-                6|
-                7[069]|
-                8(?:
-                  [01]|
-                  34|
-                  [578][45]
-                )
-              )
-            )
-          </leadingDigits>
-          <format>$2 15-$3-$4</format>
-          <intlFormat>$1 $2 $3-$4</intlFormat>
-        </numberFormat>
-        <!-- Both 4-3-3 and 4-2-4 have been seen online; we prefer the latter since it matches the
-             Argentinian ITU doc and wikipedia. -->
-        <numberFormat pattern="(\d)(\d{4})(\d{2})(\d{4})">
-          <leadingDigits>9[23]</leadingDigits>
-          <format>$2 15-$3-$4</format>
-          <intlFormat>$1 $2 $3-$4</intlFormat>
-        </numberFormat>
-        <numberFormat pattern="(\d{2})(\d{4})(\d{4})" nationalPrefixOptionalWhenFormatting="true">
-          <leadingDigits>11</leadingDigits>
-          <format>$1 $2-$3</format>
-        </numberFormat>
-        <!-- These patterns are a copy of the mobile patterns with the leading 9 removed. The most
-             specific pattern below should be a copy of the most specific mobile pattern (with the
-             leading 9 -->
-        <numberFormat pattern="(\d{3})(\d{3})(\d{4})" nationalPrefixOptionalWhenFormatting="true">
-          <leadingDigits>
-            2(?:
-              2[013]|
-              3[067]|
-              49|
-              6[01346]|
-              8|
-              9[147-9]
-            )|
-            3(?:
-              36|
-              4[1-358]|
-              5[138]|
-              6|
-              7[069]|
-              8[013578]
-            )
-          </leadingDigits>
-          <leadingDigits>
-            2(?:
-              2(?:
-                0[013-9]|
-                [13]
-              )|
-              3(?:
-                0[013-9]|
-                [67]
-              )|
-              49|
-              6(?:
-                [0136]|
-                4[0-59]
-              )|
-              8|
-              9(?:
-                [19]|
-                44|
-                7[013-9]|
-                8[14]
-              )
-            )|
-            3(?:
-              36|
-              4(?:
-                [12]|
-                3[4-6]|
-                [58]4
-              )|
-              5(?:
-                1|
-                3[0-24-689]|
-                8[46]
-              )|
-              6|
-              7[069]|
-              8(?:
-                [01]|
-                34|
-                [578][45]
-              )
-            )
-          </leadingDigits>
-          <leadingDigits>
-            2(?:
-              2(?:
-                0[013-9]|
-                [13]
-              )|
-              3(?:
-                0[013-9]|
-                [67]
-              )|
-              49|
-              6(?:
-                [0136]|
-                4[0-59]
-              )|
-              8|
-              9(?:
-                [19]|
-                44|
-                7[013-9]|
-                8[14]
-              )
-            )|
-            3(?:
-              36|
-              4(?:
-                [12]|
-                3(?:
-                  4|
-                  5[014]|
-                  6[1-39]
-                )|
-                [58]4
-              )|
-              5(?:
-                1|
-                3[0-24-689]|
-                8[46]
-              )|
-              6|
-              7[069]|
-              8(?:
-                [01]|
-                34|
-                [578][45]
-              )
-            )
-          </leadingDigits>
-          <format>$1 $2-$3</format>
-        </numberFormat>
-        <numberFormat pattern="(\d{4})(\d{2})(\d{4})" nationalPrefixOptionalWhenFormatting="true">
-          <leadingDigits>[23]</leadingDigits>
-          <format>$1 $2-$3</format>
-        </numberFormat>
         <!-- Format short numbers as a block. -->
-        <numberFormat pattern="(\d{3})" nationalPrefixFormattingRule="$FG">
+        <numberFormat pattern="(\d{3})">
           <leadingDigits>
-            1[0-2]|
-            911
+            [09]|
+            1(?:
+              [02]|
+              1[02-5]
+            )
           </leadingDigits>
           <format>$1</format>
           <intlFormat>NA</intlFormat>
         </numberFormat>
+        <numberFormat pattern="(\d{2})(\d{4})">
+          <leadingDigits>[2-8]</leadingDigits>
+          <format>$1-$2</format>
+          <intlFormat>NA</intlFormat>
+        </numberFormat>
+        <numberFormat pattern="(\d{3})(\d{4})">
+          <leadingDigits>[2-8]</leadingDigits>
+          <format>$1-$2</format>
+          <intlFormat>NA</intlFormat>
+        </numberFormat>
+        <numberFormat pattern="(\d{4})(\d{4})">
+          <leadingDigits>
+            2[0-8]|
+            [3-8]
+          </leadingDigits>
+          <format>$1-$2</format>
+          <intlFormat>NA</intlFormat>
+        </numberFormat>
+        <numberFormat pattern="(\d{4})(\d{2})(\d{4})" nationalPrefixFormattingRule="$NP$FG"
+                      nationalPrefixOptionalWhenFormatting="true">
+          <leadingDigits>
+            2(?:
+              2[024-9]|
+              3[0-59]|
+              47|
+              6[245]|
+              9[02-8]
+            )|
+            3(?:
+              3[28]|
+              4[03-9]|
+              5[2-46-8]|
+              7[1-578]|
+              8[2-9]
+            )
+          </leadingDigits>
+          <leadingDigits>
+            2(?:
+              [23]02|
+              6(?:
+                [25]|
+                4[6-8]
+              )|
+              9(?:
+                [02356]|
+                4[02568]|
+                72|
+                8[23]
+              )
+            )|
+            3(?:
+              3[28]|
+              4(?:
+                [04679]|
+                3[5-8]|
+                5[4-68]|
+                8[2379]
+              )|
+              5(?:
+                [2467]|
+                3[237]|
+                8[2-5]
+              )|
+              7[1-578]|
+              8(?:
+                [2469]|
+                3[2578]|
+                5[4-8]|
+                7[36-8]|
+                8[5-8]
+              )
+            )|
+            2(?:
+              2[24-9]|
+              3[1-59]|
+              47
+            )
+          </leadingDigits>
+          <leadingDigits>
+            2(?:
+              [23]02|
+              6(?:
+                [25]|
+                4(?:
+                  64|
+                  [78]
+                )
+              )|
+              9(?:
+                [02356]|
+                4(?:
+                  [0268]|
+                  5[2-6]
+                )|
+                72|
+                8[23]
+              )
+            )|
+            3(?:
+              3[28]|
+              4(?:
+                [04679]|
+                3[78]|
+                5(?:
+                  4[46]|
+                  8
+                )|
+                8[2379]
+              )|
+              5(?:
+                [2467]|
+                3[237]|
+                8[23]
+              )|
+              7[1-578]|
+              8(?:
+                [2469]|
+                3[278]|
+                5[56][46]|
+                86[3-6]
+              )
+            )|
+            2(?:
+              2[24-9]|
+              3[1-59]|
+              47
+            )|
+            38(?:
+              [58][78]|
+              7[378]
+            )|
+            3(?:
+              4[35][56]|
+              58[45]|
+              8(?:
+                [38]5|
+                54|
+                76
+              )
+            )[4-6]
+          </leadingDigits>
+          <leadingDigits>
+            2(?:
+              [23]02|
+              6(?:
+                [25]|
+                4(?:
+                  64|
+                  [78]
+                )
+              )|
+              9(?:
+                [02356]|
+                4(?:
+                  [0268]|
+                  5[2-6]
+                )|
+                72|
+                8[23]
+              )
+            )|
+            3(?:
+              3[28]|
+              4(?:
+                [04679]|
+                3(?:
+                  5(?:
+                    4[0-25689]|
+                    [56]
+                  )|
+                  [78]
+                )|
+                58|
+                8[2379]
+              )|
+              5(?:
+                [2467]|
+                3[237]|
+                8(?:
+                  [23]|
+                  4(?:
+                    [45]|
+                    60
+                  )|
+                  5(?:
+                    4[0-39]|
+                    5|
+                    64
+                  )
+                )
+              )|
+              7[1-578]|
+              8(?:
+                [2469]|
+                3[278]|
+                54(?:
+                  4|
+                  5[13-7]|
+                  6[89]
+                )|
+                86[3-6]
+              )
+            )|
+            2(?:
+              2[24-9]|
+              3[1-59]|
+              47
+            )|
+            38(?:
+              [58][78]|
+              7[378]
+            )|
+            3(?:
+              454|
+              85[56]
+            )[46]|
+            3(?:
+              4(?:
+                36|
+                5[56]
+              )|
+              8(?:
+                [38]5|
+                76
+              )
+            )[4-6]
+          </leadingDigits>
+          <format>$1 $2-$3</format>
+        </numberFormat>
+        <!-- Formatting for geographic numbers (including those which can be dialled with a mobile token). -->
+        <numberFormat pattern="(\d{2})(\d{4})(\d{4})" nationalPrefixFormattingRule="$NP$FG"
+                      nationalPrefixOptionalWhenFormatting="true">
+          <leadingDigits>1</leadingDigits>
+          <format>$1 $2-$3</format>
+        </numberFormat>
+        <!-- Various non-geographic numbers, including UAN, premium rate but also some mobile
+             ranges. We assume no local dialling is possible for these ranges. -->
+        <numberFormat pattern="(\d{3})(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>[68]</leadingDigits>
+          <format>$1-$2-$3</format>
+        </numberFormat>
+        <numberFormat pattern="(\d{3})(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG"
+                      nationalPrefixOptionalWhenFormatting="true">
+          <leadingDigits>[23]</leadingDigits>
+          <format>$1 $2-$3</format>
+        </numberFormat>
+        <numberFormat pattern="(\d)(\d{4})(\d{2})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>
+            9(?:
+              2[2-469]|
+              3[3-578]
+            )
+          </leadingDigits>
+          <leadingDigits>
+            9(?:
+              2(?:
+                2[024-9]|
+                3[0-59]|
+                47|
+                6[245]|
+                9[02-8]
+              )|
+              3(?:
+                3[28]|
+                4[03-9]|
+                5[2-46-8]|
+                7[1-578]|
+                8[2-9]
+              )
+            )
+          </leadingDigits>
+          <leadingDigits>
+            9(?:
+              2(?:
+                [23]02|
+                6(?:
+                  [25]|
+                  4[6-8]
+                )|
+                9(?:
+                  [02356]|
+                  4[02568]|
+                  72|
+                  8[23]
+                )
+              )|
+              3(?:
+                3[28]|
+                4(?:
+                  [04679]|
+                  3[5-8]|
+                  5[4-68]|
+                  8[2379]
+                )|
+                5(?:
+                  [2467]|
+                  3[237]|
+                  8[2-5]
+                )|
+                7[1-578]|
+                8(?:
+                  [2469]|
+                  3[2578]|
+                  5[4-8]|
+                  7[36-8]|
+                  8[5-8]
+                )
+              )
+            )|
+            92(?:
+              2[24-9]|
+              3[1-59]|
+              47
+            )
+          </leadingDigits>
+          <leadingDigits>
+            9(?:
+              2(?:
+                [23]02|
+                6(?:
+                  [25]|
+                  4(?:
+                    64|
+                    [78]
+                  )
+                )|
+                9(?:
+                  [02356]|
+                  4(?:
+                    [0268]|
+                    5[2-6]
+                  )|
+                  72|
+                  8[23]
+                )
+              )|
+              3(?:
+                3[28]|
+                4(?:
+                  [04679]|
+                  3[78]|
+                  5(?:
+                    4[46]|
+                    8
+                  )|
+                  8[2379]
+                )|
+                5(?:
+                  [2467]|
+                  3[237]|
+                  8[23]
+                )|
+                7[1-578]|
+                8(?:
+                  [2469]|
+                  3[278]|
+                  5(?:
+                    [56][46]|
+                    [78]
+                  )|
+                  7[378]|
+                  8(?:
+                    6[3-6]|
+                    [78]
+                  )
+                )
+              )
+            )|
+            92(?:
+              2[24-9]|
+              3[1-59]|
+              47
+            )|
+            93(?:
+              4[35][56]|
+              58[45]|
+              8(?:
+                [38]5|
+                54|
+                76
+              )
+            )[4-6]
+          </leadingDigits>
+          <leadingDigits>
+            9(?:
+              2(?:
+                [23]02|
+                6(?:
+                  [25]|
+                  4(?:
+                    64|
+                    [78]
+                  )
+                )|
+                9(?:
+                  [02356]|
+                  4(?:
+                    [0268]|
+                    5[2-6]
+                  )|
+                  72|
+                  8[23]
+                )
+              )|
+              3(?:
+                3[28]|
+                4(?:
+                  [04679]|
+                  3(?:
+                    5(?:
+                      4[0-25689]|
+                      [56]
+                    )|
+                    [78]
+                  )|
+                  5(?:
+                    4[46]|
+                    8
+                  )|
+                  8[2379]
+                )|
+                5(?:
+                  [2467]|
+                  3[237]|
+                  8(?:
+                    [23]|
+                    4(?:
+                      [45]|
+                      60
+                    )|
+                    5(?:
+                      4[0-39]|
+                      5|
+                      64
+                    )
+                  )
+                )|
+                7[1-578]|
+                8(?:
+                  [2469]|
+                  3[278]|
+                  5(?:
+                    4(?:
+                      4|
+                      5[13-7]|
+                      6[89]
+                    )|
+                    [56][46]|
+                    [78]
+                  )|
+                  7[378]|
+                  8(?:
+                    6[3-6]|
+                    [78]
+                  )
+                )
+              )
+            )|
+            92(?:
+              2[24-9]|
+              3[1-59]|
+              47
+            )|
+            93(?:
+              4(?:
+                36|
+                5[56]
+              )|
+              8(?:
+                [38]5|
+                76
+              )
+            )[4-6]
+          </leadingDigits>
+          <format>$2 15-$3-$4</format>
+          <intlFormat>$1 $2 $3-$4</intlFormat>
+        </numberFormat>
+        <numberFormat pattern="(\d)(\d{2})(\d{4})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>91</leadingDigits>
+          <format>$2 15-$3-$4</format>
+          <intlFormat>$1 $2 $3-$4</intlFormat>
+        </numberFormat>
+        <numberFormat pattern="(\d)(\d{3})(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>9</leadingDigits>
+          <format>$2 15-$3-$4</format>
+          <intlFormat>$1 $2 $3-$4</intlFormat>
+        </numberFormat>
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
+          11\d{8}|
           (?:
-            11|
-            (?:
-              [2368]|
-              9\d
-            )\d
-          )\d{8}
+            [2368]|
+            9\d
+          )\d{9}
         </nationalNumberPattern>
       </generalDesc>
       <noInternationalDialling>
@@ -1202,197 +1364,553 @@
         <possibleLengths national="10" localOnly="[6-8]"/>
         <exampleNumber>1123456789</exampleNumber>
         <nationalNumberPattern>
-          11\d{8}|
           (?:
+            2954|
+            3(?:
+              777|
+              865
+            )
+          )[2-8]\d{5}|
+          3(?:
+            7(?:
+              1[15]|
+              81
+            )|
+            8(?:
+              21|
+              4[16]|
+              69|
+              9[12]
+            )
+          )[46]\d{5}|
+          (?:
+            (?:
+              11[1-8]|
+              670
+            )\d|
             2(?:
               2(?:
-                [013]\d|
-                2[13-79]|
-                4[1-6]|
-                5[2457]|
-                6[124-8]|
-                7[1-4]|
-                8[13-6]|
-                9[1267]
+                1[2-6]|
+                3[3-6]
               )|
-              3(?:
-                [07]\d|
-                1[467]|
-                2[03-6]|
-                3[13-8]|
-                [49][2-6]|
-                5[2-8]|
-                6[013-9]
-              )|
-              4(?:
-                7[3-8]|
-                9\d
-              )|
+              (?:
+                3[06]|
+                49
+              )4|
               6(?:
-                [01346]\d|
-                2[24-6]|
-                5[15-8]
+                04|
+                1[2-7]|
+                4[4-6]
               )|
-              80\d|
               9(?:
-                [012789]\d|
-                3[1-6]|
-                4[02-9]|
-                5[234]|
-                6[2-46]
+                [17][4-6]|
+                9[3-6]
               )
             )|
             3(?:
-              3(?:
-                2[79]|
-                6\d|
-                8[2578]
-              )|
+              (?:
+                36|
+                64
+              )4|
               4(?:
-                0[0124-9]|
-                [1-357]\d|
-                4[24-7]|
-                6[02-9]|
-                8[0-79]|
-                9[1236-8]
+                1[2-7]|
+                [235][4-6]|
+                84
               )|
               5(?:
-                [138]\d|
-                2[1245]|
-                4[1-9]|
-                6[2-4]|
-                7[1-6]
-              )|
-              6[24]\d|
-              7(?:
-                [069]\d|
-                1[1568]|
-                2[013-9]|
-                3[145]|
-                4[0-35-9]|
-                5[14-8]|
-                7[2-57]|
-                8[0-24-9]
+                1[2-8]|
+                [38][4-6]
               )|
               8(?:
-                [01578]\d|
-                2[15-7]|
-                3[0-24-9]|
-                4[13-6]|
-                6[1-357-9]|
-                9[124]
+                1[2-6]|
+                [58][3-6]|
+                7[24-6]
+              )
+            )
+          )\d{6}|
+          (?:
+            2(?:
+              284|
+              657|
+              9(?:
+                20|
+                66
               )
             )|
-            670\d
-          )\d{6}
+            3(?:
+              4(?:
+                8[27]|
+                92
+              )|
+              755|
+              878
+            )
+          )[2-7]\d{5}|
+          (?:
+            2(?:
+              [28]0|
+              37|
+              6[36]|
+              9[48]
+            )|
+            3(?:
+              62|
+              7[069]|
+              8[03]
+            )
+          )[45]\d{6}|
+          (?:
+            2(?:
+              2(?:
+                2[59]|
+                44|
+                52
+              )|
+              3(?:
+                26|
+                4[24]
+              )|
+              473|
+              9(?:
+                [07]2|
+                2[26]|
+                34|
+                46
+              )
+            )|
+            3327
+          )[45]\d{5}|
+          (?:
+            2(?:
+              (?:
+                26|
+                62
+              )2|
+              3(?:
+                02|
+                2[03]
+              )|
+              477|
+              9(?:
+                42|
+                83
+              )
+            )|
+            3(?:
+              4(?:
+                [47]6|
+                62|
+                89
+              )|
+              5(?:
+                41|
+                64
+              )|
+              873
+            )
+          )[2-6]\d{5}|
+          2(?:
+            2(?:
+              21|
+              4[23]|
+              6[145]|
+              7[1-4]|
+              8[356]|
+              9[267]
+            )|
+            3(?:
+              16|
+              3[13-8]|
+              43|
+              5[346-8]|
+              9[3-5]
+            )|
+            475|
+            6(?:
+              2[46]|
+              4[78]|
+              5[1568]
+            )|
+            9(?:
+              03|
+              2[1457-9]|
+              3[1356]|
+              4[08]|
+              [56][23]|
+              82
+            )
+          )4\d{5}|
+          (?:
+            2(?:
+              2(?:
+                57|
+                81
+              )|
+              3(?:
+                24|
+                46|
+                92
+              )|
+              9(?:
+                01|
+                23|
+                64
+              )
+            )|
+            3(?:
+              329|
+              4(?:
+                42|
+                71
+              )|
+              5(?:
+                25|
+                37|
+                4[347]|
+                71
+              )|
+              7(?:
+                18|
+                5[17]
+              )|
+              888
+            )
+          )[3-6]\d{5}|
+          (?:
+            2(?:
+              2(?:
+                02|
+                2[3467]|
+                4[156]|
+                5[45]|
+                6[6-8]|
+                91
+              )|
+              3(?:
+                1[47]|
+                [24]5|
+                5[25]|
+                96
+              )|
+              47[48]|
+              625|
+              932
+            )|
+            3(?:
+              38[2578]|
+              4(?:
+                0[0-24-9]|
+                3[78]|
+                4[457]|
+                58|
+                6[03-9]|
+                72|
+                83|
+                9[136-8]
+              )|
+              5(?:
+                2[124]|
+                [368][23]|
+                4[2689]|
+                7[2-6]
+              )|
+              7(?:
+                16|
+                2[15]|
+                3[145]|
+                4[13]|
+                5[468]|
+                7[2-5]|
+                8[26]
+              )|
+              8(?:
+                2[5-7]|
+                3[278]|
+                4[3-5]|
+                5[78]|
+                6[1-378]|
+                [78]7|
+                94
+              )
+            )
+          )[4-6]\d{5}
         </nationalNumberPattern>
       </fixedLine>
       <!-- Also covers mobile satellite services (675 numbers). -->
-      <!-- 4-digit area codes are not covered here in detail - we only check the digit after the
-           area code is in the range 2-9. The four-digit area-code checking is done in detail if
-           we attempt to strip the caller-pays token (15) from the number. -->
       <mobile>
         <possibleLengths national="10,11" localOnly="[6-8]"/>
         <exampleNumber>91123456789</exampleNumber>
         <nationalNumberPattern>
-          675\d{7}|
           9(?:
-            11[2-9]\d{7}|
-            (?:
-              2(?:
-                2[013]|
-                3[067]|
-                49|
-                6[01346]|
-                80|
-                9[147-9]
-              )|
-              3(?:
-                36|
-                4[1-358]|
-                5[138]|
-                6[24]|
-                7[069]|
-                8[013578]
-              )
-            )[2-9]\d{6}|
-            (?:
+            2954|
+            3(?:
+              777|
+              865
+            )
+          )[2-8]\d{5}|
+          93(?:
+            7(?:
+              1[15]|
+              81
+            )|
+            8(?:
+              21|
+              4[16]|
+              69|
+              9[12]
+            )
+          )[46]\d{5}|
+          (?:
+            675\d|
+            9(?:
+              11[1-8]\d|
               2(?:
                 2(?:
-                  02|
-                  2[13-79]|
-                  4[1-6]|
-                  5[2457]|
-                  6[124-8]|
-                  7[1-4]|
-                  8[13-6]|
-                  9[1267]
+                  1[2-6]|
+                  3[3-6]
                 )|
-                3(?:
-                  02|
-                  1[467]|
-                  2[03-6]|
-                  3[13-8]|
-                  [49][2-6]|
-                  5[2-8]
-                )|
-                47[3-578]|
+                (?:
+                  3[06]|
+                  49
+                )4|
                 6(?:
-                  2[24-6]|
-                  4[6-8]|
-                  5[15-8]
+                  04|
+                  1[2-7]|
+                  4[4-6]
                 )|
                 9(?:
-                  0[1-3]|
-                  2\d|
-                  3[1-6]|
-                  4[02568]|
-                  5[2-4]|
-                  6[2-46]|
-                  72|
-                  8[23]
+                  [17][4-6]|
+                  9[3-6]
                 )
               )|
               3(?:
-                3(?:
-                  2[79]|
-                  8[2578]
-                )|
+                (?:
+                  36|
+                  64
+                )4|
                 4(?:
-                  0[0-24-9]|
-                  4[24-7]|
-                  6[02-9]|
-                  7[126]|
-                  9[1-36-8]
+                  1[2-7]|
+                  [235][4-6]|
+                  84
                 )|
                 5(?:
-                  2[1245]|
-                  3[237]|
-                  4[1-46-9]|
-                  6[2-4]|
-                  7[1-6]|
-                  8[2-5]
-                )|
-                7(?:
-                  1[1568]|
-                  2[15]|
-                  3[145]|
-                  4[13]|
-                  5[14-8]|
-                  7[2-57]|
-                  8[126]
+                  1[2-8]|
+                  [38][4-6]
                 )|
                 8(?:
-                  2[15-7]|
-                  3[2578]|
-                  4[13-6]|
-                  5[4-8]|
-                  6[1-357-9]|
-                  9[124]
+                  1[2-6]|
+                  [58][3-6]|
+                  7[24-6]
                 )
               )
-            )[2-9]\d{5}
-          )
+            )
+          )\d{6}|
+          9(?:
+            2(?:
+              284|
+              657|
+              9(?:
+                20|
+                66
+              )
+            )|
+            3(?:
+              4(?:
+                8[27]|
+                92
+              )|
+              755|
+              878
+            )
+          )[2-7]\d{5}|
+          9(?:
+            2(?:
+              [28]0|
+              37|
+              6[36]|
+              9[48]
+            )|
+            3(?:
+              62|
+              7[069]|
+              8[03]
+            )
+          )[45]\d{6}|
+          9(?:
+            2(?:
+              2(?:
+                2[59]|
+                44|
+                52
+              )|
+              3(?:
+                26|
+                4[24]
+              )|
+              473|
+              9(?:
+                [07]2|
+                2[26]|
+                34|
+                46
+              )
+            )|
+            3327
+          )[45]\d{5}|
+          9(?:
+            2(?:
+              (?:
+                26|
+                62
+              )2|
+              3(?:
+                02|
+                2[03]
+              )|
+              477|
+              9(?:
+                42|
+                83
+              )
+            )|
+            3(?:
+              4(?:
+                [47]6|
+                62|
+                89
+              )|
+              5(?:
+                41|
+                64
+              )|
+              873
+            )
+          )[2-6]\d{5}|
+          92(?:
+            2(?:
+              21|
+              4[23]|
+              6[145]|
+              7[1-4]|
+              8[356]|
+              9[267]
+            )|
+            3(?:
+              16|
+              3[13-8]|
+              43|
+              5[346-8]|
+              9[3-5]
+            )|
+            475|
+            6(?:
+              2[46]|
+              4[78]|
+              5[1568]
+            )|
+            9(?:
+              03|
+              2[1457-9]|
+              3[1356]|
+              4[08]|
+              [56][23]|
+              82
+            )
+          )4\d{5}|
+          9(?:
+            2(?:
+              2(?:
+                57|
+                81
+              )|
+              3(?:
+                24|
+                46|
+                92
+              )|
+              9(?:
+                01|
+                23|
+                64
+              )
+            )|
+            3(?:
+              329|
+              4(?:
+                42|
+                71
+              )|
+              5(?:
+                25|
+                37|
+                4[347]|
+                71
+              )|
+              7(?:
+                18|
+                5[17]
+              )|
+              888
+            )
+          )[3-6]\d{5}|
+          9(?:
+            2(?:
+              2(?:
+                02|
+                2[3467]|
+                4[156]|
+                5[45]|
+                6[6-8]|
+                91
+              )|
+              3(?:
+                1[47]|
+                [24]5|
+                5[25]|
+                96
+              )|
+              47[48]|
+              625|
+              932
+            )|
+            3(?:
+              38[2578]|
+              4(?:
+                0[0-24-9]|
+                3[78]|
+                4[457]|
+                58|
+                6[03-9]|
+                72|
+                83|
+                9[136-8]
+              )|
+              5(?:
+                2[124]|
+                [368][23]|
+                4[2689]|
+                7[2-6]
+              )|
+              7(?:
+                16|
+                2[15]|
+                3[145]|
+                4[13]|
+                5[468]|
+                7[2-5]|
+                8[26]
+              )|
+              8(?:
+                2[5-7]|
+                3[278]|
+                4[3-5]|
+                5[78]|
+                6[1-378]|
+                [78]7|
+                94
+              )
+            )
+          )[4-6]\d{5}
         </nationalNumberPattern>
       </mobile>
       <tollFree>
@@ -1412,11 +1930,12 @@
       </uan>
     </territory>
 
-    <!-- American Samoa -->
+    <!-- American Samoa (AS) -->
     <!-- Calling code and formatting shared with 'US' -->
     <!-- http://www.itu.int/oth/T0202000004/en -->
     <territory id="AS" countryCode="1" leadingDigits="684" internationalPrefix="011"
-               nationalPrefix="1">
+               nationalPrefix="1" nationalPrefixForParsing="1|([267]\d{6})$"
+               nationalPrefixTransformRule="684$1">
       <generalDesc>
         <nationalNumberPattern>
           (?:
@@ -1496,7 +2015,7 @@
       </personalNumber>
     </territory>
 
-    <!-- Austria -->
+    <!-- Austria (AT) -->
     <!-- http://www.rtr.at/en/tk/E129 -->
     <territory id="AT" countryCode="43" internationalPrefix="00" nationalPrefix="0"
                mobileNumberPortableRegion="true">
@@ -1521,6 +2040,12 @@
         <numberFormat pattern="(\d{2})(\d{3,5})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>5[079]</leadingDigits>
           <format>$1 $2</format>
+        </numberFormat>
+        <!-- Shortcode format -->
+        <numberFormat pattern="(\d{6})">
+          <leadingDigits>1</leadingDigits>
+          <format>$1</format>
+          <intlFormat>NA</intlFormat>
         </numberFormat>
         <!-- 3-digit area codes (fixed line, including premium rate and toll free). -->
         <numberFormat pattern="(\d{3})(\d{3,10})" nationalPrefixFormattingRule="$NP$FG">
@@ -1564,25 +2089,25 @@
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
-          [1-35-9]\d{8,12}|
-          4(?:
-            [0-24-9]\d{4,11}|
-            3(?:
-              (?:
-                0\d|
-                5[02-9]
-              )\d{3,9}|
-              2\d{4,5}|
-              [3467]\d{4}|
-              8\d{4,6}|
-              9\d{4,7}
-            )
+          1\d{3,12}|
+          2\d{6,12}|
+          43(?:
+            (?:
+              0\d|
+              5[02-9]
+            )\d{3,9}|
+            2\d{4,5}|
+            [3467]\d{4}|
+            8\d{4,6}|
+            9\d{4,7}
           )|
-          [1-35-8]\d{7}|
-          [1-35-7]\d{6}|
-          [135-7]\d{5}|
-          [15]\d{4}|
-          1\d{3}
+          5\d{4,12}|
+          8\d{7,12}|
+          9\d{8,12}|
+          (?:
+            [367]\d|
+            4[0-24-9]
+          )\d{4,11}
         </nationalNumberPattern>
       </generalDesc>
       <!-- Note that the full area code is not validated - just the first 3 digits. This also
@@ -1593,72 +2118,66 @@
         <possibleLengths national="[4-13]" localOnly="3"/>
         <exampleNumber>1234567890</exampleNumber>
         <nationalNumberPattern>
-          (?:
-            1(?:
-              11|
-              [2-9]\d{2,10}
-            )|
-            (?:
-              2(?:
-                1[467]|
-                2[13-8]|
-                5[2357]|
-                6[1-46-8]|
-                7[1-8]|
-                8[124-7]|
-                9[1458]
-              )|
-              3(?:
-                1[1-8]|
-                3[23568]|
-                4[5-7]|
-                5[1378]|
-                6[1-38]|
-                8[3-68]
-              )|
-              7(?:
-                2[1-8]|
-                3[25]|
-                4[13478]|
-                5[68]|
-                6[16-8]|
-                7[1-6]|
-                9[45]
-              )
-            )\d{3,9}|
-            4(?:
-              (?:
-                2[1-8]|
-                35|
-                7[1368]|
-                8[2457]
-              )\d{3,9}|
-              63\d{2,9}
-            )|
-            5(?:
-              12\d{2,9}|
-              (?:
-                2[1-8]|
-                3[357]|
-                4[147]|
-                5[12578]|
-                6[37]
-              )\d{3,9}
-            )|
-            6(?:
-              (?:
-                13|
-                2[1-47]|
-                4[135-8]|
-                5[468]
-              )\d{3,9}|
-              62\d{2,9}
-            )
-          )\d|
+          1(?:
+            11\d|
+            [2-9]\d{3,11}
+          )|
           (?:
             316|
-            732
-          )\d{3}
+            463|
+            (?:
+              51|
+              66|
+              73
+            )2
+          )\d{3,10}|
+          (?:
+            2(?:
+              1[467]|
+              2[13-8]|
+              5[2357]|
+              6[1-46-8]|
+              7[1-8]|
+              8[124-7]|
+              9[1458]
+            )|
+            3(?:
+              1[1-578]|
+              3[23568]|
+              4[5-7]|
+              5[1378]|
+              6[1-38]|
+              8[3-68]
+            )|
+            4(?:
+              2[1-8]|
+              35|
+              7[1368]|
+              8[2457]
+            )|
+            5(?:
+              2[1-8]|
+              3[357]|
+              4[147]|
+              5[12578]|
+              6[37]
+            )|
+            6(?:
+              13|
+              2[1-47]|
+              4[135-8]|
+              5[468]
+            )|
+            7(?:
+              2[1-8]|
+              35|
+              4[13478]|
+              5[68]|
+              6[16-8]|
+              7[1-6]|
+              9[45]
+            )
+          )\d{4,10}
         </nationalNumberPattern>
       </fixedLine>
       <mobile>
@@ -1715,31 +2234,20 @@
       </voip>
     </territory>
 
-    <!-- Australia -->
+    <!-- Australia (AU) -->
+    <!-- Main region for 'CC,CX' -->
     <!-- International prefix based on the wikipedia page, either being a combination of the
          "Provider override codes" with the default IDD (0011) following, or the default IDD,
          or the other IDD codes for non-default carriers. -->
-    <!-- Main region for 'CC,CX' -->
     <!-- http://www.itu.int/oth/T020200000D/en -->
     <!-- http://en.wikipedia.org/wiki/Telephone_numbers_in_Australia -->
     <!-- https://www.thenumberingsystem.com.au/#/number-register/search -->
     <territory id="AU" mainCountryForCode="true" countryCode="61"
                preferredInternationalPrefix="0011"
                internationalPrefix="001[14-689]|14(?:1[14]|34|4[17]|[56]6|7[47]|88)0011"
-               nationalPrefix="0" mobileNumberPortableRegion="true">
+               nationalPrefix="0" nationalPrefixForParsing="0|(183[12])"
+               mobileNumberPortableRegion="true">
       <availableFormats>
-        <!-- Premium rate SMS (6 digit) -->
-        <numberFormat pattern="(\d{3})(\d{3})">
-          <leadingDigits>19</leadingDigits>
-          <format>$1 $2</format>
-          <intlFormat>NA</intlFormat>
-        </numberFormat>
-        <!-- Premium rate SMS (7-8 digit) -->
-        <numberFormat pattern="(\d{4})(\d{3,4})">
-          <leadingDigits>19</leadingDigits>
-          <format>$1 $2</format>
-          <intlFormat>NA</intlFormat>
-        </numberFormat>
         <!-- Pager (5-6 digits) -->
         <numberFormat pattern="(\d{2})(\d{3,4})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>16</leadingDigits>
@@ -1751,10 +2259,22 @@
           <format>$1 $2 $3</format>
           <intlFormat>NA</intlFormat>
         </numberFormat>
+        <!-- Premium rate SMS (6 digit) -->
+        <numberFormat pattern="(\d{3})(\d{3})">
+          <leadingDigits>19</leadingDigits>
+          <format>$1 $2</format>
+          <intlFormat>NA</intlFormat>
+        </numberFormat>
         <!-- 7-digit variable cost fixed line (toll free, premium rate, shared cost) -->
         <numberFormat pattern="(\d{3})(\d{4})">
           <leadingDigits>180</leadingDigits>
           <leadingDigits>1802</leadingDigits>
+          <format>$1 $2</format>
+          <intlFormat>NA</intlFormat>
+        </numberFormat>
+        <!-- Premium rate SMS (7-8 digit) -->
+        <numberFormat pattern="(\d{4})(\d{3,4})">
+          <leadingDigits>19</leadingDigits>
           <format>$1 $2</format>
           <intlFormat>NA</intlFormat>
         </numberFormat>
@@ -1763,17 +2283,18 @@
           <leadingDigits>16</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
-        <!-- Fixed line -->
-        <numberFormat pattern="(\d)(\d{4})(\d{4})" nationalPrefixFormattingRule="($NP$FG)">
-          <leadingDigits>[2378]</leadingDigits>
-          <format>$1 $2 $3</format>
-        </numberFormat>
         <!-- Mobile and VOIP -->
         <numberFormat pattern="(\d{3})(\d{3})(\d{3})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>
             14|
             [45]
           </leadingDigits>
+          <format>$1 $2 $3</format>
+        </numberFormat>
+        <!-- Fixed line -->
+        <numberFormat pattern="(\d)(\d{4})(\d{4})" nationalPrefixFormattingRule="($NP$FG)"
+                      carrierCodeFormattingRule="$CC ($FG)">
+          <leadingDigits>[2378]</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
         <!-- 10-digit variable cost fixed line (toll free, premium rate, shared cost) -->
@@ -1789,11 +2310,15 @@
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
-          1\d{4,9}|
+          1(?:
+            [0-79]\d{7,8}|
+            8[0-24-9]\d{7}
+          )|
           (?:
             [2-478]\d\d|
             550
-          )\d{6}
+          )\d{6}|
+          1\d{4,7}
         </nationalNumberPattern>
       </generalDesc>
       <noInternationalDialling>
@@ -1851,14 +2376,15 @@
         <possibleLengths national="9"/>
         <exampleNumber>412345678</exampleNumber>
         <nationalNumberPattern>
+          483[0-3]\d{5}|
           4(?:
             [0-3]\d|
             4[047-9]|
             5[0-25-9]|
-            6[6-9]|
+            6[06-9]|
             7[02-9]|
             8[0-2457-9]|
-            9[017-9]
+            9[0-27-9]
           )\d{6}
         </nationalNumberPattern>
       </mobile>
@@ -1905,16 +2431,19 @@
         <nationalNumberPattern>
           (?:
             14(?:
-              5\d|
-              71
+              5(?:
+                1[0458]|
+                [23][458]
+              )|
+              71\d
             )|
-            550\d
-          )\d{5}
+            550\d\d
+          )\d{4}
         </nationalNumberPattern>
       </voip>
     </territory>
 
-    <!-- Aruba -->
+    <!-- Aruba (AW) -->
     <!-- http://www.itu.int/oth/T020200000B/en -->
     <territory id="AW" countryCode="297" internationalPrefix="00">
       <availableFormats>
@@ -1989,32 +2518,31 @@
       </voip>
     </territory>
 
-    <!-- Åland Islands. -->
+    <!-- Åland Islands (AX) -->
+    <!-- Calling code and formatting shared with 'FI' -->
     <!-- Adding all international carrier access codes in below doc that we found corroborating
          evidence for. Considering these are available in AX region as well.
          https://www.viestintavirasto.fi/en/internettelephone/numberingoftelecommunicationsnetworks/internationalcalls/internationalcarrieraccesscodes.html -->
     <!-- Not supporting national long distance carrier codes as these are overlapping with UAN
          ranges mentioned in ITU doc. -->
-    <!-- Calling code and formatting shared with 'FI' -->
     <!-- https://www.viestintavirasto.fi/internetpuhelin/puhelinverkonnumerointi.html -->
     <territory id="AX" countryCode="358" leadingDigits="18" preferredInternationalPrefix="00"
                internationalPrefix="00|99(?:[01469]|5(?:[14]1|3[23]|5[59]|77|88|9[09]))"
                nationalPrefix="0">
       <generalDesc>
         <nationalNumberPattern>
+          2\d{4,9}|
+          35\d{4,5}|
           (?:
-            (?:
-              [1247]\d|
-              3[0-46-9]|
-              [56]0
-            )\d\d|
+            60\d\d|
             800
           )\d{4,6}|
+          7\d{5,11}|
           (?:
-            [1-47]\d|
+            [14]\d|
+            3[0-46-9]|
             50
-          )\d{4,5}|
-          2\d{4}
+          )\d{4,8}
         </nationalNumberPattern>
       </generalDesc>
       <fixedLine>
@@ -2049,37 +2577,48 @@
            assigned to institutions such as universities, the national post, etc, where they are
            not otherwise classified as toll-free or premium-rate numbers. -->
       <uan>
-        <possibleLengths national="[5-10]"/>
+        <possibleLengths national="[5-12]"/>
         <exampleNumber>10112345</exampleNumber>
         <nationalNumberPattern>
-          (?:
-            10|
-            [23][09]
-          )\d{4,8}|
-          60(?:
-            [12]\d{5,6}|
-            6\d{7}
-          )|
+          20\d{4,8}|
+          60[12]\d{5,6}|
           7(?:
-            (?:
-              1|
-              3\d
-            )\d{7}|
+            099\d{4,5}|
             5[03-9]\d{3,7}
           )|
-          20[2-59]\d\d
+          20[2-59]\d\d|
+          (?:
+            606|
+            7(?:
+              0[78]|
+              1|
+              3\d
+            )
+          )\d{7}|
+          (?:
+            10|
+            29|
+            3[09]|
+            70[1-5]\d
+          )\d{4,8}
         </nationalNumberPattern>
       </uan>
     </territory>
 
-    <!-- Azerbaijan -->
+    <!-- Azerbaijan (AZ) -->
     <!-- http://www.itu.int/oth/T020200000F/en -->
     <territory id="AZ" countryCode="994" internationalPrefix="00" nationalPrefix="0"
                mobileNumberPortableRegion="true">
       <availableFormats>
         <numberFormat pattern="(\d{3})(\d{2})(\d{2})">
+          <leadingDigits>[1-9]</leadingDigits>
           <format>$1 $2 $3</format>
           <intlFormat>NA</intlFormat>
+        </numberFormat>
+        <!-- Premium rate (and maybe other special ranges). -->
+        <numberFormat pattern="(\d{3})(\d{2})(\d{2})(\d{2})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>90</leadingDigits>
+          <format>$1 $2 $3 $4</format>
         </numberFormat>
         <numberFormat pattern="(\d{2})(\d{3})(\d{2})(\d{2})" nationalPrefixFormattingRule="($NP$FG)">
           <leadingDigits>
@@ -2099,31 +2638,21 @@
           </leadingDigits>
           <format>$1 $2 $3 $4</format>
         </numberFormat>
-        <!-- Premium rate (and maybe other special ranges). -->
-        <numberFormat pattern="(\d{3})(\d{2})(\d{2})(\d{2})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>9</leadingDigits>
-          <format>$1 $2 $3 $4</format>
-        </numberFormat>
         <!-- ITU uses XX XXX XXXX for mobile numbers, but numbers online typically
              use XX XXX XX XX. -->
         <numberFormat pattern="(\d{2})(\d{3})(\d{2})(\d{2})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>[3-8]</leadingDigits>
+          <leadingDigits>[3-9]</leadingDigits>
           <format>$1 $2 $3 $4</format>
         </numberFormat>
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
+          365\d{6}|
           (?:
-            (?:
-              (?:
-                [12457]\d|
-                60|
-                88
-              )\d|
-              365
-            )\d{3}|
-            900200
-          )\d{3}
+            [124579]\d|
+            60|
+            88
+          )\d{7}
         </nationalNumberPattern>
       </generalDesc>
       <!-- 12109 fixed line numbers are mentioned as "Information Operator Assistance"
@@ -2133,22 +2662,20 @@
         <possibleLengths national="9" localOnly="7"/>
         <exampleNumber>123123456</exampleNumber>
         <nationalNumberPattern>
+          365(?:
+            [0-46-9]\d|
+            5[0-35-9]
+          )\d{4}|
           (?:
-            (?:
-              1[28]\d|
-              2(?:
-                [045]2|
-                1[24]|
-                2[2-4]|
-                33|
-                6[23]
-              )
-            )\d\d|
-            365(?:
-              [0-46-9]\d|
-              5[0-35-9]
+            1[28]\d|
+            2(?:
+              [045]2|
+              1[24]|
+              2[2-4]|
+              33|
+              6[23]
             )
-          )\d{4}
+          )\d{6}
         </nationalNumberPattern>
       </fixedLine>
       <!-- Prefix 36554 is added to mobile as per confirmation from Ministry of
@@ -2159,13 +2686,14 @@
         <nationalNumberPattern>
           (?:
             36554|
-            (?:
-              4[04]|
-              5[015]|
-              60|
-              7[07]
-            )\d{3}
-          )\d{4}
+            99[2-9]\d\d
+          )\d{4}|
+          (?:
+            4[04]|
+            5[015]|
+            60|
+            7[07]
+          )\d{7}
         </nationalNumberPattern>
       </mobile>
       <!-- 88 is listed as fixed-line for Baku in the ITU document, but online numbers seem to
@@ -2183,7 +2711,7 @@
       </premiumRate>
     </territory>
 
-    <!-- Bosnia and Herzegovina -->
+    <!-- Bosnia & Herzegovina (BA) -->
     <!-- accessible from http://www.cra.ba/en/telecom/numbering/ -->
     <!-- http://www.rak.ba/eng/index.php?uid=1272016657 -->
     <!-- http://en.wikipedia.org/wiki/+387 -->
@@ -2196,15 +2724,18 @@
           <intlFormat>NA</intlFormat>
         </numberFormat>
         <numberFormat pattern="(\d{2})(\d{3})(\d{3})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>[3-5]</leadingDigits>
-          <format>$1 $2-$3</format>
-        </numberFormat>
-        <numberFormat pattern="(\d{2})(\d{3})(\d{3})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>
-            6[1-356]|
+            6[1-3]|
             [7-9]
           </leadingDigits>
           <format>$1 $2 $3</format>
+        </numberFormat>
+        <numberFormat pattern="(\d{2})(\d{3})(\d{3})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>
+            [3-5]|
+            6[56]
+          </leadingDigits>
+          <format>$1 $2-$3</format>
         </numberFormat>
         <!-- 9-digit mobile. -->
         <numberFormat pattern="(\d{2})(\d{2})(\d{2})(\d{3})" nationalPrefixFormattingRule="$NP$FG">
@@ -2214,10 +2745,10 @@
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
+          6\d{8}|
           (?:
-            [3589]\d|
+            [35689]\d|
             49|
-            6\d\d?|
             70
           )\d{6}
         </nationalNumberPattern>
@@ -2253,15 +2784,13 @@
         <possibleLengths national="8,9"/>
         <exampleNumber>61123456</exampleNumber>
         <nationalNumberPattern>
+          6040[0-4]\d{4}|
           6(?:
-            0(?:
-              3\d|
-              40
-            )|
-            [1-356]\d|
-            44[0-6]|
-            71[137]
-          )\d{5}
+            03|
+            [1-356]|
+            44|
+            7\d
+          )\d{6}
         </nationalNumberPattern>
       </mobile>
       <tollFree>
@@ -2296,11 +2825,12 @@
       </uan>
     </territory>
 
-    <!-- Barbados -->
+    <!-- Barbados (BB) -->
     <!-- Calling code and formatting shared with 'US' -->
     <!-- http://www.itu.int/oth/T0202000013/en -->
     <territory id="BB" countryCode="1" leadingDigits="246" internationalPrefix="011"
-               nationalPrefix="1">
+               nationalPrefix="1" nationalPrefixForParsing="1|([2-9]\d{6})$"
+               nationalPrefixTransformRule="246$1">
       <generalDesc>
         <nationalNumberPattern>
           (?:
@@ -2432,7 +2962,7 @@
       </uan>
     </territory>
 
-    <!-- Bangladesh -->
+    <!-- Bangladesh (BD) -->
     <!-- As per official evidence, 001 and 002 can be used for International dialing covering toll
          quality and non-toll quality services. But these are not in use according to our tests
          (see b/29552679). -->
@@ -2451,42 +2981,42 @@
         <numberFormat pattern="(\d{3})(\d{3,7})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>
             3(?:
-              [2-5]1|
               [67]|
               8[013-9]
             )|
             4(?:
-              [235]1|
-              4[01346-9]|
               6[168]|
               7|
               [89][18]
             )|
             5(?:
-              [2-578]1|
               6[128]|
               9
             )|
             6(?:
-              [0389]1|
               28|
               4[14]|
-              5|
-              6[01346-9]
+              5
             )|
-            7(?:
-              [2-589]|
-              61
-            )|
+            7[2-589]|
             8(?:
               0[014-9]|
-              [12]|
-              [3-7]1
+              [12]
             )|
-            9(?:
-              [24]1|
-              [358]
-            )
+            9[358]|
+            (?:
+              3[2-5]|
+              4[235]|
+              5[2-578]|
+              6[0389]|
+              76|
+              8[3-7]|
+              9[24]
+            )1|
+            (?:
+              44|
+              66
+            )[01346-9]
           </leadingDigits>
           <format>$1-$2</format>
         </numberFormat>
@@ -2522,282 +3052,229 @@
            2, others do not - both are allowed for now. For some area codes, the subscriber number
            length described in our source documentation doesn't match numbers online (e.g. 05222)
            so we allow both for now. (This applies to 0431, 04329, 04623, 05327 as well). We have
-           also added 04452 and 04923 from numbers found online. Included prefixes 2778, 2841, 2963
-           2989 and 4462 as per user report. 9-digit 24 and 25 prefix numbers were added based on
-           user reports, although a doc from BRTC mentions that they are 10-digit numbers, which we
-           think might be a typo. -->
+           also added 04452 and 04923 from numbers found online. Included prefixes 2778, 2841, 2893,
+           2963, 298[59] and 4462 as per user report. 9-digit 24 and 25 prefix numbers were added
+           based on user reports, although a doc from BRTC mentions that they are 10-digit numbers,
+           which we think might be a typo. -->
       <fixedLine>
         <possibleLengths national="[6-10]"/>
         <exampleNumber>27111234</exampleNumber>
         <nationalNumberPattern>
           (?:
-            (?:
-              2(?:
-                [45]\d{3}|
-                7(?:
-                  1[0-267]|
-                  2[0-289]|
-                  3[0-29]|
-                  4[01]|
-                  5[1-3]|
-                  6[013]|
-                  7[0178]|
-                  91
-                )|
-                8(?:
-                  0[125]|
-                  [13][1-6]|
-                  2[0157-9]|
-                  41|
-                  6[1-35]|
-                  7[1-5]|
-                  8[1-8]|
-                  9[0-6]
-                )|
-                9(?:
-                  0[0-2]|
-                  1[0-4]|
-                  2[568]|
-                  3[3-6]|
-                  5[5-7]|
-                  6[01367]|
-                  7[15]|
-                  8[0146-9]
-                )
-              )|
-              7(?:
-                02|
-                21\d|
-                [3-589]1|
-                6[12]|
-                72[24]
-              )\d|
-              8(?:
-                (?:
-                  [01]|
-                  217|
-                  3[12]
-                )\d|
-                4[12]|
-                [5-7](?:
-                  1\d|
-                  2
-                )
-              )
-            )\d|
             3(?:
-              (?:
-                0(?:
-                  2[348]\d|
-                  3[2-6]
-                )|
-                (?:
-                  1(?:
-                    2[5-7]|
-                    [5-7]
-                  )|
-                  3(?:
-                    1|
-                    24
-                  )|
-                  [5-7]1
-                )\d
-              )\d|
-              2(?:
-                1\d\d|
-                2(?:
-                  [35]\d\d|
-                  4
-                )
-              )|
-              4(?:
-                1\d\d|
-                2(?:
-                  [25]\d\d|
-                  [47]
-                )
-              )|
-              8(?:
-                1\d\d|
-                2(?:
-                  (?:
-                    2\d|
-                    4
-                  )\d|
-                  3
-                )
-              )
+              03[56]|
+              224
             )|
             4(?:
-              0(?:
-                2(?:
-                  [09]\d|
-                  7
-                )|
-                33\d\d
-              )|
-              (?:
-                1\d|
-                4(?:
-                  2[2-46]|
-                  5[25]
-                )|
-                8(?:
-                  23|
-                  54
-                )
-              )\d\d|
-              2(?:
-                1\d\d|
-                2(?:
-                  [25]|
-                  [67]\d\d
-                )
-              )|
-              3(?:
-                1\d\d(?:
-                  \d{2}
-                )?|
-                (?:
-                  2[236-9]|
-                  32
-                )\d\d
-              )|
-              525|
-              6(?:
-                (?:
-                  [18]|
-                  2[3-6]|
-                  62
-                )\d\d|
-                5(?:
-                  [38]|
-                  [5-7]\d\d
-                )
-              )|
-              9(?:
-                (?:
-                  [18]|
-                  2[2-5]
-                )\d\d|
-                53\d\d?
-              )
-            )|
-            5(?:
-              (?:
-                02[03489]|
-                1|
-                22[2457]|
-                32[35-79]|
-                42[46]|
-                [58]26|
-                724
-              )\d\d|
-              6(?:
-                (?:
-                  [18]|
-                  53
-                )\d\d|
-                2
-              )
-            )|
-            6(?:
-              (?:
-                (?:
-                  [04]2[34]|
-                  32[3478]|
-                  52[47]|
-                  [78]2[2-5]|
-                  92[2-6]
-                )\d|
-                6(?:
-                  [18]\d|
-                  6(?:
-                    2(?:
-                      2|
-                      [34]\d
-                    )|
-                    5[245]\d
-                  )
-                )
-              )\d|
-              2(?:
-                (?:
-                  2[2-5]|
-                  8
-                )\d\d|
-                5(?:
-                  [3-5]\d\d|
-                  7
-                )
-              )
-            )|
-            9(?:
-              [24]1\d\d|
-              [35]1
+              22[25]|
+              653
             )
-          )\d{3}|
+          )\d{3,4}|
           (?:
-            3(?:
-              0(?:
-                2[02-9]\d|
-                3[56]
-              )|
-              (?:
-                22[1-5]|
-                32[2-6]|
-                422
-              )\d|
-              529
+            4(?:
+              31\d\d|
+              [46]23
             )|
-            (?:
-              4(?:
-                22[2-8]|
-                32[02-9]|
-                (?:
-                  [48][18]|
-                  71
-                )\d|
-                5(?:
-                  1\d|
-                  23
-                )|
-                6(?:
-                  2[467]|
-                  5[3-57]
-                )
-              )|
-              5(?:
-                [2-47-9]1\d|
-                5(?:
-                  1\d|
-                  26
-                )
-              )|
-              6(?:
-                0(?:
-                  1\d|
-                  24
-                )|
-                [3-589]1\d|
-                665[35]
-              )|
-              81|
-              9(?:
-                [024]2|
-                1\d|
-                81
-              )
-            )\d|
-            732
-          )\d{3}|
-          (?:
-            4[46]23|
             5(?:
               222|
               32[37]
             )
-          )\d{3}
+          )\d{3}(?:
+            \d{2}
+          )?|
+          (?:
+            3(?:
+              42[47]|
+              529|
+              823
+            )|
+            4(?:
+              027|
+              525|
+              658
+            )|
+            (?:
+              56|
+              73
+            )2|
+            6257|
+            9[35]1
+          )\d{3}|
+          (?:
+            3(?:
+              02[348]|
+              22[35]|
+              324|
+              422
+            )|
+            4(?:
+              22[67]|
+              32[236-9]|
+              6(?:
+                2[46]|
+                5[57]
+              )|
+              953
+            )|
+            5526|
+            6(?:
+              024|
+              6655
+            )|
+            81
+          )\d{4,5}|
+          (?:
+            2(?:
+              7(?:
+                1[0-267]|
+                2[0-289]|
+                3[0-29]|
+                4[01]|
+                5[1-3]|
+                6[013]|
+                7[0178]|
+                91
+              )|
+              8(?:
+                0[125]|
+                1[1-6]|
+                2[0157-9]|
+                3[1-69]|
+                41|
+                6[1-35]|
+                7[1-5]|
+                8[1-8]|
+                9[0-6]
+              )|
+              9(?:
+                0[0-2]|
+                1[0-4]|
+                2[568]|
+                3[3-6]|
+                5[5-7]|
+                6[01367]|
+                7[15]|
+                8[014-9]
+              )
+            )|
+            3(?:
+              0(?:
+                2[025-79]|
+                3[2-4]
+              )|
+              22[12]|
+              32[2356]|
+              824
+            )|
+            4(?:
+              02[09]|
+              22[348]|
+              32[045]|
+              523|
+              6(?:
+                27|
+                54
+              )
+            )|
+            666(?:
+              22|
+              53
+            )|
+            8(?:
+              4[12]|
+              [5-7]2
+            )|
+            9(?:
+              [024]2|
+              81
+            )
+          )\d{4}|
+          (?:
+            2[45]\d\d|
+            3(?:
+              1(?:
+                2[5-7]|
+                [5-7]
+              )|
+              425|
+              822
+            )|
+            4(?:
+              033|
+              1\d|
+              [257]1|
+              332|
+              4(?:
+                2[246]|
+                5[25]
+              )|
+              6(?:
+                25|
+                56|
+                62
+              )|
+              8(?:
+                23|
+                54
+              )|
+              92[2-5]
+            )|
+            5(?:
+              02[03489]|
+              22[457]|
+              32[569]|
+              42[46]|
+              6(?:
+                [18]|
+                53
+              )|
+              724|
+              826
+            )|
+            6(?:
+              023|
+              2(?:
+                2[2-5]|
+                5[3-5]|
+                8
+              )|
+              32[3478]|
+              42[34]|
+              52[47]|
+              6(?:
+                [18]|
+                6(?:
+                  2[34]|
+                  5[24]
+                )
+              )|
+              [78]2[2-5]|
+              92[2-6]
+            )|
+            7(?:
+              02|
+              21\d|
+              [3-589]1|
+              6[12]|
+              72[24]
+            )|
+            8(?:
+              0|
+              217|
+              3[12]|
+              [5-7]1
+            )|
+            9[24]1
+          )\d{5}|
+          (?:
+            (?:
+              3[2-8]|
+              5[2-57-9]|
+              6[03-589]
+            )1|
+            4[4689][18]
+          )\d{5}|
+          [59]1\d{5}
         </nationalNumberPattern>
       </fixedLine>
       <!-- Presuming that mobile numbers with the prefixes 66, 37, 44 and 38 must be followed by
@@ -2809,15 +3286,13 @@
         <nationalNumberPattern>
           (?:
             1[13-9]\d|
-            (?:
-              3[78]|
-              44
-            )[02-9]|
-            6(?:
-              44|
-              6[02-9]
-            )
-          )\d{7}
+            644
+          )\d{7}|
+          (?:
+            3[78]|
+            44|
+            66
+          )[02-9]\d{7}
         </nationalNumberPattern>
       </mobile>
       <!-- Note: Including Tele-voting numbers here as they are free of charge. -->
@@ -2841,34 +3316,32 @@
       </voip>
     </territory>
 
-    <!-- Belgium -->
+    <!-- Belgium (BE) -->
     <!-- http://www.bipt.be/en/operators/telecommunication/Numbering/Database -->
     <!-- http://www.bipt.be/public/files/en/474/20140829153659_Belgian_numbering_plan -->
     <!-- http://en.wikipedia.org/wiki/Telephone_numbers_in_Belgium -->
     <territory id="BE" countryCode="32" internationalPrefix="00" nationalPrefix="0"
                mobileNumberPortableRegion="true">
       <availableFormats>
+        <numberFormat pattern="(\d{3})(\d{2})(\d{3})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>
+            (?:
+              80|
+              9
+            )0
+          </leadingDigits>
+          <format>$1 $2 $3</format>
+        </numberFormat>
         <numberFormat pattern="(\d)(\d{3})(\d{2})(\d{2})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>
-            [23]|
-            4[23]|
-            9[2-4]
+            [239]|
+            4[23]
           </leadingDigits>
           <format>$1 $2 $3 $4</format>
         </numberFormat>
         <numberFormat pattern="(\d{2})(\d{2})(\d{2})(\d{2})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>
-            [15-7]|
-            8(?:
-              0[2-8]|
-              [1-79]
-            )
-          </leadingDigits>
+          <leadingDigits>[15-8]</leadingDigits>
           <format>$1 $2 $3 $4</format>
-        </numberFormat>
-        <numberFormat pattern="(\d{3})(\d{2})(\d{3})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>[89]</leadingDigits>
-          <format>$1 $2 $3</format>
         </numberFormat>
         <numberFormat pattern="(\d{3})(\d{2})(\d{2})(\d{2})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>4</leadingDigits>
@@ -2885,34 +3358,23 @@
         <possibleLengths national="8"/>
         <exampleNumber>12345678</exampleNumber>
         <nationalNumberPattern>
+          80[2-8]\d{5}|
           (?:
-            (?:
-              1[0-69]|
-              [23][2-8]|
-              4[23]|
-              5\d|
-              6[013-57-9]|
-              71|
-              9[2-4]
-            )\d|
-            8(?:
-              0[2-8]|
-              [1-79]\d
-            )
-          )\d{5}
+            1[0-69]|
+            [23][2-8]|
+            4[23]|
+            5\d|
+            6[013-57-9]|
+            71|
+            8[1-79]|
+            9[2-4]
+          )\d{6}
         </nationalNumberPattern>
       </fixedLine>
       <mobile>
         <possibleLengths national="9"/>
         <exampleNumber>470123456</exampleNumber>
-        <nationalNumberPattern>
-          4(?:
-            5[56]|
-            6[0135-8]|
-            [79]\d|
-            8[3-9]
-          )\d{6}
-        </nationalNumberPattern>
+        <nationalNumberPattern>4[5-9]\d{7}</nationalNumberPattern>
       </mobile>
       <tollFree>
         <possibleLengths national="8"/>
@@ -2970,7 +3432,7 @@
       </uan>
     </territory>
 
-    <!-- Burkina Faso -->
+    <!-- Burkina Faso (BF) -->
     <!-- http://www.itu.int/oth/T0202000021/en -->
     <!-- http://www.onatel.bf/plan-national-de-numerotation.aspx -->
     <territory id="BF" countryCode="226" internationalPrefix="00">
@@ -2978,12 +3440,12 @@
         <!-- The national numbering plan from ITU suggests grouping of 2, 2 and 4, but we have
              chosen to use the standard from numbers found on the internet instead. -->
         <numberFormat pattern="(\d{2})(\d{2})(\d{2})(\d{2})">
-          <leadingDigits>[25-7]</leadingDigits>
+          <leadingDigits>[025-7]</leadingDigits>
           <format>$1 $2 $3 $4</format>
         </numberFormat>
       </availableFormats>
       <generalDesc>
-        <nationalNumberPattern>[25-7]\d{7}</nationalNumberPattern>
+        <nationalNumberPattern>[025-7]\d{7}</nationalNumberPattern>
       </generalDesc>
       <fixedLine>
         <possibleLengths national="8"/>
@@ -3015,19 +3477,26 @@
         <exampleNumber>70123456</exampleNumber>
         <nationalNumberPattern>
           (?:
-            5[124-8]|
+            0[17]|
+            5[1-8]|
             [67]\d
           )\d{6}
         </nationalNumberPattern>
       </mobile>
     </territory>
 
-    <!-- Bulgaria -->
+    <!-- Bulgaria (BG) -->
     <!-- http://www.itu.int/oth/T0202000020/en -->
     <!-- https://en.wikipedia.org/wiki/Telephone_numbers_in_Bulgaria -->
     <territory id="BG" countryCode="359" internationalPrefix="00" nationalPrefix="0"
                mobileNumberPortableRegion="true">
       <availableFormats>
+        <!-- 6-digit shortcodes. -->
+        <numberFormat pattern="(\d{6})">
+          <leadingDigits>1</leadingDigits>
+          <format>$1</format>
+          <intlFormat>NA</intlFormat>
+        </numberFormat>
         <!-- Formatting rules follow the conventions seen in web-search results. A space has been
              used to separate the area code from the rest of the number, based on sites like
              http://www.goldenpages.bg. -->
@@ -3056,18 +3525,20 @@
           </leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
-        <numberFormat pattern="(\d{3})(\d{3})(\d{2})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>
-            43[1-7]|
-            70[1-9]
-          </leadingDigits>
-          <format>$1 $2 $3</format>
-        </numberFormat>
         <!-- Personal numbers & toll free. -->
         <numberFormat pattern="(\d{3})(\d{2})(\d{3})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>
-            7|
-            80
+            (?:
+              70|
+              8
+            )0
+          </leadingDigits>
+          <format>$1 $2 $3</format>
+        </numberFormat>
+        <numberFormat pattern="(\d{3})(\d{3})(\d{2})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>
+            43[1-7]|
+            7
           </leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
@@ -3097,23 +3568,18 @@
         <possibleLengths national="[6-8]" localOnly="4,5"/>
         <exampleNumber>2123456</exampleNumber>
         <nationalNumberPattern>
+          2\d{5,7}|
           (?:
-            (?:
-              [236]\d|
-              5[1-9]|
-              8[1-6]|
-              9[1-7]
-            )\d|
-            4(?:
-              [124-7]\d|
-              3[1-6]
-            )|
-            7(?:
-              0[1-9]|
-              [1-9]\d
-            )
+            43[1-6]|
+            70[1-9]
           )\d{4,5}|
-          2\d{5}
+          (?:
+            [36]\d|
+            4[124-7]|
+            [57][1-9]|
+            8[1-6]|
+            9[1-7]
+          )\d{5,6}
         </nationalNumberPattern>
       </fixedLine>
       <!-- The range 99\d{7} is marked as mobile in the ITU doc, but only 996 and 999 seem to be in
@@ -3123,19 +3589,15 @@
         <possibleLengths national="8,9"/>
         <exampleNumber>48123456</exampleNumber>
         <nationalNumberPattern>
+          43[07-9]\d{5}|
           (?:
-            4(?:
-              3[07-9]|
-              8\d
-            )|
-            (?:
-              8[7-9]\d|
-              9(?:
-                8\d|
-                9[69]
-              )
-            )\d
-          )\d{5}
+            48|
+            8[7-9]\d|
+            9(?:
+              8\d|
+              9[69]
+            )
+          )\d{6}
         </nationalNumberPattern>
       </mobile>
       <tollFree>
@@ -3148,14 +3610,16 @@
         <exampleNumber>90123456</exampleNumber>
         <nationalNumberPattern>90\d{6}</nationalNumberPattern>
       </premiumRate>
-      <personalNumber>
+      <!-- Prefix 700 is marked as Personal number in the ITU doc, but as per many websites they
+           are shared cost and are charged at a standard price. -->
+      <sharedCost>
         <possibleLengths national="8"/>
         <exampleNumber>70012345</exampleNumber>
         <nationalNumberPattern>700\d{5}</nationalNumberPattern>
-      </personalNumber>
+      </sharedCost>
     </territory>
 
-    <!-- Bahrain -->
+    <!-- Bahrain (BH) -->
     <!-- http://www.itu.int/oth/T0202000011/en -->
     <!-- http://www.tra.org.bh/en/marketNumbering.aspx -->
     <!-- http://en.wikipedia.org/wiki/Telephone_numbers_in_Bahrain -->
@@ -3163,9 +3627,8 @@
       <availableFormats>
         <numberFormat pattern="(\d{4})(\d{4})">
           <leadingDigits>
-            [1367]|
-            8[047]|
-            9[014578]
+            [13679]|
+            8[047]
           </leadingDigits>
           <format>$1 $2</format>
         </numberFormat>
@@ -3196,7 +3659,8 @@
                 0\d|
                 3[12]|
                 44|
-                7[7-9]
+                7[7-9]|
+                88
               )|
               9[69][69]
             )|
@@ -3219,8 +3683,7 @@
         <nationalNumberPattern>
           (?:
             3(?:
-              [1-4679]\d|
-              5[013-69]|
+              [1-79]\d|
               8[0-47-9]
             )\d|
             6(?:
@@ -3262,16 +3725,12 @@
       </sharedCost>
     </territory>
 
-    <!-- Burundi -->
+    <!-- Burundi (BI) -->
     <!-- http://www.itu.int/oth/T0202000022/en -->
     <territory id="BI" countryCode="257" internationalPrefix="00">
       <availableFormats>
         <numberFormat pattern="(\d{2})(\d{2})(\d{2})(\d{2})">
-          <leadingDigits>
-            [23]|
-            6[189]|
-            7[125-9]
-          </leadingDigits>
+          <leadingDigits>[2367]</leadingDigits>
           <format>$1 $2 $3 $4</format>
         </numberFormat>
       </availableFormats>
@@ -3302,14 +3761,14 @@
           (?:
             29|
             31|
-            6[189]|
+            6[1289]|
             7[125-9]
           )\d{6}
         </nationalNumberPattern>
       </mobile>
     </territory>
 
-    <!-- Benin -->
+    <!-- Benin (BJ) -->
     <!-- http://www.itu.int/oth/T0202000017/en -->
     <!-- http://arcep.bj/textes-juridiques/nos-decisions/ -->
     <territory id="BJ" countryCode="229" internationalPrefix="00">
@@ -3346,7 +3805,7 @@
         <nationalNumberPattern>
           (?:
             6\d|
-            9[03-9]
+            9[013-9]
           )\d{6}
         </nationalNumberPattern>
       </mobile>
@@ -3364,13 +3823,13 @@
       </uan>
     </territory>
 
-    <!-- Saint Barthélemy, French Antilles -->
+    <!-- St. Barthélemy (BL) -->
+    <!-- Calling code and formatting shared with 'GP' -->
     <!-- There seems to be some overlap with phone numbers from Saint Martin and Guadeloupe. The
          national numbering plan does not specify any St Barthélemy-specific numbering prefixes, but
          it appears from searches in online white and yellow pages that a subset of the prefixes
          available in these regions are used. In these cases, if getRegionCodeForNumber is used, one
          of these region codes will be returned, although numbers will be valid for both regions. -->
-    <!-- Calling code and formatting shared with 'GP' -->
     <!-- http://www.itu.int/oth/T0202000058/en -->
     <!-- https://extranet.arcep.fr/portail/Op%C3%A9rateursCE/Num%C3%A9rotation.aspx -->
     <territory id="BL" countryCode="590" internationalPrefix="00" nationalPrefix="0"
@@ -3379,7 +3838,8 @@
         <nationalNumberPattern>
           (?:
             590|
-            69\d
+            69\d|
+            976
           )\d{6}
         </nationalNumberPattern>
       </generalDesc>
@@ -3413,13 +3873,19 @@
           )\d{4}
         </nationalNumberPattern>
       </mobile>
+      <voip>
+        <possibleLengths national="9"/>
+        <exampleNumber>976012345</exampleNumber>
+        <nationalNumberPattern>976[01]\d{5}</nationalNumberPattern>
+      </voip>
     </territory>
 
-    <!-- Bermuda -->
+    <!-- Bermuda (BM) -->
     <!-- Calling code and formatting shared with 'US' -->
     <!-- http://www.itu.int/oth/T0202000018/en -->
     <territory id="BM" countryCode="1" leadingDigits="441" internationalPrefix="011"
-               nationalPrefix="1">
+               nationalPrefix="1" nationalPrefixForParsing="1|([2-8]\d{6})$"
+               nationalPrefixTransformRule="441$1">
       <generalDesc>
         <nationalNumberPattern>
           (?:
@@ -3498,7 +3964,7 @@
       </personalNumber>
     </territory>
 
-    <!-- Brunei Darussalam -->
+    <!-- Brunei (BN) -->
     <!-- http://www.itu.int/oth/T020200001F/en -->
     <!-- Format is from http://aiti.gov.bn/contact.html -->
     <territory id="BN" countryCode="673" internationalPrefix="00">
@@ -3515,13 +3981,12 @@
         <possibleLengths national="7"/>
         <exampleNumber>2345678</exampleNumber>
         <nationalNumberPattern>
+          22[0-7]\d{4}|
           (?:
-            2(?:
-              [013-9]\d|
-              2[0-7]
-            )|
-            [3-5]\d\d
-          )\d{4}
+            2[013-9]|
+            [34]\d|
+            5[0-25-9]
+          )\d{5}
         </nationalNumberPattern>
       </fixedLine>
       <mobile>
@@ -3534,16 +3999,24 @@
           )\d{4}
         </nationalNumberPattern>
       </mobile>
+      <voip>
+        <possibleLengths national="7"/>
+        <exampleNumber>5345678</exampleNumber>
+        <nationalNumberPattern>5[34]\d{5}</nationalNumberPattern>
+      </voip>
     </territory>
 
-    <!-- Bolivia -->
+    <!-- Bolivia (BO) -->
     <!-- http://www.itu.int/oth/T020200001A/en -->
     <!-- http://www.bolivia.com/Servicios/Plandenumeracion.pdf -->
     <territory id="BO" countryCode="591" internationalPrefix="00(?:1\d)?" nationalPrefix="0"
                nationalPrefixForParsing="0(1\d)?">
       <availableFormats>
         <numberFormat pattern="(\d)(\d{7})" carrierCodeFormattingRule="$NP$CC $FG">
-          <leadingDigits>[2-4]</leadingDigits>
+          <leadingDigits>
+            [23]|
+            4[46]
+          </leadingDigits>
           <format>$1 $2</format>
         </numberFormat>
         <numberFormat pattern="(\d{8})" carrierCodeFormattingRule="$NP$CC $FG">
@@ -3558,11 +4031,15 @@
       <generalDesc>
         <nationalNumberPattern>
           (?:
-            [2-467]\d{3}|
-            80017
-          )\d{4}
+            [2-467]\d\d|
+            8001
+          )\d{5}
         </nationalNumberPattern>
       </generalDesc>
+      <noInternationalDialling>
+        <possibleLengths national="9"/>
+        <nationalNumberPattern>8001[07]\d{4}</nationalNumberPattern>
+      </noInternationalDialling>
       <fixedLine>
         <possibleLengths national="8" localOnly="7"/>
         <exampleNumber>22123456</exampleNumber>
@@ -3623,15 +4100,15 @@
         <exampleNumber>71234567</exampleNumber>
         <nationalNumberPattern>[67]\d{7}</nationalNumberPattern>
       </mobile>
-      <!-- Added prefix 80017 based on user report. -->
+      <!-- Added prefix 8001[07] based on user report. -->
       <tollFree>
         <possibleLengths national="9"/>
         <exampleNumber>800171234</exampleNumber>
-        <nationalNumberPattern>80017\d{4}</nationalNumberPattern>
+        <nationalNumberPattern>8001[07]\d{4}</nationalNumberPattern>
       </tollFree>
     </territory>
 
-    <!-- Bonaire, Sint Eustatius and Saba -->
+    <!-- Caribbean Netherlands (BQ) -->
     <!-- Calling code and formatting shared with 'CW' -->
     <!-- http://www.itu.int/oth/T02020000F8/en -->
     <territory id="BQ" countryCode="599" leadingDigits="[347]" internationalPrefix="00">
@@ -3684,7 +4161,7 @@
       </mobile>
     </territory>
 
-    <!-- Brazil -->
+    <!-- Brazil (BR) -->
     <!-- http://en.wikipedia.org/wiki/%2B55 -->
     <!-- http://www.itu.int/oth/T020200001D/en -->
     <!-- The national prefix for parsing here also contains a capturing group for the main number,
@@ -3708,9 +4185,26 @@
                  )?"
                nationalPrefixTransformRule="$2" mobileNumberPortableRegion="true">
       <availableFormats>
-        <!-- First handle X00, 4020 and 4370, i.e. all phone numbers other than fixed-line or
-             mobile; this simplifies the fixed-line and mobile formatting patterns so they don't
-             have to exclude 4020 and 4370 explicitly. -->
+        <!-- Format short numbers as a block. -->
+        <numberFormat pattern="(\d{3,6})">
+          <leadingDigits>
+            1(?:
+              1[25-8]|
+              2[357-9]|
+              3[02-68]|
+              4[12568]|
+              5|
+              6[0-8]|
+              8[015]|
+              9[0-47-9]
+            )|
+            321|
+            610
+          </leadingDigits>
+          <format>$1</format>
+          <intlFormat>NA</intlFormat>
+        </numberFormat>
+        <!-- 8-digit shared cost numbers (mostly national only). -->
         <numberFormat pattern="(\d{4})(\d{4})">
           <leadingDigits>
             300|
@@ -3720,71 +4214,66 @@
             )
           </leadingDigits>
           <leadingDigits>
-            300|
             4(?:
-              0(?:
-                0|
-                20
-              )|
-              370
-            )
+              02|
+              37
+            )0|
+            [34]00
           </leadingDigits>
           <format>$1-$2</format>
         </numberFormat>
+        <numberFormat pattern="(\d{4})(\d{4})">
+          <leadingDigits>[2-57]</leadingDigits>
+          <leadingDigits>
+            [2357]|
+            4(?:
+              [0-24-9]|
+              3(?:
+                [0-689]|
+                7[1-9]
+              )
+            )
+          </leadingDigits>
+          <format>$1-$2</format>
+          <intlFormat>NA</intlFormat>
+        </numberFormat>
+        <!-- Variable cost numbers (9 - 10 digits). -->
         <numberFormat pattern="(\d{3})(\d{2,3})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>[3589]00</leadingDigits>
+          <leadingDigits>
+            (?:
+              [358]|
+              90
+            )0
+          </leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
-        <!-- Format short numbers as a block. -->
-        <numberFormat pattern="(\d{3,5})">
-          <leadingDigits>1[125689]</leadingDigits>
-          <format>$1</format>
-          <intlFormat>NA</intlFormat>
-        </numberFormat>
-        <!-- Fixed-line and pre-transition mobile numbers and mobile radio services dialled without
-             an area code. Although the second and third digits are not required to correctly
-             determine the appropriate format for a number, it speeds up AYTF since it doesn't need
-             to keep several patterns in scope (except for 4020 numbers, which is a tradeoff we make
-             for a simpler regex).
-             Note: We keep formatting pre-transition mobile numbers for a while after they're
-             invalid so that they are readable on clients that are still migrating. -->
-        <numberFormat pattern="(\d{4})(\d{4})">
-          <leadingDigits>
-            [2-9](?:
-              0[1-9]|
-              [1-9]
-            )
-          </leadingDigits>
-          <format>$1-$2</format>
-          <intlFormat>NA</intlFormat>
-        </numberFormat>
-        <!-- Mobile numbers dialled without an area code. Although the second and third digits are
-             not required to correctly determine the appropriate format for a number, it speeds up
-             AYTF since it doesn't need to keep several patterns in scope (except for 4020 numbers,
-             which is a tradeoff we make for a simpler regex). -->
         <numberFormat pattern="(\d{5})(\d{4})">
-          <leadingDigits>
-            9(?:
-              0[1-9]|
-              [1-9]
-            )
-          </leadingDigits>
+          <leadingDigits>9</leadingDigits>
           <format>$1-$2</format>
           <intlFormat>NA</intlFormat>
         </numberFormat>
         <!-- Fixed-line and pre-transition mobile numbers and mobile radio services dialled with an
-             area code.
-             Note: We keep formatting pre-transition mobile numbers for a while after they're
-             invalid so that they are readable on clients that are still migrating. -->
+             area code. -->
         <numberFormat pattern="(\d{2})(\d{4})(\d{4})" nationalPrefixFormattingRule="($FG)"
                       carrierCodeFormattingRule="$NP $CC ($FG)">
-          <leadingDigits>[1-9][1-9]</leadingDigits>
+          <leadingDigits>
+            (?:
+              [14689][1-9]|
+              2[12478]|
+              3[1-578]|
+              5[13-5]|
+              7[13-579]
+            )[2-57]
+          </leadingDigits>
           <format>$1 $2-$3</format>
         </numberFormat>
-        <!-- Mobile numbers dialled with an area code. -->
+        <!-- Mobile numbers (post transition, 11 digits). -->
         <numberFormat pattern="(\d{2})(\d{5})(\d{4})" nationalPrefixFormattingRule="($FG)"
                       carrierCodeFormattingRule="$NP $CC ($FG)">
-          <leadingDigits>[1-9][1-9]9</leadingDigits>
+          <leadingDigits>
+            [16][1-9]|
+            [2-57-9]
+          </leadingDigits>
           <format>$1 $2-$3</format>
         </numberFormat>
       </availableFormats>
@@ -3805,13 +4294,8 @@
       <noInternationalDialling>
         <possibleLengths national="8"/>
         <nationalNumberPattern>
-          (?:
-            300\d|
-            40(?:
-              0\d|
-              20
-            )
-          )\d{4}
+          4020\d{4}|
+          [34]00\d{5}
         </nationalNumberPattern>
       </noInternationalDialling>
       <!-- 52 is not added as an area code even though ITU mentions it, since it is not yet
@@ -3829,42 +4313,22 @@
           )[2-5]\d{7}
         </nationalNumberPattern>
       </fixedLine>
-      <!-- Between 2012 and 2017, Brazil's mobile numbers migrated from 10 to 11 digits long by
-           inserting a 9 before the last 8 digits. Mobile radio services were not migrated and
-           remain 10 digits long, where the 3rd digit is 7. 10-digit mobile numbers are slated to
-           be removed from valid ranges below. According to ANATEL, dialling the mobile numbers
-           in the old ranges during transition resulted in hearing recorded messages instructing
-           users on how to dial the new numbers. As of February 2017, no such messages greet users
-           and the old numbers simply don't connect. See
-           http://www.anatel.gov.br/setorregulado/index.php/perguntas-frequentes?catid=1 FAQ
-           "O que ocorrerá após o Dia D (dia que começará a mudança da numeração)?" and
-           http://www.anatel.gov.br/setorregulado/index.php/nono-digito -->
-      <!-- In this regular expression pattern, we have 2 blocks; the first block includes area
-           codes which only have their post-transition ranges validated; the second block includes
-           area codes where we validate both pre-and post-transition ranges. In the second block,
-           pre-transition numbers have subscriber numbers of the form [6-9]\d{7}, while their
-           corresponding post-transition numbers have subscriber numbers of the form 9[6-9]\d{7},
-           and 9[0-5]\d{7} subscriber numbers are the newly available ranges after transition. -->
+      <!-- Mobile radio services were not migrated and remain 10 digits long, where the 3rd digit is
+           7.  -->
       <!-- 52 is not included as a valid area code even though ITU mentions it, since it is not
            assigned as per ANATEL and Wikipedia. -->
       <mobile>
-        <possibleLengths national="10,11" localOnly="8"/>
+        <possibleLengths national="10,11" localOnly="8,9"/>
         <exampleNumber>11961234567</exampleNumber>
         <nationalNumberPattern>
           (?:
-            [189][1-9]|
-            2[12478]
-          )(?:
-            7|
-            9\d
-          )\d{7}|
-          (?:
+            [14689][1-9]|
+            2[12478]|
             3[1-578]|
-            [46][1-9]|
             5[13-5]|
             7[13-579]
           )(?:
-            [6-9]|
+            7|
             9\d
           )\d{7}
         </nationalNumberPattern>
@@ -3878,10 +4342,8 @@
         <possibleLengths national="9,10"/>
         <exampleNumber>300123456</exampleNumber>
         <nationalNumberPattern>
-          (?:
-            300|
-            [59]00\d?
-          )\d{6}
+          300\d{6}|
+          [59]00\d{6,7}
         </nationalNumberPattern>
       </premiumRate>
       <!-- Supported 4370 as shared cost based on user report. -->
@@ -3889,27 +4351,22 @@
         <possibleLengths national="8,10"/>
         <exampleNumber>40041234</exampleNumber>
         <nationalNumberPattern>
-          (?:
-            300\d(?:
-              \d{2}
-            )?|
-            4(?:
-              0(?:
-                0\d|
-                20
-              )|
-              370
-            )
-          )\d{4}
+          300\d{7}|
+          [34]00\d{5}|
+          4(?:
+            02|
+            37
+          )0\d{4}
         </nationalNumberPattern>
       </sharedCost>
     </territory>
 
-    <!-- Bahamas -->
+    <!-- Bahamas (BS) -->
     <!-- Calling code and formatting shared with 'US' -->
     <!-- http://www.itu.int/oth/T0202000010/en -->
     <territory id="BS" countryCode="1" leadingDigits="242" internationalPrefix="011"
-               nationalPrefix="1" mobileNumberPortableRegion="true">
+               nationalPrefix="1" nationalPrefixForParsing="1|([3-8]\d{6})$"
+               nationalPrefixTransformRule="242$1" mobileNumberPortableRegion="true">
       <generalDesc>
         <nationalNumberPattern>
           (?:
@@ -3996,18 +4453,16 @@
         <possibleLengths national="10" localOnly="7"/>
         <exampleNumber>8002123456</exampleNumber>
         <nationalNumberPattern>
-          (?:
-            242300|
-            8(?:
-              00|
-              33|
-              44|
-              55|
-              66|
-              77|
-              88
-            )[2-9]\d\d
-          )\d{4}
+          242300\d{4}|
+          8(?:
+            00|
+            33|
+            44|
+            55|
+            66|
+            77|
+            88
+          )[2-9]\d{6}
         </nationalNumberPattern>
       </tollFree>
       <premiumRate>
@@ -4041,7 +4496,7 @@
       </uan>
     </territory>
 
-    <!-- Bhutan -->
+    <!-- Bhutan (BT) -->
     <!-- Universal personal telecommunication prefixes 700 and 878 are not
          added as there is no information on length of numbers. -->
     <!-- Pager service prefix 91 is not added as there is no information on
@@ -4049,10 +4504,14 @@
     <!-- http://www.itu.int/oth/T0202000019/en -->
     <territory id="BT" countryCode="975" internationalPrefix="00">
       <availableFormats>
+        <numberFormat pattern="(\d{3})(\d{3})">
+          <leadingDigits>[2-7]</leadingDigits>
+          <format>$1 $2</format>
+          <intlFormat>NA</intlFormat>
+        </numberFormat>
         <numberFormat pattern="(\d)(\d{3})(\d{3})">
           <leadingDigits>
-            [23568]|
-            4[5-7]|
+            [2-68]|
             7[246]
           </leadingDigits>
           <format>$1 $2 $3</format>
@@ -4099,16 +4558,16 @@
       </mobile>
     </territory>
 
-    <!-- Botswana -->
+    <!-- Botswana (BW) -->
     <!-- http://www.itu.int/oth/T020200001C/en -->
     <territory id="BW" countryCode="267" internationalPrefix="00">
       <availableFormats>
-        <numberFormat pattern="(\d{3})(\d{4})">
-          <leadingDigits>[2-6]</leadingDigits>
-          <format>$1 $2</format>
-        </numberFormat>
         <numberFormat pattern="(\d{2})(\d{5})">
           <leadingDigits>90</leadingDigits>
+          <format>$1 $2</format>
+        </numberFormat>
+        <numberFormat pattern="(\d{3})(\d{4})">
+          <leadingDigits>[2-6]</leadingDigits>
           <format>$1 $2</format>
         </numberFormat>
         <numberFormat pattern="(\d{2})(\d{3})(\d{3})">
@@ -4118,15 +4577,14 @@
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
+          90\d{5}|
           (?:
-            (?:
-              [2-6]|
-              7\d
-            )\d|
-            90
-          )\d{5}
+            [2-6]|
+            7\d
+          )\d{6}
         </nationalNumberPattern>
       </generalDesc>
+      <!-- Number range 373 is been supported based on user report and online evidence. -->
       <fixedLine>
         <possibleLengths national="7"/>
         <exampleNumber>2401234</exampleNumber>
@@ -4141,7 +4599,7 @@
               1[0-35-9]|
               55|
               [69]\d|
-              7[01]
+              7[013]
             )|
             4(?:
               6[03]|
@@ -4169,13 +4627,11 @@
         <possibleLengths national="8"/>
         <exampleNumber>71123456</exampleNumber>
         <nationalNumberPattern>
+          77200\d{3}|
           7(?:
-            [1-6]\d{3}|
-            7(?:
-              [014-8]\d\d|
-              200
-            )
-          )\d{3}
+            [1-6]\d|
+            7[014-8]
+          )\d{5}
         </nationalNumberPattern>
       </mobile>
       <!-- No reliable information about toll-free numbers can be found; many are written on the
@@ -4201,7 +4657,7 @@
       </voip>
     </territory>
 
-    <!-- Belarus -->
+    <!-- Belarus (BY) -->
     <!-- Information on national prefix provided by a Belarussian person. -->
     <!-- http://www.eng.beltelecom.by/en/subscribers/phone-codes -->
     <territory id="BY" countryCode="375" preferredInternationalPrefix="8~10"
@@ -4218,62 +4674,52 @@
           <leadingDigits>800</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
-        <!-- 3 digit area codes (fixed line only). -->
-        <numberFormat pattern="(\d{3})(\d{2})(\d{2})(\d{2})" nationalPrefixFormattingRule="$NP 0$FG">
-          <leadingDigits>
-            1(?:
-              5[24]|
-              6[235]|
-              7[467]
-            )|
-            2(?:
-              1[246]|
-              2[25]|
-              3[26]
-            )
-          </leadingDigits>
-          <leadingDigits>
-            1(?:
-              5[24]|
-              6(?:
-                2|
-                3[04-9]|
-                5[0346-9]
-              )|
-              7(?:
-                [46]|
-                7[37-9]
-              )
-            )|
-            2(?:
-              1[246]|
-              2[25]|
-              3[26]
-            )
-          </leadingDigits>
-          <format>$1 $2-$3-$4</format>
-        </numberFormat>
         <!-- 4 digit area codes (fixed line only). -->
         <numberFormat pattern="(\d{4})(\d{2})(\d{3})" nationalPrefixFormattingRule="$NP 0$FG">
           <leadingDigits>
             1(?:
-              [56]|
+              5[169]|
+              6[3-5]|
               7[179]
             )|
-            2[1-3]
+            2(?:
+              1[35]|
+              2[34]|
+              3[3-5]
+            )
           </leadingDigits>
           <leadingDigits>
             1(?:
-              [56]|
+              5[169]|
+              6(?:
+                3[1-3]|
+                4|
+                5[125]
+              )|
               7(?:
                 1[3-9]|
-                7|
+                7[0-24-6]|
                 9[2-7]
               )
             )|
-            2[1-3]
+            2(?:
+              1[35]|
+              2[34]|
+              3[3-5]
+            )
           </leadingDigits>
           <format>$1 $2-$3</format>
+        </numberFormat>
+        <!-- 3 digit area codes (fixed line only). -->
+        <numberFormat pattern="(\d{3})(\d{2})(\d{2})(\d{2})" nationalPrefixFormattingRule="$NP 0$FG">
+          <leadingDigits>
+            1(?:
+              [56]|
+              7[467]
+            )|
+            2[1-3]
+          </leadingDigits>
+          <format>$1 $2-$3-$4</format>
         </numberFormat>
         <!-- 2 digit "area codes" (mostly mobile, but some fixed line ranges). -->
         <numberFormat pattern="(\d{2})(\d{3})(\d{2})(\d{2})" nationalPrefixFormattingRule="$NP 0$FG">
@@ -4289,19 +4735,21 @@
       <generalDesc>
         <nationalNumberPattern>
           (?:
-            (?:
-              [12]|
-              8[0-7]\d
-            )\d|
+            [12]\d|
             33|
             44|
             902
           )\d{7}|
           8(?:
-            [05-79]\d|
-            1[0-489]
+            0[0-79]\d{5,7}|
+            [1-7]\d{9}
+          )|
+          8(?:
+            1[0-489]|
+            [5-79]\d
           )\d{7}|
-          8[0-79]\d{5,7}|
+          8[1-79]\d{6,7}|
+          8[0-79]\d{5}|
           8\d{5}
         </nationalNumberPattern>
       </generalDesc>
@@ -4309,15 +4757,15 @@
       <noInternationalDialling>
         <possibleLengths national="[6-11]"/>
         <nationalNumberPattern>
+          800\d{3,7}|
           (?:
             8(?:
-              0[013]|
+              0[13]|
               10|
               20\d
             )|
             902
-          )\d{7}|
-          800\d{3,6}
+          )\d{7}
         </nationalNumberPattern>
       </noInternationalDialling>
       <!-- Using test number for Grodno from the plan. -->
@@ -4381,11 +4829,11 @@
         <possibleLengths national="[6-11]"/>
         <exampleNumber>8011234567</exampleNumber>
         <nationalNumberPattern>
+          800\d{3,7}|
           8(?:
-            0[013]|
+            0[13]|
             20\d
-          )\d{7}|
-          800\d{3,6}
+          )\d{7}
         </nationalNumberPattern>
       </tollFree>
       <!-- Putting Interactive Polling Service (paid) here too. -->
@@ -4407,7 +4855,7 @@
       </voip>
     </territory>
 
-    <!-- Belize -->
+    <!-- Belize (BZ) -->
     <!-- The trunk prefix, formally 0, was dropped in the last reorganisation of the numbering plan. -->
     <!-- http://www.itu.int/oth/T0202000016/en -->
     <territory id="BZ" countryCode="501" internationalPrefix="00">
@@ -4441,16 +4889,10 @@
         <exampleNumber>2221234</exampleNumber>
         <nationalNumberPattern>
           (?:
-            2(?:
-              [02]\d|
-              36
-            )|
-            [3-58][02]\d|
-            7(?:
-              [02]\d|
-              32
-            )
-          )\d{4}
+            236|
+            732
+          )\d{4}|
+          [2-578][02]\d{5}
         </nationalNumberPattern>
       </fixedLine>
       <!-- 62[6-9], 63X, 65X and 6[67][2-9] were added as we have been able to successfully
@@ -4470,7 +4912,7 @@
       </tollFree>
     </territory>
 
-    <!-- Canada -->
+    <!-- Canada (CA) -->
     <!-- Calling code and formatting shared with 'US' -->
     <!-- http://www.cnac.ca/canadian_dial_plan/canadian_dial_plan.htm -->
     <territory id="CA" countryCode="1" internationalPrefix="011" nationalPrefix="1"
@@ -4631,9 +5073,9 @@
       </voip>
     </territory>
 
-    <!-- Cocos Islands -->
-    <!-- References state Cocos Islands have fixed line numbers starting +61 8 9162. -->
+    <!-- Cocos (Keeling) Islands (CC) -->
     <!-- Calling code and formatting shared with 'AU' -->
+    <!-- References state Cocos Islands have fixed line numbers starting +61 8 9162. -->
     <!-- http://en.wikipedia.org/wiki/List_of_country_calling_codes -->
     <!-- http://en.wikipedia.org/wiki/Telephone_numbers_in_Australia -->
     <!-- https://www.thenumberingsystem.com.au/#/number-register/search -->
@@ -4643,11 +5085,15 @@
                nationalPrefixTransformRule="8$1">
       <generalDesc>
         <nationalNumberPattern>
-          1\d{5,9}|
+          1(?:
+            [0-79]\d|
+            8[0-24-9]
+          )\d{7}|
           (?:
-            [48]\d\d|
+            [148]\d\d|
             550
-          )\d{6}
+          )\d{6}|
+          1\d{5,7}
         </nationalNumberPattern>
       </generalDesc>
       <fixedLine>
@@ -4694,14 +5140,15 @@
         <possibleLengths national="9"/>
         <exampleNumber>412345678</exampleNumber>
         <nationalNumberPattern>
+          483[0-3]\d{5}|
           4(?:
             [0-3]\d|
             4[047-9]|
             5[0-25-9]|
-            6[6-9]|
+            6[06-9]|
             7[02-9]|
             8[0-2457-9]|
-            9[017-9]
+            9[0-27-9]
           )\d{6}
         </nationalNumberPattern>
       </mobile>
@@ -4740,16 +5187,19 @@
         <nationalNumberPattern>
           (?:
             14(?:
-              5\d|
-              71
+              5(?:
+                1[0458]|
+                [23][458]
+              )|
+              71\d
             )|
-            550\d
-          )\d{5}
+            550\d\d
+          )\d{4}
         </nationalNumberPattern>
       </voip>
     </territory>
 
-    <!-- Congo, Dem. Rep. of the (formerly Zaire) -->
+    <!-- Congo - Kinshasa (CD) -->
     <!-- http://www.itu.int/oth/T0202000037/en -->
     <territory id="CD" countryCode="243" internationalPrefix="00" nationalPrefix="0">
       <availableFormats>
@@ -4794,18 +5244,16 @@
         <possibleLengths national="7,9"/>
         <exampleNumber>991234567</exampleNumber>
         <nationalNumberPattern>
+          88\d{5}|
           (?:
-            8(?:
-              [0-2459]\d\d|
-              8
-            )|
-            9[017-9]\d\d
-          )\d{5}
+            8[0-2459]|
+            9[017-9]
+          )\d{7}
         </nationalNumberPattern>
       </mobile>
     </territory>
 
-    <!-- Central African Republic -->
+    <!-- Central African Republic (CF) -->
     <!-- http://www.itu.int/oth/T0202000028/en -->
     <territory id="CF" countryCode="236" internationalPrefix="00">
       <availableFormats>
@@ -4839,7 +5287,7 @@
       </premiumRate>
     </territory>
 
-    <!-- Congo (Rep. of the) (Brazzaville) -->
+    <!-- Congo - Brazzaville (CG) -->
     <!-- http://www.itu.int/oth/T020200002E/en -->
     <territory id="CG" countryCode="242" internationalPrefix="00">
       <availableFormats>
@@ -4847,24 +5295,22 @@
           <leadingDigits>801</leadingDigits>
           <format>$1 $2 $3 $4</format>
         </numberFormat>
-        <numberFormat pattern="(\d{2})(\d{3})(\d{4})">
-          <leadingDigits>[02]</leadingDigits>
-          <format>$1 $2 $3</format>
-        </numberFormat>
         <numberFormat pattern="(\d)(\d{4})(\d{4})">
           <leadingDigits>8</leadingDigits>
+          <format>$1 $2 $3</format>
+        </numberFormat>
+        <numberFormat pattern="(\d{2})(\d{3})(\d{4})">
+          <leadingDigits>[02]</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
+          222\d{6}|
           (?:
-            (?:
-              0\d|
-              80
-            )\d|
-            222
-          )\d{6}
+            0\d|
+            80
+          )\d{7}
         </nationalNumberPattern>
       </generalDesc>
       <fixedLine>
@@ -4891,25 +5337,25 @@
       </premiumRate>
     </territory>
 
-    <!-- Switzerland -->
+    <!-- Switzerland (CH) -->
     <!-- Under Technical prescriptions: Numbering plan for international carriers. -->
     <!-- http://www.bakom.admin.ch/themen/telekom/00479/00604/index.html?lang=en -->
     <territory id="CH" countryCode="41" internationalPrefix="00" nationalPrefix="0"
                mobileNumberPortableRegion="true">
       <availableFormats>
-        <numberFormat pattern="(\d{2})(\d{3})(\d{2})(\d{2})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>
-            [2-7]|
-            [89]1
-          </leadingDigits>
-          <format>$1 $2 $3 $4</format>
-        </numberFormat>
         <numberFormat pattern="(\d{3})(\d{3})(\d{3})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>
             8[047]|
-            9
+            90
           </leadingDigits>
           <format>$1 $2 $3</format>
+        </numberFormat>
+        <numberFormat pattern="(\d{2})(\d{3})(\d{2})(\d{2})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>
+            [2-79]|
+            81
+          </leadingDigits>
+          <format>$1 $2 $3 $4</format>
         </numberFormat>
         <numberFormat pattern="(\d{3})(\d{2})(\d{3})(\d{2})(\d{2})"
                       nationalPrefixFormattingRule="$NP$FG">
@@ -4981,19 +5427,19 @@
       </voicemail>
     </territory>
 
-    <!-- Côte d'Ivoire -->
+    <!-- Côte d’Ivoire (CI) -->
     <!-- http://www.itu.int/oth/T0202000031/en -->
     <!-- http://fr.wikipedia.org/wiki/Liste_des_indicatifs_téléphoniques_en_Côte_d’Ivoire -->
     <territory id="CI" countryCode="225" internationalPrefix="00">
       <availableFormats>
         <!-- Using format from online yellow pages over format implied in national numbering plan. -->
         <numberFormat pattern="(\d{2})(\d{2})(\d{2})(\d{2})">
-          <leadingDigits>[02-8]</leadingDigits>
+          <leadingDigits>[02-9]</leadingDigits>
           <format>$1 $2 $3 $4</format>
         </numberFormat>
       </availableFormats>
       <generalDesc>
-        <nationalNumberPattern>[02-8]\d{7}</nationalNumberPattern>
+        <nationalNumberPattern>[02-9]\d{7}</nationalNumberPattern>
       </generalDesc>
       <fixedLine>
         <possibleLengths national="8"/>
@@ -5020,32 +5466,34 @@
            successfully delivered. Supported by numbers found on the internet. Also added 43
            (Moov) based on numbers found online. Added 8[456] MTN ranges based on Wikipedia page.
            50 has been removed since Warid seems to have stopped operation in Côte d'Ivoire.
-           Prefix 73 added based on user report. -->
+           Prefix 73 and 97[0-3] are added based on user reports. -->
       <mobile>
         <possibleLengths national="8"/>
         <exampleNumber>01234567</exampleNumber>
         <nationalNumberPattern>
+          97[0-3]\d{5}|
           (?:
-            [07][1-9]|
-            [45]\d|
+            0[1-9]|
+            [457]\d|
             6[014-9]|
-            8[4-9]
+            8[4-9]|
+            95
           )\d{6}
         </nationalNumberPattern>
       </mobile>
     </territory>
 
-    <!-- Cook Islands -->
+    <!-- Cook Islands (CK) -->
     <!-- http://www.itu.int/oth/T020200002F/en -->
     <territory id="CK" countryCode="682" internationalPrefix="00">
       <availableFormats>
         <numberFormat pattern="(\d{2})(\d{3})">
-          <leadingDigits>[2-8]</leadingDigits>
+          <leadingDigits>[2-578]</leadingDigits>
           <format>$1 $2</format>
         </numberFormat>
       </availableFormats>
       <generalDesc>
-        <nationalNumberPattern>[2-8]\d{4}</nationalNumberPattern>
+        <nationalNumberPattern>[2-578]\d{4}</nationalNumberPattern>
       </generalDesc>
       <fixedLine>
         <possibleLengths national="5"/>
@@ -5061,11 +5509,11 @@
       <mobile>
         <possibleLengths national="5"/>
         <exampleNumber>71234</exampleNumber>
-        <nationalNumberPattern>[5-8]\d{4}</nationalNumberPattern>
+        <nationalNumberPattern>[578]\d{4}</nationalNumberPattern>
       </mobile>
     </territory>
 
-    <!-- Chile -->
+    <!-- Chile (CL) -->
     <!-- As per ITU doc, from 5 Sep 2016, fixed-mobile portability will apply in Chile. So same
          nationalNumberPatterns are maintained in both fixed-line and mobile categories. -->
     <!-- According to subtel.gob.cl as of August 2014, nationalPrefix(0) and carrier codes are not
@@ -5086,36 +5534,42 @@
         <numberFormat pattern="(\d{4})">
           <leadingDigits>
             1(?:
-              [03-58]|
-              [29]1
-            )
+              [03-589]|
+              21
+            )|
+            [29]0|
+            78
           </leadingDigits>
           <format>$1</format>
           <intlFormat>NA</intlFormat>
+        </numberFormat>
+        <!-- For only 219X prefix used rurally by CTR. -->
+        <numberFormat pattern="(\d{5})(\d{4})" nationalPrefixFormattingRule="($FG)">
+          <leadingDigits>21</leadingDigits>
+          <format>$1 $2</format>
+        </numberFormat>
+        <!-- Format for VOIP numbers. -->
+        <numberFormat pattern="(\d{2})(\d{3})(\d{4})">
+          <leadingDigits>44</leadingDigits>
+          <format>$1 $2 $3</format>
         </numberFormat>
         <!-- Format for 2X fixed-line numbers. Note that due to fixed-mobile portability same
              ranges are maintained in both fixed-line and mobile categories. Formats are based
              on original phone number type. -->
         <numberFormat pattern="(\d)(\d{4})(\d{4})" nationalPrefixFormattingRule="($FG)">
-          <leadingDigits>
-            2(?:
-              2|
-              32
-            )
-          </leadingDigits>
-          <leadingDigits>
-            2(?:
-              2|
-              32[0-46-8]
-            )
-          </leadingDigits>
+          <leadingDigits>2[23]</leadingDigits>
+          <format>$1 $2 $3</format>
+        </numberFormat>
+        <!-- Format for mobile numbers. -->
+        <numberFormat pattern="(\d)(\d{4})(\d{4})">
+          <leadingDigits>9[2-9]</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
         <!-- Format for all other fixed-line numbers. -->
         <numberFormat pattern="(\d{2})(\d{3})(\d{4})" nationalPrefixFormattingRule="($FG)">
           <leadingDigits>
             3[2-5]|
-            [47][1-35]|
+            [47]|
             5[1-3578]|
             6[13-57]|
             8(?:
@@ -5125,44 +5579,30 @@
           </leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
-        <!-- For only 219X prefix used rurally by CTR. -->
-        <numberFormat pattern="(\d{5})(\d{4})" nationalPrefixFormattingRule="($FG)">
-          <leadingDigits>2</leadingDigits>
-          <format>$1 $2</format>
-        </numberFormat>
-        <!-- Format for mobile numbers. -->
-        <numberFormat pattern="(\d)(\d{4})(\d{4})">
-          <leadingDigits>9[2-9]</leadingDigits>
-          <format>$1 $2 $3</format>
-        </numberFormat>
-        <!-- Format for VOIP numbers. -->
-        <numberFormat pattern="(\d{2})(\d{3})(\d{4})">
-          <leadingDigits>44</leadingDigits>
-          <format>$1 $2 $3</format>
-        </numberFormat>
         <!-- Format for variable cost numbers like toll-free, shared cost. -->
         <numberFormat pattern="(\d{3})(\d{3})(\d{3,4})">
-          <leadingDigits>[68]00</leadingDigits>
+          <leadingDigits>
+            60|
+            8
+          </leadingDigits>
           <format>$1 $2 $3</format>
-        </numberFormat>
-        <!-- For 11 digit shared cost numbers. -->
-        <numberFormat pattern="(\d{3})(\d{3})(\d{2})(\d{3})">
-          <leadingDigits>600</leadingDigits>
-          <format>$1 $2 $3 $4</format>
         </numberFormat>
         <!-- For 11 digit toll-free numbers. -->
         <numberFormat pattern="(\d{4})(\d{3})(\d{4})">
           <leadingDigits>1</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
+        <!-- For 11 digit shared cost numbers. -->
+        <numberFormat pattern="(\d{3})(\d{3})(\d{2})(\d{3})">
+          <leadingDigits>60</leadingDigits>
+          <format>$1 $2 $3 $4</format>
+        </numberFormat>
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
-          (?:
-            1230|
-            [2-57-9]\d|
-            6\d{1,3}
-          )\d{7}
+          12300\d{6}|
+          6\d{9,10}|
+          [2-9]\d{8}
         </nationalNumberPattern>
       </generalDesc>
       <noInternationalDialling>
@@ -5180,8 +5620,7 @@
            already numbers with the prefix "23" are being added.
            See: http://www.gob.cl/especiales/informate-de-la-nueva-forma-de-marcar/
                 http://www.subtel.cl/index.php?option=com_content&view=article&id=3081:&catid=3:noticias
-           Added prefixes 2323 and 2326 range based on online evidence. Added prefixes 2324, 2327
-           and 2328 based on user reports. -->
+           Added 232[3-8] ranges based on online evidence. -->
       <fixedLine>
         <possibleLengths national="9"/>
         <exampleNumber>221234567</exampleNumber>
@@ -5189,25 +5628,22 @@
           (?:
             2(?:
               1962|
-              (?:
+              3(?:
                 2\d\d|
-                32[0-46-8]
-              )\d
-            )|
-            (?:
-              (?:
-                3[2-5]|
-                [47][1-35]|
-                5[1-3578]|
-                6[13-57]|
-                9[2-9]
-              )\d|
-              8(?:
-                0[1-9]|
-                [1-9]\d
+                300
               )
-            )\d\d
-          )\d{4}
+            )|
+            80[1-9]\d\d
+          )\d{4}|
+          (?:
+            22|
+            3[2-5]|
+            [47][1-35]|
+            5[1-3578]|
+            6[13-57]|
+            8[1-9]|
+            9[2-9]
+          )\d{7}
         </nationalNumberPattern>
       </fixedLine>
       <!-- Supported 9[23] mobile ranges as per user report. -->
@@ -5218,25 +5654,22 @@
           (?:
             2(?:
               1962|
-              (?:
+              3(?:
                 2\d\d|
-                32[0-46-8]
-              )\d
-            )|
-            (?:
-              (?:
-                3[2-5]|
-                [47][1-35]|
-                5[1-3578]|
-                6[13-57]|
-                9[2-9]
-              )\d|
-              8(?:
-                0[1-9]|
-                [1-9]\d
+                300
               )
-            )\d\d
-          )\d{4}
+            )|
+            80[1-9]\d\d
+          )\d{4}|
+          (?:
+            22|
+            3[2-5]|
+            [47][1-35]|
+            5[1-3578]|
+            6[13-57]|
+            8[1-9]|
+            9[2-9]
+          )\d{7}
         </nationalNumberPattern>
       </mobile>
       <!-- Toll free patterns have been collected by looking at numbers on the internet, rather than
@@ -5247,9 +5680,9 @@
         <exampleNumber>800123456</exampleNumber>
         <nationalNumberPattern>
           (?:
-            1230\d|
-            800
-          )\d{6}
+            123|
+            8
+          )00\d{6}
         </nationalNumberPattern>
       </tollFree>
       <!-- http://empresa.movistar.cl/nuestros_productos/soluciones_telefonia_ip/servicios/servicio_600.php -->
@@ -5265,7 +5698,7 @@
       </voip>
     </territory>
 
-    <!-- Cameroon -->
+    <!-- Cameroon (CM) -->
     <!-- http://www.itu.int/oth/T0202000024/en -->
     <!-- http://www.itu.int/dms_pub/itu-t/opb/sp/T-SP-OB.1063-2014-OAS-PDF-E.pdf -->
     <territory id="CM" countryCode="237" internationalPrefix="00">
@@ -5318,48 +5751,33 @@
       </tollFree>
     </territory>
 
-    <!-- China -->
+    <!-- China (CN) -->
     <!-- The international/national prefix patterns must not collide with valid prefixes such
          as 17[0678] and 19[89]. 179XX00 is a valid calling prefix, see: www.chahaoba.com/179 -->
     <!-- http://www.itu.int/oth/T020200002B/en -->
     <!-- https://en.wikipedia.org/wiki/Telephone_numbers_in_China -->
     <territory id="CN" countryCode="86" preferredInternationalPrefix="00"
-               internationalPrefix="(?:1(?:[12]\d{3}|79\d{2}|9[0-7]\d{2}))?00" nationalPrefix="0"
-               nationalPrefixForParsing="0|(1(?:[12]\d{3}|79\d{2}|9[0-7]\d{2}))">
+               internationalPrefix="00|1(?:[12]\d|79|9[0235-7])\d\d00" nationalPrefix="0"
+               nationalPrefixForParsing="0|(1(?:[12]\d|79|9[0235-7])\d\d)">
       <availableFormats>
-        <numberFormat pattern="(\d{3})(\d{3})(\d{4})">
-          <leadingDigits>[48]00</leadingDigits>
-          <format>$1 $2 $3</format>
-        </numberFormat>
-        <!-- 100xx and 95xxx(x) short numbers without area codes. Without this rule, these short
-             numbers will be formatted incorrectly by the AsYouTypeFormatter because they overlap
-             with area codes 010, 095x. These numbers are defined in ShortNumberMetadata.xml but
-             must be accounted for here. Note although ITU says the format is more like 95 xxx, in
-             reality no space is used when writing such numbers in China. -->
         <numberFormat pattern="(\d{5,6})">
-          <leadingDigits>
-            100|
-            95
-          </leadingDigits>
+          <leadingDigits>96</leadingDigits>
           <format>$1</format>
           <intlFormat>NA</intlFormat>
         </numberFormat>
-        <!-- 100xx and 95xxx(x) numbers with area codes (these numbers without an area code are now
-             dealt with by ShortNumberMetadata.xml) and 96xxx(x) numbers with area codes (we don't
-             support these as short numbers because they are only unique within a province, not
-             within a country). -->
+        <!-- 100xx and 9[56]xxx(x) numbers with two-digit area codes. -->
         <numberFormat pattern="(\d{2})(\d{5,6})" nationalPrefixFormattingRule="$NP$FG"
                       carrierCodeFormattingRule="$CC $FG">
           <leadingDigits>
             (?:
               10|
-              2\d
+              2[0-57-9]
             )[19]
           </leadingDigits>
           <leadingDigits>
             (?:
               10|
-              2\d
+              2[0-57-9]
             )(?:
               10|
               9[56]
@@ -5368,7 +5786,7 @@
           <leadingDigits>
             (?:
               10|
-              2\d
+              2[0-57-9]
             )(?:
               100|
               9[56]
@@ -5376,86 +5794,67 @@
           </leadingDigits>
           <format>$1 $2</format>
         </numberFormat>
-        <numberFormat pattern="(\d{3})(\d{5,6})" nationalPrefixFormattingRule="$NP$FG"
-                      carrierCodeFormattingRule="$CC $FG">
-          <leadingDigits>[3-9]</leadingDigits>
-          <leadingDigits>[3-9]\d\d[19]</leadingDigits>
+        <numberFormat pattern="(\d{3})(\d{4})">
+          <leadingDigits>[1-9]</leadingDigits>
           <leadingDigits>
-            [3-9]\d\d(?:
+            1[1-9]|
+            26|
+            [3-9]|
+            (?:
               10|
-              9[56]
+              2[0-57-9]
+            )(?:
+              [0-8]|
+              9[0-47-9]
+            )
+          </leadingDigits>
+          <leadingDigits>
+            1[1-9]|
+            26|
+            [3-9]|
+            (?:
+              10|
+              2[0-57-9]
+            )(?:
+              [02-8]|
+              1(?:
+                0[1-9]|
+                [1-9]
+              )|
+              9[0-47-9]
             )
           </leadingDigits>
           <format>$1 $2</format>
+          <intlFormat>NA</intlFormat>
         </numberFormat>
-        <!-- Local numbers -->
-        <!-- Chinese fixed-line numbers can be dialed from a cell phone without area code and they
-             can be 7 to 8 digits. This rule is here to make formatting work with such numbers, as
-             people frequently store them in their cellphones. It has to stay before formatting
-             rules for fixed-line numbers to make AsYouTypeFormatter work with these numbers. The
-             leadingDigits prefix makes sure it doesn't clash with mobile numbers. -->
-        <numberFormat pattern="(\d{3,4})(\d{4})">
-          <leadingDigits>[2-9]</leadingDigits>
+        <!-- 8-digit premium rate numbers. -->
+        <numberFormat pattern="(\d{4})(\d{4})">
+          <leadingDigits>16[08]</leadingDigits>
           <format>$1 $2</format>
           <intlFormat>NA</intlFormat>
         </numberFormat>
-        <numberFormat pattern="(\d{2})(\d{4})(\d{4,6})" nationalPrefixFormattingRule="$NP$FG"
-                      nationalPrefixOptionalWhenFormatting="true"
-                      carrierCodeFormattingRule="$CC $FG">
-          <leadingDigits>21</leadingDigits>
-          <format>$1 $2 $3</format>
-        </numberFormat>
-        <numberFormat pattern="(\d{2})(\d{4})(\d{4})" nationalPrefixFormattingRule="$NP$FG"
-                      nationalPrefixOptionalWhenFormatting="true"
-                      carrierCodeFormattingRule="$CC $FG">
-          <leadingDigits>
-            10[1-9]|
-            2[02-9]
-          </leadingDigits>
-          <leadingDigits>
-            10[1-9]|
-            2[02-9]
-          </leadingDigits>
-          <leadingDigits>
-            10(?:
-              [1-79]|
-              8(?:
-                0[1-9]|
-                [1-9]
-              )
-            )|
-            2[02-9]
-          </leadingDigits>
-          <format>$1 $2 $3</format>
-        </numberFormat>
-        <numberFormat pattern="(\d{3})(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG"
-                      nationalPrefixOptionalWhenFormatting="true"
+        <!-- 100xx and 9[56]xxx(x) numbers with three-digit area codes. -->
+        <numberFormat pattern="(\d{3})(\d{5,6})" nationalPrefixFormattingRule="$NP$FG"
                       carrierCodeFormattingRule="$CC $FG">
           <leadingDigits>
             3(?:
-              1[02-9]|
+              [157]|
               35|
               49|
-              5|
-              7[02-68]|
               9[1-68]
             )|
             4(?:
-              1[02-9]|
+              [17]|
               2[179]|
-              [35][2-9]|
               6[47-9]|
-              7|
               8[23]
             )|
             5(?:
-              3[03-9]|
+              [1357]|
+              2[37]|
               4[36]|
-              5[02-9]|
               6[1-46]|
-              7[028]|
-              80|
-              9[2-46-9]
+              80
             )|
             6(?:
               3[1-5]|
@@ -5466,18 +5865,16 @@
               01|
               [1579]|
               2[248]|
-              3[04-9]|
+              3[014-9]|
               4[3-6]|
-              6[2368]
+              6[023689]
             )|
             8(?:
               1[236-8]|
               2[5-7]|
-              3|
-              5[1-9]|
-              7[02-9]|
+              [37]|
               8[36-8]|
-              9[1-7]
+              9[1-8]
             )|
             9(?:
               0[1-3689]|
@@ -5485,96 +5882,600 @@
               [379]|
               4[13]|
               5[1-5]
+            )|
+            (?:
+              4[35]|
+              59|
+              85
+            )[1-9]
+          </leadingDigits>
+          <leadingDigits>
+            (?:
+              3(?:
+                [157]\d|
+                35|
+                49|
+                9[1-68]
+              )|
+              4(?:
+                [17]\d|
+                2[179]|
+                [35][1-9]|
+                6[47-9]|
+                8[23]
+              )|
+              5(?:
+                [1357]\d|
+                2[37]|
+                4[36]|
+                6[1-46]|
+                80|
+                9[1-9]
+              )|
+              6(?:
+                3[1-5]|
+                6[0238]|
+                9[12]
+              )|
+              7(?:
+                01|
+                [1579]\d|
+                2[248]|
+                3[014-9]|
+                4[3-6]|
+                6[023689]
+              )|
+              8(?:
+                1[236-8]|
+                2[5-7]|
+                [37]\d|
+                5[1-9]|
+                8[36-8]|
+                9[1-8]
+              )|
+              9(?:
+                0[1-3689]|
+                1[1-79]|
+                [379]\d|
+                4[13]|
+                5[1-5]
+              )
+            )[19]
+          </leadingDigits>
+          <leadingDigits>
+            85[23](?:
+              10|
+              95
+            )|
+            (?:
+              3(?:
+                [157]\d|
+                35|
+                49|
+                9[1-68]
+              )|
+              4(?:
+                [17]\d|
+                2[179]|
+                [35][1-9]|
+                6[47-9]|
+                8[23]
+              )|
+              5(?:
+                [1357]\d|
+                2[37]|
+                4[36]|
+                6[1-46]|
+                80|
+                9[1-9]
+              )|
+              6(?:
+                3[1-5]|
+                6[0238]|
+                9[12]
+              )|
+              7(?:
+                01|
+                [1579]\d|
+                2[248]|
+                3[014-9]|
+                4[3-6]|
+                6[023689]
+              )|
+              8(?:
+                1[236-8]|
+                2[5-7]|
+                [37]\d|
+                5[14-9]|
+                8[36-8]|
+                9[1-8]
+              )|
+              9(?:
+                0[1-3689]|
+                1[1-79]|
+                [379]\d|
+                4[13]|
+                5[1-5]
+              )
+            )(?:
+              10|
+              9[56]
+            )
+          </leadingDigits>
+          <leadingDigits>
+            85[23](?:
+              100|
+              95
+            )|
+            (?:
+              3(?:
+                [157]\d|
+                35|
+                49|
+                9[1-68]
+              )|
+              4(?:
+                [17]\d|
+                2[179]|
+                [35][1-9]|
+                6[47-9]|
+                8[23]
+              )|
+              5(?:
+                [1357]\d|
+                2[37]|
+                4[36]|
+                6[1-46]|
+                80|
+                9[1-9]
+              )|
+              6(?:
+                3[1-5]|
+                6[0238]|
+                9[12]
+              )|
+              7(?:
+                01|
+                [1579]\d|
+                2[248]|
+                3[014-9]|
+                4[3-6]|
+                6[023689]
+              )|
+              8(?:
+                1[236-8]|
+                2[5-7]|
+                [37]\d|
+                5[14-9]|
+                8[36-8]|
+                9[1-8]
+              )|
+              9(?:
+                0[1-3689]|
+                1[1-79]|
+                [379]\d|
+                4[13]|
+                5[1-5]
+              )
+            )(?:
+              100|
+              9[56]
+            )
+          </leadingDigits>
+          <format>$1 $2</format>
+        </numberFormat>
+        <numberFormat pattern="(\d{4})(\d{4})">
+          <leadingDigits>[1-9]</leadingDigits>
+          <leadingDigits>
+            1[1-9]|
+            26|
+            [3-9]|
+            (?:
+              10|
+              2[0-57-9]
+            )(?:
+              [0-8]|
+              9[0-47-9]
+            )
+          </leadingDigits>
+          <leadingDigits>
+            26|
+            3(?:
+              [0268]|
+              9[079]
+            )|
+            4(?:
+              [049]|
+              2[02-68]|
+              [35]0|
+              6[0-356]|
+              8[014-9]
+            )|
+            5(?:
+              0|
+              2[0-24-689]|
+              4[0-2457-9]|
+              6[057-9]|
+              90
+            )|
+            6(?:
+              [0-24578]|
+              6[14-79]|
+              9[03-9]
+            )|
+            7(?:
+              0[02-9]|
+              2[0135-79]|
+              3[23]|
+              4[0-27-9]|
+              6[1457]|
+              8
+            )|
+            8(?:
+              [046]|
+              1[01459]|
+              2[0-489]|
+              50|
+              8[0-2459]|
+              9[09]
+            )|
+            9(?:
+              0[0457]|
+              1[08]|
+              [268]|
+              4[024-9]
+            )|
+            (?:
+              34|
+              85[23]
+            )[0-8]|
+            (?:
+              1|
+              58
+            )[1-9]|
+            (?:
+              63|
+              95
+            )[06-9]|
+            (?:
+              33|
+              85[23]9
+            )[0-46-9]|
+            (?:
+              10|
+              2[0-57-9]|
+              3(?:
+                [157]\d|
+                35|
+                49|
+                9[1-68]
+              )|
+              4(?:
+                [17]\d|
+                2[179]|
+                [35][1-9]|
+                6[47-9]|
+                8[23]
+              )|
+              5(?:
+                [1357]\d|
+                2[37]|
+                4[36]|
+                6[1-46]|
+                80|
+                9[1-9]
+              )|
+              6(?:
+                3[1-5]|
+                6[0238]|
+                9[12]
+              )|
+              7(?:
+                01|
+                [1579]\d|
+                2[248]|
+                3[014-9]|
+                4[3-6]|
+                6[023689]
+              )|
+              8(?:
+                1[236-8]|
+                2[5-7]|
+                [37]\d|
+                5[14-9]|
+                8[36-8]|
+                9[1-8]
+              )|
+              9(?:
+                0[1-3689]|
+                1[1-79]|
+                [379]\d|
+                4[13]|
+                5[1-5]
+              )
+            )(?:
+              [0-8]|
+              9[0-47-9]
+            )
+          </leadingDigits>
+          <leadingDigits>
+            26|
+            3(?:
+              [0268]|
+              3[0-46-9]|
+              4[0-8]|
+              9[079]
+            )|
+            4(?:
+              [049]|
+              2[02-68]|
+              [35]0|
+              6[0-356]|
+              8[014-9]
+            )|
+            5(?:
+              0|
+              2[0-24-689]|
+              4[0-2457-9]|
+              6[057-9]|
+              90
+            )|
+            6(?:
+              [0-24578]|
+              3[06-9]|
+              6[14-79]|
+              9[03-9]
+            )|
+            7(?:
+              0[02-9]|
+              2[0135-79]|
+              3[23]|
+              4[0-27-9]|
+              6[1457]|
+              8
+            )|
+            8(?:
+              [046]|
+              1[01459]|
+              2[0-489]|
+              5(?:
+                0|
+                [23](?:
+                  [02-8]|
+                  1[1-9]|
+                  9[0-46-9]
+                )
+              )|
+              8[0-2459]|
+              9[09]
+            )|
+            9(?:
+              0[0457]|
+              1[08]|
+              [268]|
+              4[024-9]|
+              5[06-9]
+            )|
+            (?:
+              1|
+              58|
+              85[23]10
+            )[1-9]|
+            (?:
+              10|
+              2[0-57-9]
+            )(?:
+              [0-8]|
+              9[0-47-9]
+            )|
+            (?:
+              3(?:
+                [157]\d|
+                35|
+                49|
+                9[1-68]
+              )|
+              4(?:
+                [17]\d|
+                2[179]|
+                [35][1-9]|
+                6[47-9]|
+                8[23]
+              )|
+              5(?:
+                [1357]\d|
+                2[37]|
+                4[36]|
+                6[1-46]|
+                80|
+                9[1-9]
+              )|
+              6(?:
+                3[1-5]|
+                6[0238]|
+                9[12]
+              )|
+              7(?:
+                01|
+                [1579]\d|
+                2[248]|
+                3[014-9]|
+                4[3-6]|
+                6[023689]
+              )|
+              8(?:
+                1[236-8]|
+                2[5-7]|
+                [37]\d|
+                5[14-9]|
+                8[36-8]|
+                9[1-8]
+              )|
+              9(?:
+                0[1-3689]|
+                1[1-79]|
+                [379]\d|
+                4[13]|
+                5[1-5]
+              )
+            )(?:
+              [02-8]|
+              1(?:
+                0[1-9]|
+                [1-9]
+              )|
+              9[0-47-9]
+            )
+          </leadingDigits>
+          <format>$1 $2</format>
+          <intlFormat>NA</intlFormat>
+        </numberFormat>
+        <!-- 10 digit toll free or shared cost range -->
+        <numberFormat pattern="(\d{3})(\d{3})(\d{4})">
+          <leadingDigits>
+            (?:
+              4|
+              80
+            )0
+          </leadingDigits>
+          <format>$1 $2 $3</format>
+        </numberFormat>
+        <!-- 10 digit fixed line range -->
+        <numberFormat pattern="(\d{2})(\d{4})(\d{4})" nationalPrefixFormattingRule="$NP$FG"
+                      nationalPrefixOptionalWhenFormatting="true"
+                      carrierCodeFormattingRule="$CC $FG">
+          <leadingDigits>
+            10|
+            2(?:
+              [02-57-9]|
+              1[1-9]
+            )
+          </leadingDigits>
+          <leadingDigits>
+            10|
+            2(?:
+              [02-57-9]|
+              1[1-9]
+            )
+          </leadingDigits>
+          <leadingDigits>
+            10[0-79]|
+            2(?:
+              [02-57-9]|
+              1[1-79]
+            )|
+            (?:
+              10|
+              21
+            )8(?:
+              0[1-9]|
+              [1-9]
             )
           </leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
-        <numberFormat pattern="(\d{3})(\d{4})(\d{4})" nationalPrefixFormattingRule="$NP$FG"
+        <!-- 10 digit fixed line range -->
+        <numberFormat pattern="(\d{3})(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG"
                       nationalPrefixOptionalWhenFormatting="true"
                       carrierCodeFormattingRule="$CC $FG">
           <leadingDigits>
             3(?:
-              11|
-              7[179]
+              [3-59]|
+              7[02-68]
             )|
             4(?:
-              [15]1|
-              3[1-35]
+              [26-8]|
+              3[3-9]|
+              5[2-9]
             )|
             5(?:
-              1|
-              2[37]|
-              3[12]|
-              51|
-              7[13-79]|
-              9[15]
+              3[03-9]|
+              [468]|
+              7[028]|
+              9[2-46-9]
             )|
+            6|
             7(?:
-              [39]1|
-              5[457]|
-              6[09]
+              [0-247]|
+              3[04-9]|
+              5[0-4689]|
+              6[2368]
             )|
             8(?:
-              [57]1|
-              98
-            )
+              [1-358]|
+              9[1-7]
+            )|
+            9(?:
+              [013479]|
+              5[1-5]
+            )|
+            (?:
+              [34]1|
+              55|
+              79|
+              87
+            )[02-9]
           </leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
+        <!-- 10-11 digit shared cost range -->
+        <numberFormat pattern="(\d{3})(\d{7,8})">
+          <leadingDigits>9</leadingDigits>
+          <format>$1 $2</format>
+        </numberFormat>
+        <!-- 11 digit fixed line range -->
         <numberFormat pattern="(\d{4})(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG"
                       nationalPrefixOptionalWhenFormatting="true"
                       carrierCodeFormattingRule="$CC $FG">
-          <leadingDigits>807</leadingDigits>
-          <leadingDigits>8078</leadingDigits>
+          <leadingDigits>80</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
+        <!-- 11 digit fixed line range -->
+        <numberFormat pattern="(\d{3})(\d{4})(\d{4})" nationalPrefixFormattingRule="$NP$FG"
+                      nationalPrefixOptionalWhenFormatting="true"
+                      carrierCodeFormattingRule="$CC $FG">
+          <leadingDigits>[3-578]</leadingDigits>
+          <format>$1 $2 $3</format>
+        </numberFormat>
+        <!-- Mobile range -->
         <numberFormat pattern="(\d{3})(\d{4})(\d{4})" carrierCodeFormattingRule="$CC $FG">
-          <leadingDigits>
-            1(?:
-              [3-57-9]|
-              6[267]
-            )
-          </leadingDigits>
+          <leadingDigits>1[3-9]</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
-        <numberFormat pattern="(\d{5})(\d{3})(\d{4})">
-          <leadingDigits>108</leadingDigits>
-          <leadingDigits>1080</leadingDigits>
-          <leadingDigits>10800</leadingDigits>
-          <format>$1 $2 $3</format>
-        </numberFormat>
-        <numberFormat pattern="(\d{3})(\d{7,8})">
-          <leadingDigits>950</leadingDigits>
-          <format>$1 $2</format>
+        <!-- 12 digit toll free range -->
+        <numberFormat pattern="(\d{2})(\d{3})(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG"
+                      nationalPrefixOptionalWhenFormatting="true">
+          <leadingDigits>[12]</leadingDigits>
+          <format>$1 $2 $3 $4</format>
         </numberFormat>
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
+          1[1279]\d{8,9}|
+          2\d{9}(?:
+            \d{2}
+          )?|
+          [12]\d{6,7}|
+          86\d{6}|
           (?:
-            (?:
-              (?:
-                1[03-68]|
-                2\d
-              )\d\d|
-              [3-79]
-            )\d|
+            1[03-68]\d|
+            6
+          )\d{7,9}|
+          (?:
+            [3-579]\d|
             8[0-57-9]
-          )\d{7}|
-          [1-579]\d{10}|
-          8[0-57-9]\d{8,9}|
-          [1-79]\d{9}|
-          [1-9]\d{7}|
-          [12]\d{6}
+          )\d{6,9}
         </nationalNumberPattern>
       </generalDesc>
       <noInternationalDialling>
         <possibleLengths national="[10-12]"/>
         <nationalNumberPattern>
           (?:
-            4|
             (?:
-              10
-            )?8
+              10|
+              21
+            )8|
+            [48]
           )00\d{7}|
           950\d{7,8}
         </nationalNumberPattern>
@@ -5587,16 +6488,46 @@
            exactly like fixed-line numbers. We don't support them for 4-digit area codes though,
            as they don't seem to be used there based on making actual phone calls. -->
       <fixedLine>
-        <possibleLengths national="[7-12]" localOnly="5,6"/>
+        <possibleLengths national="[7-11]" localOnly="5,6"/>
         <exampleNumber>1012345678</exampleNumber>
         <nationalNumberPattern>
-          21(?:
-            100\d{2}|
-            95\d{3,4}|
-            \d{8,10}
+          (?:
+            10(?:
+              [02-79]\d\d|
+              [18](?:
+                0[1-9]|
+                [1-9]\d
+              )
+            )|
+            21(?:
+              [18](?:
+                0[1-9]|
+                [1-9]\d
+              )|
+              [2-79]\d\d
+            )
+          )\d{5}|
+          (?:
+            43[35]|
+            754
+          )\d{7,8}|
+          8(?:
+            078\d{7}|
+            51\d{7,8}
           )|
           (?:
             10|
+            (?:
+              2|
+              85
+            )1|
+            43[35]|
+            754
+          )(?:
+            100\d\d|
+            95\d{3,4}
+          )|
+          (?:
             2[02-57-9]|
             3(?:
               11|
@@ -5604,7 +6535,7 @@
             )|
             4(?:
               [15]1|
-              3[1-35]
+              3[12]
             )|
             5(?:
               1\d|
@@ -5615,19 +6546,33 @@
               9[15]
             )|
             7(?:
-              31|
-              5[457]|
-              6[09]|
-              91
+              [39]1|
+              5[57]|
+              6[09]
             )|
             8(?:
-              [57]1|
+              71|
               98
             )
           )(?:
-            100\d{2}|
-            95\d{3,4}|
-            \d{8}
+            [02-8]\d{7}|
+            1(?:
+              0(?:
+                0\d\d(?:
+                  \d{3}
+                )?|
+                [1-9]\d{5}
+              )|
+              [1-9]\d{6}
+            )|
+            9(?:
+              [0-46-9]\d{6}|
+              5\d{3}(?:
+                \d(?:
+                  \d{2}
+                )?
+              )?
+            )
           )|
           (?:
             3(?:
@@ -5641,9 +6586,9 @@
             4(?:
               1[02-9]|
               2[179]|
-              3[3-9]|
+              3[46-9]|
               5[2-9]|
-              6[4789]|
+              6[47-9]|
               7\d|
               8[23]
             )|
@@ -5667,18 +6612,17 @@
               2[248]|
               3[04-9]|
               4[3-6]|
-              5[0-4689]|
+              5[0-3689]|
               6[2368]|
               9[02-9]
             )|
             8(?:
-              078|
               1[236-8]|
               2[5-7]|
               3\d|
-              5[1-9]|
+              5[2-9]|
               7[02-9]|
-              8[3678]|
+              8[36-8]|
               9[1-7]
             )|
             9(?:
@@ -5689,44 +6633,59 @@
               5[1-5]
             )
           )(?:
-            100\d{2}|
-            95\d{3,4}|
-            \d{7}
+            [02-8]\d{6}|
+            1(?:
+              0(?:
+                0\d\d(?:
+                  \d{2}
+                )?|
+                [1-9]\d{4}
+              )|
+              [1-9]\d{5}
+            )|
+            9(?:
+              [0-46-9]\d{5}|
+              5\d{3,5}
+            )
           )
         </nationalNumberPattern>
       </fixedLine>
-      <!-- 170, 176 and 177 prefixes are introduced in early 2014 for 4G networks. ITU mentions
-           146 range as "Non-geographic number, Mobile (IoT dedicated)". Library does not support
-           "Internet of things (IoT)" numbers which are generally used for communication between
-           the devices. So we don't include 146 here at this time. -->
+      <!-- 170, 176 and 177 prefixes are introduced in early 2014 for 4G networks. ITU mentions 13
+           digit 10647, 1440 and 10 digit 14[68] ranges as "Non-geographic number, Mobile (IoT
+           dedicated)". Library does not support "Internet of things (IoT)" numbers which are
+           generally used for communication between the devices. So we don't include 146 here at
+           this time. -->
       <mobile>
         <possibleLengths national="11"/>
         <exampleNumber>13123456789</exampleNumber>
         <nationalNumberPattern>
+          1740[0-5]\d{6}|
           1(?:
-            [38]\d{3}|
-            4[57]\d{2}|
-            5[0-35-9]\d{2}|
-            6[267]\d{2}|
-            7(?:
-              [0-35-8]\d{2}|
-              40[0-5]
-            )|
-            9[189]\d{2}
-          )\d{6}
+            [38]\d|
+            4[57]|
+            5[0-35-9]|
+            6[25-7]|
+            7[0-35-8]|
+            9[189]
+          )\d{8}
         </nationalNumberPattern>
       </mobile>
       <!-- Toll free, premium rate, and VoIP numbers are not clearly defined in the official Chinese
            number plan, and do not seem to have been standardized. The information below is
-           collected from searching the web. -->
+           collected from searching the web. 12 digit 800 numbers with area codes of Shanghai(21)
+           and Beijing(10) are toll-free based on online references. -->
       <!-- http://en.wikipedia.org/wiki/Toll-free_telephone_number -->
       <tollFree>
         <possibleLengths national="10,12"/>
         <exampleNumber>8001234567</exampleNumber>
         <nationalNumberPattern>
           (?:
-            10
-          )?800\d{7}
+            (?:
+              10|
+              21
+            )8|
+            8
+          )00\d{7}
         </nationalNumberPattern>
       </tollFree>
       <premiumRate>
@@ -5757,7 +6716,7 @@
               [17]\d|
               2[179]|
               [35][1-9]|
-              6[4789]|
+              6[47-9]|
               8[23]
             )|
             5(?:
@@ -5786,7 +6745,7 @@
               2[5-7]|
               [37]\d|
               5[14-9]|
-              8[3678]|
+              8[36-8]|
               9[1-8]
             )|
             9(?:
@@ -5801,7 +6760,7 @@
       </sharedCost>
     </territory>
 
-    <!-- Colombia -->
+    <!-- Colombia (CO) -->
     <!-- http://www.itu.int/oth/T020200002C/en -->
     <!-- http://en.wikipedia.org/wiki/Telephone_numbers_in_Colombia -->
     <territory id="CO" countryCode="57" internationalPrefix="00(?:4(?:[14]4|56)|[579])"
@@ -5811,11 +6770,8 @@
         <numberFormat pattern="(\d)(\d{7})" nationalPrefixFormattingRule="($FG)"
                       carrierCodeFormattingRule="$NP$CC $FG">
           <leadingDigits>
-            1(?:
-              [2-79]|
-              8[2-9]
-            )|
-            [24-8]
+            [14][2-9]|
+            [25-8]
           </leadingDigits>
           <format>$1 $2</format>
         </numberFormat>
@@ -5824,18 +6780,7 @@
           <format>$1 $2</format>
         </numberFormat>
         <numberFormat pattern="(\d)(\d{3})(\d{7})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>
-            1(?:
-              80|
-              9
-            )
-          </leadingDigits>
-          <leadingDigits>
-            1(?:
-              800|
-              9
-            )
-          </leadingDigits>
+          <leadingDigits>1</leadingDigits>
           <format>$1-$2-$3</format>
           <intlFormat>$1 $2 $3</intlFormat>
         </numberFormat>
@@ -5859,11 +6804,23 @@
         <possibleLengths national="10"/>
         <exampleNumber>3211234567</exampleNumber>
         <nationalNumberPattern>
+          3333(?:
+            0(?:
+              0\d|
+              1[0-5]
+            )|
+            [4-9]\d\d
+          )\d{3}|
+          33(?:
+            00|
+            3[0-24-9]
+          )\d{6}|
           3(?:
             0[0-5]|
             1\d|
             2[0-3]|
-            5[01]
+            5[01]|
+            70
           )\d{7}
         </nationalNumberPattern>
       </mobile>
@@ -5884,7 +6841,7 @@
       </premiumRate>
     </territory>
 
-    <!-- Costa Rica -->
+    <!-- Costa Rica (CR) -->
     <!-- http://www.itu.int/oth/T0202000030/en -->
     <!-- http://en.wikipedia.org/wiki/Telephone_numbers_in_Costa_Rica -->
     <territory id="CR" countryCode="506" internationalPrefix="00"
@@ -5917,35 +6874,27 @@
         <possibleLengths national="8"/>
         <exampleNumber>22123456</exampleNumber>
         <nationalNumberPattern>
+          210[7-9]\d{4}|
           2(?:
-            [024-7]\d\d|
-            1(?:
-              0[7-9]|
-              [1-9]\d
-            )
-          )\d{4}
+            [024-7]\d|
+            1[1-9]
+          )\d{5}
         </nationalNumberPattern>
       </fixedLine>
       <mobile>
         <possibleLengths national="8"/>
         <exampleNumber>83123456</exampleNumber>
         <nationalNumberPattern>
+          6500[01]\d{3}|
+          5(?:
+            0[01]|
+            7[0-3]
+          )\d{5}|
           (?:
-            (?:
-              5(?:
-                0[01]|
-                7[0-3]
-              )|
-              (?:
-                7[0-3]|
-                8[3-9]
-              )\d
-            )\d\d|
-            6(?:
-              [0-4]\d{3}|
-              500[01]
-            )
-          )\d{3}
+            6[0-4]|
+            7[0-3]|
+            8[3-9]
+          )\d{6}
         </nationalNumberPattern>
       </mobile>
       <tollFree>
@@ -5975,12 +6924,15 @@
       </voip>
     </territory>
 
-    <!-- Cuba -->
+    <!-- Cuba (CU) -->
     <!-- http://www.itu.int/oth/T0202000033/en -->
     <territory id="CU" countryCode="53" internationalPrefix="119" nationalPrefix="0">
       <availableFormats>
         <numberFormat pattern="(\d{2})(\d{4,6})" nationalPrefixFormattingRule="($NP$FG)">
-          <leadingDigits>[2-4]</leadingDigits>
+          <leadingDigits>
+            2[1-4]|
+            [34]
+          </leadingDigits>
           <format>$1 $2</format>
         </numberFormat>
         <numberFormat pattern="(\d)(\d{6,7})" nationalPrefixFormattingRule="($NP$FG)">
@@ -5991,29 +6943,44 @@
           <leadingDigits>5</leadingDigits>
           <format>$1 $2</format>
         </numberFormat>
+        <numberFormat pattern="(\d{3})(\d{7})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>8</leadingDigits>
+          <format>$1 $2</format>
+        </numberFormat>
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
-          [2-57]\d{7}|
-          [2-47]\d{6}|
-          [34]\d{5}
+          [27]\d{6,7}|
+          [34]\d{5,7}|
+          (?:
+            5|
+            8\d\d
+          )\d{7}
         </nationalNumberPattern>
       </generalDesc>
+      <!-- Based on one of the data sources, 80[25] and 878 ranges are fixed-line as per
+           Government docs, though no other references are found. -->
       <fixedLine>
-        <possibleLengths national="[6-8]" localOnly="4,5"/>
+        <possibleLengths national="[6-8],10" localOnly="4,5"/>
         <exampleNumber>71234567</exampleNumber>
         <nationalNumberPattern>
           (?:
-            2[1-4]|
-            7\d
-          )\d{5,6}|
+            3[23]|
+            48
+          )\d{4,6}|
           (?:
-            3[1-3]|
-            4[1-35-8]
+            31|
+            4[36]|
+            8(?:
+              0[25]|
+              78
+            )\d
           )\d{6}|
-          3[23]\d{4,5}|
-          4[12578]\d{5}|
-          4[78]\d{4}
+          (?:
+            2[1-4]|
+            4[1257]|
+            7\d
+          )\d{5,6}
         </nationalNumberPattern>
       </fixedLine>
       <mobile>
@@ -6021,19 +6988,34 @@
         <exampleNumber>51234567</exampleNumber>
         <nationalNumberPattern>5\d{7}</nationalNumberPattern>
       </mobile>
+      <tollFree>
+        <possibleLengths national="10"/>
+        <exampleNumber>8001234567</exampleNumber>
+        <nationalNumberPattern>800\d{7}</nationalNumberPattern>
+      </tollFree>
+      <sharedCost>
+        <possibleLengths national="10"/>
+        <exampleNumber>8071234567</exampleNumber>
+        <nationalNumberPattern>807\d{7}</nationalNumberPattern>
+      </sharedCost>
     </territory>
 
-    <!-- Cape Verde -->
+    <!-- Cape Verde (CV) -->
     <!-- http://www.itu.int/oth/T0202000026/en -->
     <territory id="CV" countryCode="238" internationalPrefix="0">
       <availableFormats>
         <numberFormat pattern="(\d{3})(\d{2})(\d{2})">
-          <leadingDigits>[2-59]</leadingDigits>
+          <leadingDigits>[2-589]</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
       </availableFormats>
       <generalDesc>
-        <nationalNumberPattern>[2-59]\d{6}</nationalNumberPattern>
+        <nationalNumberPattern>
+          (?:
+            [2-59]\d\d|
+            800
+          )\d{4}
+        </nationalNumberPattern>
       </generalDesc>
       <fixedLine>
         <possibleLengths national="7"/>
@@ -6065,9 +7047,14 @@
           )\d{5}
         </nationalNumberPattern>
       </mobile>
+      <tollFree>
+        <possibleLengths national="7"/>
+        <exampleNumber>8001234</exampleNumber>
+        <nationalNumberPattern>800\d{4}</nationalNumberPattern>
+      </tollFree>
     </territory>
 
-    <!-- Curaçao -->
+    <!-- Curaçao (CW) -->
     <!-- Main region for 'BQ' -->
     <!-- http://www.itu.int/oth/T02020000F5/en -->
     <!-- All the formatting patterns for country-code 599 are here. -->
@@ -6097,19 +7084,28 @@
       </generalDesc>
       <fixedLine>
         <possibleLengths national="7,8"/>
-        <exampleNumber>94151234</exampleNumber>
+        <exampleNumber>94351234</exampleNumber>
         <nationalNumberPattern>
           9(?:
-            (?:
-              [48]\d|
-              50
-            )\d|
+            4(?:
+              3[0-5]|
+              4[14]|
+              6\d
+            )|
+            50\d|
             7(?:
-              2[0-24]|
-              [34]\d|
-              6[35-7]|
+              2[014]|
+              3[02-9]|
+              4[4-9]|
+              6[357]|
               77|
               8[7-9]
+            )|
+            8(?:
+              3[39]|
+              [46]\d|
+              7[01]|
+              8[57-9]
             )
           )\d{4}
         </nationalNumberPattern>
@@ -6118,16 +7114,11 @@
         <possibleLengths national="7,8"/>
         <exampleNumber>95181234</exampleNumber>
         <nationalNumberPattern>
+          953[01]\d{4}|
           9(?:
-            5(?:
-              [12467]\d|
-              3[01]
-            )|
-            6(?:
-              [15-9]\d|
-              3[01]
-            )
-          )\d{4}
+            5[12467]|
+            6[5-9]
+          )\d{5}
         </nationalNumberPattern>
       </mobile>
       <pager>
@@ -6144,9 +7135,9 @@
       </sharedCost>
     </territory>
 
-    <!-- Christmas Islands -->
-    <!-- References state Christmas Islands have fixed line numbers starting +61 8 9164. -->
+    <!-- Christmas Island (CX) -->
     <!-- Calling code and formatting shared with 'AU' -->
+    <!-- References state Christmas Islands have fixed line numbers starting +61 8 9164. -->
     <!-- http://en.wikipedia.org/wiki/List_of_country_calling_codes -->
     <!-- http://en.wikipedia.org/wiki/Telephone_numbers_in_Australia -->
     <!-- https://www.thenumberingsystem.com.au/#/number-register/search -->
@@ -6156,11 +7147,15 @@
                nationalPrefixTransformRule="8$1">
       <generalDesc>
         <nationalNumberPattern>
-          1\d{5,9}|
+          1(?:
+            [0-79]\d|
+            8[0-24-9]
+          )\d{7}|
           (?:
-            [48]\d\d|
+            [148]\d\d|
             550
-          )\d{6}
+          )\d{6}|
+          1\d{5,7}
         </nationalNumberPattern>
       </generalDesc>
       <fixedLine>
@@ -6211,14 +7206,15 @@
         <possibleLengths national="9"/>
         <exampleNumber>412345678</exampleNumber>
         <nationalNumberPattern>
+          483[0-3]\d{5}|
           4(?:
             [0-3]\d|
             4[047-9]|
             5[0-25-9]|
-            6[6-9]|
+            6[06-9]|
             7[02-9]|
             8[0-2457-9]|
-            9[017-9]
+            9[0-27-9]
           )\d{6}
         </nationalNumberPattern>
       </mobile>
@@ -6257,16 +7253,19 @@
         <nationalNumberPattern>
           (?:
             14(?:
-              5\d|
-              71
+              5(?:
+                1[0458]|
+                [23][458]
+              )|
+              71\d
             )|
-            550\d
-          )\d{5}
+            550\d\d
+          )\d{4}
         </nationalNumberPattern>
       </voip>
     </territory>
 
-    <!-- Cyprus -->
+    <!-- Cyprus (CY) -->
     <!-- http://www.itu.int/oth/T0202000034/en -->
     <territory id="CY" countryCode="357" internationalPrefix="00" mobileNumberPortableRegion="true">
       <availableFormats>
@@ -6328,7 +7327,7 @@
       </uan>
     </territory>
 
-    <!-- Czech Rep. -->
+    <!-- Czechia (CZ) -->
     <!-- http://www.itu.int/oth/T0202000035/en -->
     <!-- http://en.wikipedia.org/wiki/%2B420 -->
     <territory id="CZ" countryCode="420" internationalPrefix="00" mobileNumberPortableRegion="true">
@@ -6341,11 +7340,11 @@
           <format>$1 $2 $3</format>
         </numberFormat>
         <numberFormat pattern="(\d{2})(\d{3})(\d{3})(\d{3})">
-          <leadingDigits>9[36]</leadingDigits>
+          <leadingDigits>9</leadingDigits>
           <format>$1 $2 $3 $4</format>
         </numberFormat>
         <numberFormat pattern="(\d{3})(\d{3})(\d{3})(\d{3})">
-          <leadingDigits>96</leadingDigits>
+          <leadingDigits>9</leadingDigits>
           <format>$1 $2 $3 $4</format>
         </numberFormat>
       </availableFormats>
@@ -6353,9 +7352,9 @@
         <nationalNumberPattern>
           (?:
             [2-578]\d|
-            60|
-            9\d{1,4}
-          )\d{7}
+            60
+          )\d{7}|
+          9\d{8,11}
         </nationalNumberPattern>
       </generalDesc>
       <fixedLine>
@@ -6440,7 +7439,7 @@
       </voicemail>
     </territory>
 
-    <!-- Germany -->
+    <!-- Germany (DE) -->
     <!-- http://www.itu.int/oth/T0202000051/en -->
     <!-- http://en.wikipedia.org/wiki/Telephone_numbers_in_germany -->
     <!-- Due to the high complexity of ranges in the German numbering scheme, the regular
@@ -6466,57 +7465,45 @@
               0[1-389]|
               1[124]|
               2[18]|
-              3[14]|
-              [4-9]1
+              3[14]
             )|
             3(?:
               [35-9][15]|
               4[015]
             )|
+            906|
             (?:
+              2[4-9]|
               4[2-9]|
-              [57][1-9]|
+              [579][1-9]|
               [68][1-8]
-            )1|
-            9(?:
-              06|
-              [1-9]1
-            )
+            )1
           </leadingDigits>
           <leadingDigits>
             2(?:
               0[1-389]|
-              1(?:
-                [14]|
-                2[0-8]
-              )|
-              2[18]|
-              3[14]|
-              [4-9]1
+              12[0-8]
             )|
             3(?:
               [35-9][15]|
               4[015]
             )|
+            906|
+            2(?:
+              [13][14]|
+              2[18]
+            )|
             (?:
+              2[4-9]|
               4[2-9]|
-              [57][1-9]|
+              [579][1-9]|
               [68][1-8]
-            )1|
-            9(?:
-              06|
-              [1-9]1
-            )
+            )1
           </leadingDigits>
           <format>$1 $2</format>
         </numberFormat>
-        <!-- Short shared cost numbers. -->
-        <numberFormat pattern="(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>138</leadingDigits>
-          <format>$1 $2</format>
-        </numberFormat>
-        <!-- Fixed line, 4 digit area codes. -->
-        <numberFormat pattern="(\d{4})(\d{3,11})" nationalPrefixFormattingRule="$NP$FG">
+        <!-- Fixed line, 4 digit area codes. Only area code 5361 has two digit subscriber numbers. -->
+        <numberFormat pattern="(\d{4})(\d{2,11})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>
             [24-6]|
             3(?:
@@ -6525,18 +7512,13 @@
               7[2-467]|
               8[2-46-8]
             )|
-            7(?:
-              0[2-8]|
-              [1-9]
-            )|
+            70[2-8]|
             8(?:
               0[2-9]|
               [1-8]
             )|
-            9(?:
-              0[7-9]|
-              [1-9]
-            )
+            90[7-9]|
+            [79][1-9]
           </leadingDigits>
           <leadingDigits>
             [24-6]|
@@ -6545,33 +7527,25 @@
                 0[1-467]|
                 2[127-9]|
                 3[124578]|
-                [46][1246]|
                 7[1257-9]|
                 8[1256]|
                 9[145]
               )|
               4(?:
                 2[135]|
-                3[1357]|
                 4[13578]|
-                6[1246]|
-                7[1356]|
                 9[1346]
               )|
               5(?:
                 0[14]|
                 2[1-3589]|
-                3[1357]|
-                [49][1246]|
                 6[1-4]|
                 7[13468]|
                 8[13568]
               )|
               6(?:
-                0[1356]|
                 2[1-489]|
                 3[124-6]|
-                4[1347]|
                 6[13]|
                 7[12579]|
                 8[1-356]|
@@ -6579,7 +7553,6 @@
               )|
               7(?:
                 2[1-7]|
-                3[1357]|
                 4[145]|
                 6[1-5]|
                 7[1-4]
@@ -6587,7 +7560,6 @@
               8(?:
                 21|
                 3[1468]|
-                4[1347]|
                 6|
                 7[1467]|
                 8[136]
@@ -6595,7 +7567,6 @@
               9(?:
                 0[12479]|
                 2[1358]|
-                3[1357]|
                 4[134679]|
                 6[1-9]|
                 7[136]|
@@ -6603,19 +7574,35 @@
                 9[1468]
               )
             )|
-            7(?:
-              0[2-8]|
-              [1-9]
-            )|
+            70[2-8]|
             8(?:
               0[2-9]|
               [1-8]
             )|
-            9(?:
-              0[7-9]|
-              [1-9]
-            )
+            90[7-9]|
+            [79][1-9]|
+            3[68]4[1347]|
+            3(?:
+              47|
+              60
+            )[1356]|
+            3(?:
+              3[46]|
+              46|
+              5[49]
+            )[1246]|
+            3[4579]3[1357]
           </leadingDigits>
+          <format>$1 $2</format>
+        </numberFormat>
+        <!-- Short shared cost numbers. -->
+        <numberFormat pattern="(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>138</leadingDigits>
+          <format>$1 $2</format>
+        </numberFormat>
+        <!-- Fixed line, 5 digit area codes. -->
+        <numberFormat pattern="(\d{5})(\d{2,10})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>3</leadingDigits>
           <format>$1 $2</format>
         </numberFormat>
         <!-- UAN (181) numbers. -->
@@ -6634,19 +7621,9 @@
           </leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
-        <!-- Fixed line, 5 digit area codes. -->
-        <numberFormat pattern="(\d{5})(\d{3,10})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>3</leadingDigits>
-          <format>$1 $2</format>
-        </numberFormat>
         <!-- Mobile/pager format (from ITU document). Actual usage varies. -->
         <numberFormat pattern="(\d{3})(\d{7,8})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>
-            1(?:
-              6[02-489]|
-              7
-            )
-          </leadingDigits>
+          <leadingDigits>1[67]</leadingDigits>
           <format>$1 $2</format>
         </numberFormat>
         <!-- Toll free (800) numbers. -->
@@ -6654,9 +7631,24 @@
           <leadingDigits>8</leadingDigits>
           <format>$1 $2</format>
         </numberFormat>
-        <!-- Mobile format for 15x mobile numbers. -->
+        <!-- Where we have seen prefixes in use for the IVPN/User Group numbers, we format it the
+             way it is generally written. For other prefixes, we fall back to using a three-digit
+             prefix since we have currently no more information to allow us to format these more
+             precisely. -->
+        <numberFormat pattern="(\d{5})(\d{6})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>185</leadingDigits>
+          <leadingDigits>1850</leadingDigits>
+          <leadingDigits>18500</leadingDigits>
+          <format>$1 $2</format>
+        </numberFormat>
+        <!-- Personal numbers. -->
+        <numberFormat pattern="(\d{3})(\d{4})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>7</leadingDigits>
+          <format>$1 $2 $3</format>
+        </numberFormat>
+        <!-- Various UAN numbers. -->
         <numberFormat pattern="(\d{4})(\d{7})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>15[1279]</leadingDigits>
+          <leadingDigits>18[68]</leadingDigits>
           <format>$1 $2</format>
         </numberFormat>
         <!-- Some mobile numbers (carrier services etc..) have a 6 digit NSN and need to be formatted
@@ -6666,36 +7658,13 @@
           <leadingDigits>15[0568]</leadingDigits>
           <format>$1 $2</format>
         </numberFormat>
-        <!-- Personal numbers. -->
-        <numberFormat pattern="(\d{3})(\d{4})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>7</leadingDigits>
-          <format>$1 $2 $3</format>
+        <!-- Mobile format for 15x mobile numbers. -->
+        <numberFormat pattern="(\d{4})(\d{7})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>15[1279]</leadingDigits>
+          <format>$1 $2</format>
         </numberFormat>
         <!-- Various UAN numbers. -->
         <numberFormat pattern="(\d{3})(\d{8})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>18[2-579]</leadingDigits>
-          <leadingDigits>18[2-579]</leadingDigits>
-          <leadingDigits>
-            18(?:
-              [2-479]|
-              5(?:
-                0[1-9]|
-                [1-9]
-              )
-            )
-          </leadingDigits>
-          <format>$1 $2</format>
-        </numberFormat>
-        <!-- Various UAN numbers. -->
-        <numberFormat pattern="(\d{4})(\d{7})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>18[68]</leadingDigits>
-          <format>$1 $2</format>
-        </numberFormat>
-        <!-- Where we have seen prefixes in use for the IVPN/User Group numbers, we format it the
-             way it is generally written. For other prefixes, we fall back to using a three-digit
-             prefix since we have currently no more information to allow us to format these more
-             precisely. -->
-        <numberFormat pattern="(\d{5})(\d{6})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>18</leadingDigits>
           <format>$1 $2</format>
         </numberFormat>
@@ -6710,53 +7679,46 @@
           <format>$1 $2 $3</format>
         </numberFormat>
         <!-- Voicemail. -->
-        <numberFormat pattern="(\d{3})(\d{2})(\d{8})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>15[013-68]</leadingDigits>
+        <numberFormat pattern="(\d{4})(\d{2})(\d{7})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>15[279]</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
         <!-- Voicemail. -->
-        <numberFormat pattern="(\d{4})(\d{2})(\d{7})" nationalPrefixFormattingRule="$NP$FG">
+        <numberFormat pattern="(\d{3})(\d{2})(\d{8})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>15</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
-          (?:
-            1|
-            [235-9]\d{11}|
-            4(?:
-              [0-8]\d{2,10}|
-              9(?:
-                [05]\d{7}|
-                [46][1-8]\d{2,6}
-              )
-            )
-          )\d{3}|
-          [1-35-9]\d{6,13}|
+          [2579]\d{5,14}|
           49(?:
-            (?:
-              [0-25]\d|
-              3[1-689]
-            )\d{4,8}|
-            4[1-8]\d{4}|
-            6[0-8]\d{3,4}|
-            7[1-7]\d{5,8}
+            [05]\d{10}|
+            [46][1-8]\d{4,9}
           )|
-          497[0-7]\d{4}|
+          49(?:
+            [0-25]\d|
+            3[1-689]|
+            7[1-7]
+          )\d{4,8}|
           49(?:
             [0-2579]\d|
-            [34][1-9]
+            [34][1-9]|
+            6[0-8]
           )\d{3}|
-          [1-9]\d{5}|
-          [13468]\d{4}
+          49\d{3,4}|
+          (?:
+            1|
+            [368]\d|
+            4[0-8]
+          )\d{3,13}
         </nationalNumberPattern>
       </generalDesc>
       <!-- The German ITU numbering plan gives overly simplistic minimum/maximum
            lengths for number ranges. This would (if taken literally) result in 1 or 2 length
-           subscriber numbers (e.g. 5-digit area code for 6 digit number).
-           A contact of the German numbering authority confirmed that subscriber numbers
-           are never shorter than 3-digits, and we've adopted this in the range data. -->
+           subscriber numbers. However, a contact of the German numbering authority
+           confirmed that subscriber numbers can never be shorter than 2-digit and total
+           length can not be less than 6 digits. -->
       <!-- Maximum lengths of German numbers are generally undefined, since any subscriber
            number can connect to a private exchange (PABX), which can consume additionally
            dialled digits (e.g. for calling individual rooms in a hotel directly). This means that in
@@ -6765,9 +7727,18 @@
            This needs to be shorter to avoid range lengths overlapping which would otherwise
            cause issues in parsing (since 49 is both an area code and the country calling code). -->
       <fixedLine>
-        <possibleLengths national="[5-15]" localOnly="3,4"/>
+        <possibleLengths national="[5-15]" localOnly="[2-4]"/>
         <exampleNumber>30123456</exampleNumber>
         <nationalNumberPattern>
+          (?:
+            32|
+            49[4-6]\d
+          )\d{9}|
+          49[0-7]\d{3,9}|
+          (?:
+            [34]0|
+            [68]9
+          )\d{3,13}|
           (?:
             2(?:
               0[1-689]|
@@ -6775,6 +7746,19 @@
               4[0-8]|
               7[1-7]|
               8[0-7]
+            )|
+            3(?:
+              [3569]\d|
+              4[0-79]|
+              7[1-7]|
+              8[1-8]
+            )|
+            4(?:
+              1[02-9]|
+              [2-48]\d|
+              5[0-6]|
+              6[0-8]|
+              7[0-79]
             )|
             5(?:
               0[2-8]|
@@ -6784,7 +7768,7 @@
             )|
             6(?:
               0[02-9]|
-              [1-3589]\d|
+              [1-358]\d|
               [47][0-8]|
               6[1-9]
             )|
@@ -6800,7 +7784,7 @@
             8(?:
               0[2-9]|
               1[0-79]|
-              [29]\d|
+              2\d|
               3[0-46-9]|
               4[0-6]|
               5[013-9]|
@@ -6815,56 +7799,7 @@
               6[0-8]|
               7[0-467]
             )
-          )\d{4,12}|
-          3(?:
-            (?:
-              [03569]\d|
-              4[0-79]|
-              7[1-7]|
-              8[1-8]
-            )\d{4,12}|
-            2\d{9}
-          )|
-          4(?:
-            (?:
-              [02-48]\d|
-              1[02-9]|
-              5[0-6]|
-              6[0-8]|
-              7[0-79]
-            )\d{4,12}|
-            9(?:
-              [0-37]\d{4,9}|
-              [4-6]\d{4,10}
-            )
-          )|
-          (?:
-            2(?:
-              0[1-389]|
-              1[124]|
-              2[18]|
-              3[14]|
-              [4-9]1
-            )|
-            3(?:
-              0\d?|
-              [35-9][15]|
-              4[015]
-            )|
-            4(?:
-              0\d?|
-              [2-9]1
-            )|
-            [57][1-9]1|
-            [68](?:
-              [1-8]1|
-              9\d?
-            )|
-            9(?:
-              06|
-              [1-9]1
-            )
-          )\d{3}
+          )\d{3,12}
         </nationalNumberPattern>
       </fixedLine>
       <!-- According to
@@ -6878,13 +7813,11 @@
         <possibleLengths national="10,11"/>
         <exampleNumber>15123456789</exampleNumber>
         <nationalNumberPattern>
+          15[0-25-9]\d{8}|
           1(?:
-            5[0-25-9]\d{8}|
-            (?:
-              6[023]|
-              7\d
-            )\d{7,8}
-          )
+            6[023]|
+            7\d
+          )\d{7,8}
         </nationalNumberPattern>
       </mobile>
       <pager>
@@ -6927,12 +7860,10 @@
         <possibleLengths national="[7-14]"/>
         <exampleNumber>18012345</exampleNumber>
         <nationalNumberPattern>
-          1(?:
-            3(?:
-              7[1-6]\d\d|
-              8
-            )|
-            80\d{1,7}
+          180\d{5,11}|
+          13(?:
+            7[1-6]\d\d|
+            8
           )\d{4}
         </nationalNumberPattern>
       </sharedCost>
@@ -6961,36 +7892,34 @@
         <exampleNumber>177991234567</exampleNumber>
         <nationalNumberPattern>
           1(?:
-            5(?:
-              (?:
-                [03-68]00|
-                113
-              )\d|
-              2\d55|
-              7\d99|
-              9\d33
+            6(?:
+              013|
+              255|
+              399
             )|
+            7(?:
+              (?:
+                [015]1|
+                [69]3
+              )3|
+              [2-4]55|
+              [78]99
+            )
+          )\d{7,8}|
+          15(?:
             (?:
-              6(?:
-                013|
-                255|
-                399
-              )|
-              7(?:
-                (?:
-                  [015]1|
-                  [69]3
-                )3|
-                [2-4]55|
-                [78]99
-              )
-            )\d?
+              [03-68]00|
+              113
+            )\d|
+            2\d55|
+            7\d99|
+            9\d33
           )\d{7}
         </nationalNumberPattern>
       </voicemail>
     </territory>
 
-    <!-- Djibouti -->
+    <!-- Djibouti (DJ) -->
     <!-- http://www.itu.int/oth/T020200003A/en -->
     <territory id="DJ" countryCode="253" internationalPrefix="00">
       <availableFormats>
@@ -7025,7 +7954,7 @@
       </mobile>
     </territory>
 
-    <!-- Denmark -->
+    <!-- Denmark (DK) -->
     <!-- http://www.dba.erhvervsstyrelsen.dk/numbering-lists -->
     <!-- https://en.wikipedia.org/wiki/Telephone_numbers_in_Denmark -->
     <!-- https://www.itu.int/oth/T0202000038/en -->
@@ -7048,7 +7977,7 @@
           (?:
             [2-7]\d|
             8[126-9]|
-            9[1-36-9]
+            9[1-46-9]
           )\d{6}
         </nationalNumberPattern>
       </fixedLine>
@@ -7059,7 +7988,7 @@
           (?:
             [2-7]\d|
             8[126-9]|
-            9[1-36-9]
+            9[1-46-9]
           )\d{6}
         </nationalNumberPattern>
       </mobile>
@@ -7075,11 +8004,12 @@
       </premiumRate>
     </territory>
 
-    <!-- Dominica -->
+    <!-- Dominica (DM) -->
     <!-- Calling code and formatting shared with 'US' -->
     <!-- http://www.itu.int/oth/T020200003B/en -->
     <territory id="DM" countryCode="1" leadingDigits="767" internationalPrefix="011"
-               nationalPrefix="1">
+               nationalPrefix="1" nationalPrefixForParsing="1|([2-7]\d{6})$"
+               nationalPrefixTransformRule="767$1">
       <generalDesc>
         <nationalNumberPattern>
           (?:
@@ -7160,7 +8090,7 @@
       </personalNumber>
     </territory>
 
-    <!-- Dominican Rep. -->
+    <!-- Dominican Republic (DO) -->
     <!-- Calling code and formatting shared with 'US' -->
     <!-- http://www.itu.int/oth/T020200003C/en -->
     <territory id="DO" countryCode="1" leadingDigits="8[024]9" internationalPrefix="011"
@@ -7274,7 +8204,7 @@
       </personalNumber>
     </territory>
 
-    <!-- Algeria -->
+    <!-- Algeria (DZ) -->
     <!-- http://www.itu.int/oth/T0202000003/en -->
     <!-- http://www.arpt.dz -->
     <territory id="DZ" countryCode="213" internationalPrefix="00" nationalPrefix="0">
@@ -7284,12 +8214,12 @@
           <leadingDigits>[1-4]</leadingDigits>
           <format>$1 $2 $3 $4</format>
         </numberFormat>
-        <numberFormat pattern="(\d{3})(\d{2})(\d{2})(\d{2})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>[5-8]</leadingDigits>
-          <format>$1 $2 $3 $4</format>
-        </numberFormat>
         <numberFormat pattern="(\d{2})(\d{3})(\d{2})(\d{2})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>9</leadingDigits>
+          <format>$1 $2 $3 $4</format>
+        </numberFormat>
+        <numberFormat pattern="(\d{3})(\d{2})(\d{2})(\d{2})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>[5-8]</leadingDigits>
           <format>$1 $2 $3 $4</format>
         </numberFormat>
       </availableFormats>
@@ -7308,15 +8238,13 @@
         <possibleLengths national="8,9"/>
         <exampleNumber>12345678</exampleNumber>
         <nationalNumberPattern>
+          9619\d{5}|
           (?:
-            (?:
-              1\d|
-              2[013-79]|
-              3[0-8]|
-              4[0135689]
-            )\d|
-            9619
-          )\d{5}
+            1\d|
+            2[013-79]|
+            3[0-8]|
+            4[0135689]
+          )\d{6}
         </nationalNumberPattern>
       </fixedLine>
       <!-- Adding 65 and 78 from numbers found online. Also, prefix 670 is added since the carrier
@@ -7328,14 +8256,16 @@
         <exampleNumber>551234567</exampleNumber>
         <nationalNumberPattern>
           (?:
-            (?:
-              5[4-6]|
-              7[7-9]
-            )\d|
+            5(?:
+              4[0-29]|
+              5\d|
+              6[01]
+            )|
             6(?:
               [569]\d|
               7[0-6]
-            )
+            )|
+            7[7-9]\d
           )\d{6}
         </nationalNumberPattern>
       </mobile>
@@ -7363,7 +8293,7 @@
       </voip>
     </territory>
 
-    <!-- Ecuador -->
+    <!-- Ecuador (EC) -->
     <!-- http://en.wikipedia.org/wiki/+593 -->
     <!-- http://www.arcotel.gob.ec/plan-tecnico-fundamental-de-numeracion-series-numericas/ -->
     <!-- http://www.itu.int/oth/T020200003D/en -->
@@ -7409,17 +8339,13 @@
         <possibleLengths national="9"/>
         <exampleNumber>991234567</exampleNumber>
         <nationalNumberPattern>
+          964[0-2]\d{5}|
           9(?:
-            (?:
-              39|
-              [57][89]|
-              [89]\d
-            )\d|
-            6(?:
-              [0-27-9]\d|
-              30
-            )
-          )\d{5}
+            39|
+            [57][89]|
+            6[0-37-9]|
+            [89]\d
+          )\d{6}
         </nationalNumberPattern>
       </mobile>
       <tollFree>
@@ -7434,7 +8360,7 @@
       </voip>
     </territory>
 
-    <!-- Estonia -->
+    <!-- Estonia (EE) -->
     <!-- http://www.itu.int/oth/T0202000043/en -->
     <territory id="EE" countryCode="372" internationalPrefix="00" mobileNumberPortableRegion="true">
       <availableFormats>
@@ -7579,7 +8505,7 @@
       </personalNumber>
     </territory>
 
-    <!-- Egypt -->
+    <!-- Egypt (EG) -->
     <!-- http://www.itu.int/oth/T020200003E/en -->
     <territory id="EG" countryCode="20" internationalPrefix="00" nationalPrefix="0"
                mobileNumberPortableRegion="true">
@@ -7604,11 +8530,9 @@
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
-          (?:
-            [189]\d?|
-            [24-6]
-          )\d{8}|
-          [13]\d{7}
+          [189]\d{8,9}|
+          [24-6]\d{8}|
+          [135]\d{7}
         </nationalNumberPattern>
       </generalDesc>
       <!-- Subscriber numbers starting with 5 are also permitted for the area codes 040, with 5, 6
@@ -7619,10 +8543,11 @@
         <exampleNumber>234567890</exampleNumber>
         <nationalNumberPattern>
           (?:
-            1(?:
-              3[23]|
-              5\d?
-            )|
+            15\d|
+            57[23]
+          )\d{5,6}|
+          (?:
+            13[23]|
             (?:
               2[2-4]|
               3
@@ -7634,8 +8559,7 @@
             )|
             5(?:
               0[2-7]|
-              5\d|
-              7[23]
+              5\d
             )|
             6[24-689]3|
             8(?:
@@ -7671,10 +8595,9 @@
       </premiumRate>
     </territory>
 
-    <!-- Western Sahara -->
-    <!-- Country calling code shared with Morocco (MA). -->
-    <!-- Two area codes are defined in the Morocco ITU document; 05288 XXXXX and 05289 XXXXX -->
+    <!-- Western Sahara (EH) -->
     <!-- Calling code and formatting shared with 'MA' -->
+    <!-- Two area codes are defined in the Morocco ITU document; 05288 XXXXX and 05289 XXXXX -->
     <!-- http://www.itu.int/oth/T0202000090/en -->
     <territory id="EH" countryCode="212" leadingDigits="528[89]" internationalPrefix="00"
                nationalPrefix="0">
@@ -7698,9 +8621,9 @@
               8[0-247-9]
             )|
             7(?:
-              0[067]|
+              0[06-8]|
               6[1267]|
-              7[017]
+              7[0-27]
             )
           )\d{6}
         </nationalNumberPattern>
@@ -7719,11 +8642,16 @@
       <voip>
         <possibleLengths national="9"/>
         <exampleNumber>592401234</exampleNumber>
-        <nationalNumberPattern>5924[01]\d{4}</nationalNumberPattern>
+        <nationalNumberPattern>
+          592(?:
+            4[0-2]|
+            93
+          )\d{4}
+        </nationalNumberPattern>
       </voip>
     </territory>
 
-    <!-- Eritrea -->
+    <!-- Eritrea (ER) -->
     <!-- http://www.itu.int/oth/T0202000042/en -->
     <territory id="ER" countryCode="291" internationalPrefix="00" nationalPrefix="0">
       <availableFormats>
@@ -7765,23 +8693,29 @@
       </mobile>
     </territory>
 
-    <!-- Spain -->
+    <!-- Spain (ES) -->
     <!-- http://www.minetur.gob.es/telecomunicaciones/es-ES/Servicios/Numeracion/Documents/14-10_Descripcion_PNN.pdf -->
     <territory id="ES" countryCode="34" internationalPrefix="00" mobileNumberPortableRegion="true">
       <availableFormats>
+        <!-- 4-digit shortcodes which would otherwise be formatted as 'XXX X' -->
+        <numberFormat pattern="(\d{4})">
+          <leadingDigits>905</leadingDigits>
+          <format>$1</format>
+          <intlFormat>NA</intlFormat>
+        </numberFormat>
+        <!-- 6-digit shortcodes which would otherwise be formatted as 'XXX XX X' -->
+        <numberFormat pattern="(\d{6})">
+          <leadingDigits>[79]9</leadingDigits>
+          <format>$1</format>
+          <intlFormat>NA</intlFormat>
+        </numberFormat>
+        <!-- Toll free numbers. -->
         <numberFormat pattern="(\d{3})(\d{3})(\d{3})">
           <leadingDigits>[89]00</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
         <numberFormat pattern="(\d{3})(\d{2})(\d{2})(\d{2})">
-          <leadingDigits>
-            [568]|
-            7[0-48]|
-            9(?:
-              0[12]|
-              [1-8]
-            )
-          </leadingDigits>
+          <leadingDigits>[5-9]</leadingDigits>
           <format>$1 $2 $3 $4</format>
         </numberFormat>
       </availableFormats>
@@ -7800,43 +8734,34 @@
         <possibleLengths national="9"/>
         <exampleNumber>810123456</exampleNumber>
         <nationalNumberPattern>
+          96906(?:
+            0[0-8]|
+            1[1-9]|
+            [2-9]\d
+          )\d\d|
+          9(?:
+            69(?:
+              0[0-57-9]|
+              [1-9]\d
+            )|
+            73(?:
+              [0-8]\d|
+              9[1-9]
+            )
+          )\d{4}|
           (?:
             8(?:
               [1356]\d|
               [28][0-8]|
               [47][1-9]
-            )\d{4}|
+            )|
             9(?:
-              (?:
-                (?:
-                  [135]\d|
-                  [28][0-8]|
-                  4[1-9]
-                )\d\d|
-                7(?:
-                  [124-9]\d\d|
-                  3(?:
-                    [0-8]\d|
-                    9[1-9]
-                  )
-                )
-              )\d\d|
-              6(?:
-                [0-8]\d{4}|
-                9(?:
-                  0(?:
-                    [0-57-9]\d\d|
-                    6(?:
-                      0[0-8]|
-                      1[1-9]|
-                      [2-9]\d
-                    )
-                  )|
-                  [1-9]\d{3}
-                )
-              )
+              [135]\d|
+              [268][0-8]|
+              4[1-9]|
+              7[124-9]
             )
-          )\d\d
+          )\d{6}
         </nationalNumberPattern>
       </fixedLine>
       <!-- The ranges 969060900 to 969061099 and 973900000 to 973909999 are mobile according to
@@ -7845,19 +8770,17 @@
         <possibleLengths national="9"/>
         <exampleNumber>612345678</exampleNumber>
         <nationalNumberPattern>
+          9(?:
+            6906(?:
+              09|
+              10
+            )|
+            7390\d\d
+          )\d\d|
           (?:
-            (?:
-              6\d|
-              7[1-48]
-            )\d{5}|
-            9(?:
-              6906(?:
-                09|
-                10
-              )|
-              7390\d\d
-            )
-          )\d\d
+            6\d|
+            7[1-48]
+          )\d{7}
         </nationalNumberPattern>
       </mobile>
       <tollFree>
@@ -7888,7 +8811,7 @@
       </uan>
     </territory>
 
-    <!-- Ethiopia -->
+    <!-- Ethiopia (ET) -->
     <!-- http://www.itu.int/oth/T0202000044/en -->
     <territory id="ET" countryCode="251" internationalPrefix="00" nationalPrefix="0">
       <availableFormats>
@@ -7905,7 +8828,7 @@
           )\d{7}
         </nationalNumberPattern>
       </generalDesc>
-      <!-- Found valid fixed-line numbers online that starts with prefix 11 639 -->
+      <!-- Found valid fixed-line numbers online that starts with prefix 11 617 and 11 639. -->
       <fixedLine>
         <possibleLengths national="9" localOnly="7"/>
         <exampleNumber>111112345</exampleNumber>
@@ -7945,7 +8868,7 @@
                 5[0-4]
               )|
               6(?:
-                18|
+                1[78]|
                 2[69]|
                 39|
                 4[5-7]|
@@ -7992,6 +8915,7 @@
             )|
             4(?:
               6(?:
+                119|
                 22[0-24-7]|
                 33[1-5]|
                 44[13-69]|
@@ -8041,8 +8965,8 @@
       </mobile>
     </territory>
 
-    <!-- Finland -->
-    <!-- Main region for 'AX', except fixed-line all other phone number ranges are shared. -->
+    <!-- Finland (FI) -->
+    <!-- Main region for 'AX' -->
     <!-- Adding all international carrier access codes in below doc that we found corroborating
          evidence for. https://www.viestintavirasto.fi/en/internettelephone/numberingoftelecommunicationsnetworks/internationalcalls/internationalcarrieraccesscodes.html -->
     <!-- Not supporting national long distance carrier codes as these are overlapping with UAN
@@ -8058,7 +8982,7 @@
              for directory services so are covered in ShortNumberMetadata.xml intead. However,
              they still need a national prefix so we have a formatting rule here. -->
         <numberFormat pattern="(\d{5})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>7</leadingDigits>
+          <leadingDigits>75[12]</leadingDigits>
           <format>$1</format>
           <intlFormat>NA</intlFormat>
         </numberFormat>
@@ -8074,69 +8998,73 @@
           </leadingDigits>
           <format>$1 $2</format>
         </numberFormat>
-        <!-- General format for 2-digit prefix (6-10 digit numbers). -->
-        <numberFormat pattern="(\d{2})(\d{4,8})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>
-            1(?:
-              0[1-9]|
-              [3-79][1-8]|
-              8
-            )|
-            2(?:
-              0[1-9]|
-              9
-            )|
-            [45]|
-            7[135]
-          </leadingDigits>
-          <format>$1 $2</format>
+        <!-- Format for 6 digit short codes. -->
+        <numberFormat pattern="(\d{6})">
+          <leadingDigits>11</leadingDigits>
+          <format>$1</format>
+          <intlFormat>NA</intlFormat>
         </numberFormat>
         <!-- General format for 3-digit prefix (6-10 digit numbers). -->
         <numberFormat pattern="(\d{3})(\d{3,7})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>
-            (?:
-              1|
-              20
-            )0|
-            [36-8]
+            [12]00|
+            [368]|
+            70[07-9]
           </leadingDigits>
+          <format>$1 $2</format>
+        </numberFormat>
+        <!-- General format for 2-digit prefix (6-10 digit numbers). -->
+        <numberFormat pattern="(\d{2})(\d{4,8})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>
+            [1245]|
+            7[135]
+          </leadingDigits>
+          <format>$1 $2</format>
+        </numberFormat>
+        <numberFormat pattern="(\d{2})(\d{6,10})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>7</leadingDigits>
           <format>$1 $2</format>
         </numberFormat>
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
+          [1-35689]\d{4}|
+          7\d{10,11}|
           (?:
             [124-7]\d|
             3[0-46-9]
           )\d{8}|
-          [1-9]\d{5,8}|
-          [1-35689]\d{4}
+          [1-9]\d{5,8}
         </nationalNumberPattern>
       </generalDesc>
       <!-- According to the national numbering plan, service numbers are in general not accessible
            from abroad, although 600/700/800 numbers may be. -->
       <noInternationalDialling>
-        <possibleLengths national="[5-10]"/>
+        <possibleLengths national="[5-12]"/>
         <nationalNumberPattern>
-          [13]00\d{3,7}|
           20(?:
-            0\d{3,7}|
-            (?:
-              2[023]|
-              9[89]
-            )\d{1,6}
-          )|
-          60(?:
-            [12]\d{5,6}|
-            6\d{7}
-          )|
-          7(?:
-            (?:
+            2[023]|
+            9[89]
+          )\d{1,6}|
+          (?:
+            60[12]\d|
+            7099
+          )\d{4,5}|
+          (?:
+            606|
+            7(?:
+              0[78]|
               1|
               3\d
-            )\d{7}|
-            5[03-9]\d{3,7}
-          )
+            )
+          )\d{7}|
+          (?:
+            [1-3]00|
+            7(?:
+              0[1-5]\d\d|
+              5[03-9]
+            )
+          )\d{3,7}
         </nationalNumberPattern>
       </noInternationalDialling>
       <!-- This is limited to geographic numbers - non-geographic nationwide subscriber numbers
@@ -8179,30 +9107,35 @@
            assigned to institutions such as universities, the national post, etc, where they are
            not otherwise classified as toll-free or premium-rate numbers. -->
       <uan>
-        <possibleLengths national="[5-10]"/>
+        <possibleLengths national="[5-12]"/>
         <exampleNumber>10112345</exampleNumber>
         <nationalNumberPattern>
-          (?:
-            10|
-            [23][09]
-          )\d{4,8}|
-          60(?:
-            [12]\d{5,6}|
-            6\d{7}
-          )|
+          20\d{4,8}|
+          60[12]\d{5,6}|
           7(?:
-            (?:
-              1|
-              3\d
-            )\d{7}|
+            099\d{4,5}|
             5[03-9]\d{3,7}
           )|
-          20[2-59]\d\d
+          20[2-59]\d\d|
+          (?:
+            606|
+            7(?:
+              0[78]|
+              1|
+              3\d
+            )
+          )\d{7}|
+          (?:
+            10|
+            29|
+            3[09]|
+            70[1-5]\d
+          )\d{4,8}
         </nationalNumberPattern>
       </uan>
     </territory>
 
-    <!-- Fiji -->
+    <!-- Fiji (FJ) -->
     <!-- http://www.itu.int/oth/T0202000048/en -->
     <!-- http://www.tfl.com.fj -->
     <territory id="FJ" countryCode="679" preferredInternationalPrefix="00"
@@ -8222,13 +9155,11 @@
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
+          45\d{5}|
           (?:
-            (?:
-              0800\d|
-              [235-9]
-            )\d|
-            45
-          )\d{5}
+            0800\d|
+            [235-9]
+          )\d{6}
         </nationalNumberPattern>
       </generalDesc>
       <!-- Adding the prefixes 30X, 31X and 62X, since numbers with these prefixes have been found
@@ -8238,16 +9169,12 @@
         <possibleLengths national="7"/>
         <exampleNumber>3212345</exampleNumber>
         <nationalNumberPattern>
+          603\d{4}|
           (?:
-            (?:
-              3[0-5]|
-              8[58]
-            )\d|
-            6(?:
-              03|
-              [25-7]\d
-            )
-          )\d{4}
+            3[0-5]|
+            6[25-7]|
+            8[58]
+          )\d{5}
         </nationalNumberPattern>
       </fixedLine>
       <mobile>
@@ -8271,7 +9198,7 @@
       </tollFree>
     </territory>
 
-    <!-- Falkland Islands (Malvinas) -->
+    <!-- Falkland Islands (Islas Malvinas) (FK) -->
     <!-- http://www.itu.int/oth/T0202000046/en -->
     <territory id="FK" countryCode="500" internationalPrefix="00">
       <generalDesc>
@@ -8289,25 +9216,12 @@
       </mobile>
     </territory>
 
-    <!-- Micronesia, Federated States of -->
+    <!-- Micronesia (FM) -->
     <!-- http://www.itu.int/oth/T020200008B/en -->
     <territory id="FM" countryCode="691" internationalPrefix="00">
       <availableFormats>
         <numberFormat pattern="(\d{3})(\d{4})">
-          <leadingDigits>
-            3(?:
-              20|
-              [357]
-            )|
-            9
-          </leadingDigits>
-          <leadingDigits>
-            3(?:
-              20[1-9]|
-              [357]
-            )|
-            9
-          </leadingDigits>
+          <leadingDigits>[39]</leadingDigits>
           <format>$1 $2</format>
         </numberFormat>
       </availableFormats>
@@ -8338,7 +9252,7 @@
       </mobile>
     </territory>
 
-    <!-- Faroe Islands -->
+    <!-- Faroe Islands (FO) -->
     <!-- http://www.itu.int/oth/T0202000047/en -->
     <!-- All numbers are formatted together, as a block. -->
     <territory id="FO" countryCode="298" internationalPrefix="00"
@@ -8406,7 +9320,7 @@
       </voip>
     </territory>
 
-    <!-- France -->
+    <!-- France (FR) -->
     <!-- http://www.itu.int/oth/T020200004A/en -->
     <!-- http://www.arcep.fr/index.php?id=8146 -->
     <!-- http://en.wikipedia.org/wiki/%2B33 -->
@@ -8415,22 +9329,28 @@
     <territory id="FR" countryCode="33" internationalPrefix="00" nationalPrefix="0"
                mobileNumberPortableRegion="true">
       <availableFormats>
+        <!-- 4-digit shortcodes. -->
+        <numberFormat pattern="(\d{4})">
+          <leadingDigits>10</leadingDigits>
+          <format>$1</format>
+          <intlFormat>NA</intlFormat>
+        </numberFormat>
         <!-- 6-digit shortcodes. -->
         <numberFormat pattern="(\d{3})(\d{3})">
-          <leadingDigits>11</leadingDigits>
+          <leadingDigits>1</leadingDigits>
           <format>$1 $2</format>
           <intlFormat>NA</intlFormat>
+        </numberFormat>
+        <!-- Variable cost (toll free, premium rate etc.) -->
+        <numberFormat pattern="(\d{3})(\d{2})(\d{2})(\d{2})" nationalPrefixFormattingRule="$NP $FG">
+          <leadingDigits>8</leadingDigits>
+          <format>$1 $2 $3 $4</format>
         </numberFormat>
         <!-- General format (fixed, mobile, voip) -->
         <numberFormat pattern="(\d)(\d{2})(\d{2})(\d{2})(\d{2})"
                       nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>[1-79]</leadingDigits>
           <format>$1 $2 $3 $4 $5</format>
-        </numberFormat>
-        <!-- Variable cost (toll free, premium rate etc.) -->
-        <numberFormat pattern="(\d{3})(\d{2})(\d{2})(\d{2})" nationalPrefixFormattingRule="$NP $FG">
-          <leadingDigits>8</leadingDigits>
-          <format>$1 $2 $3 $4</format>
         </numberFormat>
       </availableFormats>
       <generalDesc>
@@ -8439,7 +9359,12 @@
       <fixedLine>
         <possibleLengths national="9"/>
         <exampleNumber>123456789</exampleNumber>
-        <nationalNumberPattern>[1-5]\d{8}</nationalNumberPattern>
+        <nationalNumberPattern>
+          (?:
+            [1-35]\d|
+            4[1-9]
+          )\d{7}
+        </nationalNumberPattern>
       </fixedLine>
       <!-- 700 numbers are mobile phone services as per https://www.arcep.fr/index.php?id=8146
            where length is mentioned as 'extended length numbers'. As we are not sure, supporting
@@ -8449,13 +9374,11 @@
         <possibleLengths national="9"/>
         <exampleNumber>612345678</exampleNumber>
         <nationalNumberPattern>
+          700\d{6}|
           (?:
-            6\d\d|
-            7(?:
-              00|
-              [3-9]\d
-            )
-          )\d{6}
+            6\d|
+            7[3-9]
+          )\d{7}
         </nationalNumberPattern>
       </mobile>
       <tollFree>
@@ -8466,12 +9389,30 @@
       <premiumRate>
         <possibleLengths national="9"/>
         <exampleNumber>891123456</exampleNumber>
-        <nationalNumberPattern>8[129]\d{7}</nationalNumberPattern>
+        <nationalNumberPattern>
+          836(?:
+            0[0-36-9]|
+            [1-9]\d
+          )\d{4}|
+          8(?:
+            1[2-9]|
+            2[2-47-9]|
+            3[0-57-9]|
+            [569]\d|
+            8[0-35-9]
+          )\d{6}
+        </nationalNumberPattern>
       </premiumRate>
       <sharedCost>
         <possibleLengths national="9"/>
         <exampleNumber>884012345</exampleNumber>
-        <nationalNumberPattern>884\d{6}</nationalNumberPattern>
+        <nationalNumberPattern>
+          8(?:
+            1[01]|
+            2[0156]|
+            84
+          )\d{6}
+        </nationalNumberPattern>
       </sharedCost>
       <!-- 087 numbers used to be used for this. -->
       <voip>
@@ -8488,16 +9429,26 @@
       </uan>
     </territory>
 
-    <!-- Gabon -->
+    <!-- Gabon (GA) -->
     <!-- Note: We cannot set nationalPrefix="0" while fixed line numbers can start with a zero
          as this breaks parsing (it treats all leading zeros as national prefixes. -->
     <!-- http://www.itu.int/oth/T020200004E/en -->
     <!-- http://www.arcep.ga -->
-    <territory id="GA" countryCode="241" internationalPrefix="00">
+    <territory id="GA" countryCode="241" internationalPrefix="00"
+               nationalPrefixForParsing="0(11\d{6}|6[256]\d{6}|7[47]\d{6})"
+               nationalPrefixTransformRule="$1">
       <availableFormats>
         <!-- If no leading zero was supplied, format with the national prefix. -->
         <numberFormat pattern="(\d)(\d{2})(\d{2})(\d{2})" nationalPrefixFormattingRule="0$FG">
           <leadingDigits>[2-7]</leadingDigits>
+          <format>$1 $2 $3 $4</format>
+        </numberFormat>
+        <!-- Even in new way of dialling, 0 is mandatory when dialling domestically. -->
+        <numberFormat pattern="(\d{2})(\d{2})(\d{2})(\d{2})" nationalPrefixFormattingRule="0$FG">
+          <leadingDigits>
+            11|
+            [67]
+          </leadingDigits>
           <format>$1 $2 $3 $4</format>
         </numberFormat>
         <!-- This already has a leading zero so we format is "as is". -->
@@ -8509,12 +9460,17 @@
       <generalDesc>
         <nationalNumberPattern>
           (?:
-            0\d|
-            [2-7]
-          )\d{6}
+            [067]\d|
+            11
+          )\d{6}|
+          [2-7]\d{6}
         </nationalNumberPattern>
       </generalDesc>
-      <!-- A 7-digit fixed-line plan was scheduled to be implemented on June 17, 2012 to unify fixed
+      <!-- Gabon has undergone renumbering in November 2019 where the prefix 01 is changed to 011;
+           and intial "0" is no more needed when dialled internationally. Thus they become 7 digit
+           to 8 digit excluding 0. -->
+      <!-- About numbers in older version, which may soon get invalid:
+           A 7-digit fixed-line plan was scheduled to be implemented on June 17, 2012 to unify fixed
            line and mobile numbering. However, this has only partially happened; mobile numbers can
            now be dialed without a leading zero, but fixed line numbers still require it. Their own
            website still lists fixed line numbers as "+241 01 44 68 11" and upon ringing they will
@@ -8522,26 +9478,32 @@
       <fixedLine>
         <possibleLengths national="8"/>
         <exampleNumber>01441234</exampleNumber>
-        <nationalNumberPattern>01\d{6}</nationalNumberPattern>
+        <nationalNumberPattern>[01]1\d{6}</nationalNumberPattern>
       </fixedLine>
-      <!-- Mobile numbers can be 7 or 8 digits (with or without a leading zero). -->
+      <!-- Gabon has undergon renumbering in November 2019 where the prefixes 0[256] are changed
+           to 6[256] respectively and similarly 0[47] changed to 7[47]. The intial "0" is no more
+           needed when dialled internationally. Thus they become 7 digit to 8 digit excluding 0. -->
+      <!-- About old numbers, which may soon get invalid: Mobile numbers can be 7 or 8 digits
+           (with or without a leading zero). -->
       <mobile>
         <possibleLengths national="7,8"/>
         <exampleNumber>06031234</exampleNumber>
         <nationalNumberPattern>
           (?:
             0[2-7]|
-            [2-7]
-          )\d{6}
+            6[256]|
+            7[47]
+          )\d{6}|
+          [2-7]\d{6}
         </nationalNumberPattern>
       </mobile>
     </territory>
 
-    <!-- United Kingdom -->
+    <!-- United Kingdom (GB) -->
+    <!-- Main region for 'GG,IM,JE' -->
     <!-- Note that this excludes Isle of Man, Jersey and Guernsey prefixes for the purposes of
          validation, although the formatting rules are shared. Also numbers are fine-grained where
          needed in order to disambiguate between the 4 regions. -->
-    <!-- Main region for 'GG,IM,JE' -->
     <!-- http://static.ofcom.org.uk/static/numbering/ -->
     <!-- http://stakeholders.ofcom.org.uk/telecoms/numbering/ -->
     <!-- http://en.wikipedia.org/wiki/List_of_United_Kingdom_dialling_codes -->
@@ -8549,14 +9511,6 @@
     <territory id="GB" mainCountryForCode="true" countryCode="44" internationalPrefix="00"
                nationalPrefix="0" preferredExtnPrefix=" x" mobileNumberPortableRegion="true">
       <availableFormats>
-        <!-- Special case: 845 46 47 (UK NHS Direct). -->
-        <numberFormat pattern="(\d{3})(\d{2})(\d{2})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>845</leadingDigits>
-          <leadingDigits>8454</leadingDigits>
-          <leadingDigits>84546</leadingDigits>
-          <leadingDigits>845464</leadingDigits>
-          <format>$1 $2 $3</format>
-        </numberFormat>
         <!-- Special case: 800 1111 (UK Child Line). -->
         <numberFormat pattern="(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>800</leadingDigits>
@@ -8566,91 +9520,17 @@
           <leadingDigits>8001111</leadingDigits>
           <format>$1 $2</format>
         </numberFormat>
+        <!-- Special case: 845 46 47 (UK NHS Direct). -->
+        <numberFormat pattern="(\d{3})(\d{2})(\d{2})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>845</leadingDigits>
+          <leadingDigits>8454</leadingDigits>
+          <leadingDigits>84546</leadingDigits>
+          <leadingDigits>845464</leadingDigits>
+          <format>$1 $2 $3</format>
+        </numberFormat>
         <!-- Shorter than normal toll-free numbers (9-digits). -->
         <numberFormat pattern="(\d{3})(\d{6})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>800</leadingDigits>
-          <format>$1 $2</format>
-        </numberFormat>
-        <!-- 4-digit area codes (9 or 10 digit numbers). -->
-        <numberFormat pattern="(\d{4})(\d{5,6})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>
-            1(?:
-              [2-79][02-9]|
-              8
-            )
-          </leadingDigits>
-          <leadingDigits>
-            1(?:
-              [24][02-9]|
-              3(?:
-                [02-79]|
-                8[0-46-9]
-              )|
-              5(?:
-                [04-9]|
-                2[024-9]|
-                3[014-689]
-              )|
-              6(?:
-                [02-8]|
-                9[0-24578]
-              )|
-              7(?:
-                [02-57-9]|
-                6[013-9]
-              )|
-              8|
-              9(?:
-                [0235-9]|
-                4[2-9]
-              )
-            )
-          </leadingDigits>
-          <leadingDigits>
-            1(?:
-              [24][02-9]|
-              3(?:
-                [02-79]|
-                8(?:
-                  [0-4689]|
-                  7[0-24-9]
-                )
-              )|
-              5(?:
-                [04-9]|
-                2(?:
-                  [025-9]|
-                  4[013-9]
-                )|
-                3(?:
-                  [014-68]|
-                  9[0-37-9]
-                )
-              )|
-              6(?:
-                [02-8]|
-                9(?:
-                  [0-2458]|
-                  7[0-25689]
-                )
-              )|
-              7(?:
-                [02-57-9]|
-                6(?:
-                  [013-79]|
-                  8[0-25689]
-                )
-              )|
-              8|
-              9(?:
-                [0235-9]|
-                4(?:
-                  [2-57-9]|
-                  6[0-689]
-                )
-              )
-            )
-          </leadingDigits>
           <format>$1 $2</format>
         </numberFormat>
         <!-- 5-digit area codes (9 or 10 digit numbers).
@@ -8664,8 +9544,46 @@
               38|
               5[23]|
               69|
-              7|
+              76|
               94
+            )
+          </leadingDigits>
+          <leadingDigits>
+            1(?:
+              (?:
+                38|
+                69
+              )7|
+              5(?:
+                24|
+                39
+              )|
+              768|
+              946
+            )
+          </leadingDigits>
+          <leadingDigits>
+            1(?:
+              3873|
+              5(?:
+                242|
+                39[4-6]
+              )|
+              (?:
+                697|
+                768
+              )[347]|
+              9467
+            )
+          </leadingDigits>
+          <format>$1 $2</format>
+        </numberFormat>
+        <!-- 4-digit area codes (9 or 10 digit numbers). -->
+        <numberFormat pattern="(\d{4})(\d{5,6})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>
+            1(?:
+              [2-69][02-9]|
+              [78]
             )
           </leadingDigits>
           <format>$1 $2</format>
@@ -8692,16 +9610,16 @@
           </leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
+        <!-- 7ddd (not 70, 76) with 10 digits. Includes 7624 for IM. -->
+        <numberFormat pattern="(\d{4})(\d{6})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>7</leadingDigits>
+          <format>$1 $2</format>
+        </numberFormat>
         <!-- 3-digit area codes and other 3-3-4 formats (fixed line, premium rate, toll free etc.)
              For geographic area codes: 11d, 1d1, 3dd, 9dd -->
         <numberFormat pattern="(\d{3})(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>[1389]</leadingDigits>
           <format>$1 $2 $3</format>
-        </numberFormat>
-        <!-- 7ddd (not 70, 76) with 10 digits. Includes 7624 for IM. -->
-        <numberFormat pattern="(\d{4})(\d{6})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>7</leadingDigits>
-          <format>$1 $2</format>
         </numberFormat>
       </availableFormats>
       <generalDesc>
@@ -8727,95 +9645,102 @@
         <nationalNumberPattern>
           (?:
             1(?:
-              1(?:
-                3[0-58]|
-                4[0-5]|
-                5[0-26-9]|
-                6[0-4]|
-                [78][0-49]
-              )|
+              (?:
+                1(?:
+                  3[0-58]|
+                  4[0-5]|
+                  5[0-26-9]|
+                  6[0-4]|
+                  [78][0-49]
+                )|
+                3(?:
+                  0\d|
+                  1[0-8]|
+                  [25][02-9]|
+                  3[02-579]|
+                  [468][0-46-9]|
+                  7[1-35-79]|
+                  9[2-578]
+                )|
+                4(?:
+                  0[03-9]|
+                  [137]\d|
+                  [28][02-57-9]|
+                  4[02-69]|
+                  5[0-8]|
+                  [69][0-79]
+                )|
+                5(?:
+                  0[1-35-9]|
+                  [16]\d|
+                  2[024-9]|
+                  3[015689]|
+                  4[02-9]|
+                  5[03-9]|
+                  7[0-35-9]|
+                  8[0-468]|
+                  9[0-57-9]
+                )|
+                6(?:
+                  0[034689]|
+                  1\d|
+                  2[0-35689]|
+                  [38][013-9]|
+                  4[1-467]|
+                  5[0-69]|
+                  6[13-9]|
+                  7[0-8]|
+                  9[0-24578]
+                )|
+                7(?:
+                  0[0246-9]|
+                  2\d|
+                  3[0236-8]|
+                  4[03-9]|
+                  5[0-46-9]|
+                  6[013-9]|
+                  7[0-35-9]|
+                  8[024-9]|
+                  9[02-9]
+                )|
+                8(?:
+                  0[35-9]|
+                  2[1-57-9]|
+                  3[02-578]|
+                  4[0-578]|
+                  5[124-9]|
+                  6[2-69]|
+                  7\d|
+                  8[02-9]|
+                  9[02569]
+                )|
+                9(?:
+                  0[02-589]|
+                  [18]\d|
+                  2[02-689]|
+                  3[1-57-9]|
+                  4[2-9]|
+                  5[0-579]|
+                  6[2-47-9]|
+                  7[0-24578]|
+                  9[2-57]
+                )
+              )\d\d|
               2(?:
-                0[024-9]|
-                1[0-7]|
-                2[3-9]|
-                3[3-79]|
-                4[1-689]|
-                [58][02-9]|
-                6[0-47-9]|
-                7[013-9]|
-                9\d
-              )|
-              3(?:
-                0\d|
-                1[0-8]|
-                [25][02-9]|
-                3[02-579]|
-                [468][0-46-9]|
-                7[1-35-79]|
-                9[2-578]
-              )|
-              4(?:
-                0[03-9]|
-                [137]\d|
-                [28][02-57-9]|
-                4[02-69]|
-                5[0-8]|
-                [69][0-79]
-              )|
-              5(?:
-                0[1-35-9]|
-                [16]\d|
-                2[024-9]|
-                3[015689]|
-                4[02-9]|
-                5[03-9]|
-                7[0-35-9]|
-                8[0-468]|
-                9[0-57-9]
-              )|
-              6(?:
-                0[034689]|
-                1\d|
-                2[0-35689]|
-                [38][013-9]|
-                4[1-467]|
-                5[0-69]|
-                6[13-9]|
-                7[0-8]|
-                9[0-24578]
-              )|
-              7(?:
-                0[0246-9]|
-                2\d|
-                3[0236-8]|
-                4[03-9]|
-                5[0-46-9]|
-                6[013-9]|
-                7[0-35-9]|
-                8[024-9]|
-                9[02-9]
-              )|
-              8(?:
-                0[35-9]|
-                2[1-57-9]|
-                3[02-578]|
-                4[0-578]|
-                5[124-9]|
-                6[2-69]|
-                7\d|
-                8[02-9]|
-                9[02569]
-              )|
-              9(?:
-                0[02-589]|
-                [18]\d|
-                2[02-689]|
-                3[1-57-9]|
-                4[2-9]|
-                5[0-579]|
-                6[2-47-9]|
-                7[0-24578]|
-                9[2-57]
+                (?:
+                  0[024-9]|
+                  2[3-9]|
+                  3[3-79]|
+                  4[1-689]|
+                  [58][02-9]|
+                  6[0-47-9]|
+                  7[013-9]|
+                  9\d
+                )\d\d|
+                1(?:
+                  [0-7]\d\d|
+                  80[04589]
+                )
               )
             )|
             2(?:
@@ -8824,144 +9749,142 @@
               4[017]|
               8[0-46-9]|
               9[0-2]
-            )\d
-          )\d{6}|
+            )\d{3}
+          )\d{4}|
           1(?:
-            (?:
-              2(?:
-                0(?:
-                  46[1-4]|
-                  87[2-9]
-                )|
-                545[1-79]|
-                76(?:
-                  2\d|
-                  3[1-8]|
-                  6[1-6]
-                )|
-                9(?:
-                  7(?:
-                    2[0-4]|
-                    3[2-5]
-                  )|
-                  8(?:
-                    2[2-8]|
-                    7[0-47-9]|
-                    8[3-5]
-                  )
-                )
+            2(?:
+              0(?:
+                46[1-4]|
+                87[2-9]
               )|
-              3(?:
-                6(?:
-                  38[2-5]|
-                  47[23]
-                )|
-                8(?:
-                  47[04-9]|
-                  64[0157-9]
-                )
-              )|
-              4(?:
-                044[1-7]|
-                20(?:
-                  2[23]|
-                  8\d
-                )|
-                6(?:
-                  0(?:
-                    30|
-                    5[2-57]|
-                    6[1-8]|
-                    7[2-8]
-                  )|
-                  140
-                )|
-                8(?:
-                  052|
-                  87[1-3]
-                )
-              )|
-              5(?:
-                2(?:
-                  4(?:
-                    3[2-79]|
-                    6\d
-                  )|
-                  76\d
-                )|
-                6(?:
-                  26[06-9]|
-                  686
-                )
-              )|
-              6(?:
-                06(?:
-                  4\d|
-                  7[4-79]
-                )|
-                295[5-7]|
-                35[34]\d|
-                47(?:
-                  24|
-                  61
-                )|
-                59(?:
-                  5[08]|
-                  6[67]|
-                  74
-                )|
-                9(?:
-                  55[0-4]|
-                  77[23]
-                )
-              )|
-              8(?:
-                27[56]\d|
-                37(?:
-                  5[2-5]|
-                  8[239]
-                )|
-                843[2-58]
+              545[1-79]|
+              76(?:
+                2\d|
+                3[1-8]|
+                6[1-6]
               )|
               9(?:
-                0(?:
-                  0(?:
-                    6[1-8]|
-                    85
-                  )|
-                  52\d
+                7(?:
+                  2[0-4]|
+                  3[2-5]
                 )|
-                3583|
-                4(?:
-                  66[1-8]|
-                  9(?:
-                    2[01]|
-                    81
-                  )
-                )|
-                63(?:
-                  23|
-                  3[1-4]
-                )|
-                9561
-              )
-            )\d|
-            7(?:
-              (?:
-                26(?:
-                  6[13-9]|
-                  7[0-7]
-                )|
-                442\d|
-                50(?:
-                  2[0-3]|
-                  [3-68]2|
-                  76
+                8(?:
+                  2[2-8]|
+                  7[0-47-9]|
+                  8[3-5]
                 )
+              )
+            )|
+            3(?:
+              6(?:
+                38[2-5]|
+                47[23]
+              )|
+              8(?:
+                47[04-9]|
+                64[0157-9]
+              )
+            )|
+            4(?:
+              044[1-7]|
+              20(?:
+                2[23]|
+                8\d
+              )|
+              6(?:
+                0(?:
+                  30|
+                  5[2-57]|
+                  6[1-8]|
+                  7[2-8]
+                )|
+                140
+              )|
+              8(?:
+                052|
+                87[1-3]
+              )
+            )|
+            5(?:
+              2(?:
+                4(?:
+                  3[2-79]|
+                  6\d
+                )|
+                76\d
+              )|
+              6(?:
+                26[06-9]|
+                686
+              )
+            )|
+            6(?:
+              06(?:
+                4\d|
+                7[4-79]
+              )|
+              295[5-7]|
+              35[34]\d|
+              47(?:
+                24|
+                61
+              )|
+              59(?:
+                5[08]|
+                6[67]|
+                74
+              )|
+              9(?:
+                55[0-4]|
+                77[23]
+              )
+            )|
+            7(?:
+              26(?:
+                6[13-9]|
+                7[0-7]
+              )|
+              (?:
+                442|
+                688
               )\d|
-              6888[2-46-8]
+              50(?:
+                2[0-3]|
+                [3-68]2|
+                76
+              )
+            )|
+            8(?:
+              27[56]\d|
+              37(?:
+                5[2-5]|
+                8[239]
+              )|
+              843[2-58]
+            )|
+            9(?:
+              0(?:
+                0(?:
+                  6[1-8]|
+                  85
+                )|
+                52\d
+              )|
+              3583|
+              4(?:
+                66[1-8]|
+                9(?:
+                  2[01]|
+                  81
+                )
+              )|
+              63(?:
+                23|
+                3[1-4]
+              )|
+              9561
             )
-          )\d\d
+          )\d{3}
         </nationalNumberPattern>
       </fixedLine>
       <!-- http://stakeholders.ofcom.org.uk/telecoms/numbering/telephone-no-availability/numbers-administered/
@@ -8971,47 +9894,37 @@
         <exampleNumber>7400123456</exampleNumber>
         <nationalNumberPattern>
           7(?:
-            (?:
-              [1-3]\d\d|
-              5(?:
-                0[0-8]|
-                [13-9]\d|
-                2[0-35-9]
-              )|
-              8(?:
-                [014-9]\d|
-                [23][0-8]
-              )
-            )\d|
+            457[0-57-9]|
+            700[01]|
+            911[028]
+          )\d{5}|
+          7(?:
+            [1-3]\d\d|
             4(?:
-              [0-46-9]\d\d|
-              5(?:
-                [0-689]\d|
-                7[0-57-9]
-              )
+              [0-46-9]\d|
+              5[0-689]
+            )|
+            5(?:
+              0[0-8]|
+              [13-9]\d|
+              2[0-35-9]
             )|
             7(?:
-              0(?:
-                0[01]|
-                [1-9]\d
-              )|
-              (?:
-                [1-7]\d|
-                8[02-9]|
-                9[0-689]
-              )\d
+              0[1-9]|
+              [1-7]\d|
+              8[02-9]|
+              9[0-689]
+            )|
+            8(?:
+              [014-9]\d|
+              [23][0-8]
             )|
             9(?:
-              (?:
-                [024-9]\d|
-                3[0-689]
-              )\d|
-              1(?:
-                [02-9]\d|
-                1[028]
-              )
+              [024-9]\d|
+              1[02-9]|
+              3[0-689]
             )
-          )\d{5}
+          )\d{6}
         </nationalNumberPattern>
       </mobile>
       <!-- 76 with 10 digits; excluding ranges used in IM. -->
@@ -9089,11 +10002,12 @@
       </uan>
     </territory>
 
-    <!-- Grenada -->
+    <!-- Grenada (GD) -->
     <!-- Calling code and formatting shared with 'US' -->
     <!-- http://www.itu.int/oth/T0202000057/en -->
     <territory id="GD" countryCode="1" leadingDigits="473" internationalPrefix="011"
-               nationalPrefix="1">
+               nationalPrefix="1" nationalPrefixForParsing="1|([2-9]\d{6})$"
+               nationalPrefixTransformRule="473$1">
       <generalDesc>
         <nationalNumberPattern>
           (?:
@@ -9191,7 +10105,7 @@
       </personalNumber>
     </territory>
 
-    <!-- Georgia -->
+    <!-- Georgia (GE) -->
     <!-- It seems there may be special 6 digit numbers beginning with 91, but we are not sure, so
          these are omitted for now. -->
     <!-- http://www.itu.int/oth/T0202000050/en -->
@@ -9199,22 +10113,24 @@
     <territory id="GE" countryCode="995" internationalPrefix="00" nationalPrefix="0"
                mobileNumberPortableRegion="true">
       <availableFormats>
-        <!-- Format isn't very strictly defined - the yellow pages omits area code and does 2 2 2,
+        <numberFormat pattern="(\d{3})(\d{3})(\d{3})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>70</leadingDigits>
+          <format>$1 $2 $3</format>
+        </numberFormat>
+        <!-- This format is for two digit area code fixed line range of Tblisi(32). -->
+        <numberFormat pattern="(\d{2})(\d{3})(\d{2})(\d{2})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>32</leadingDigits>
+          <format>$1 $2 $3 $4</format>
+        </numberFormat>
+        <numberFormat pattern="(\d{3})(\d{2})(\d{2})(\d{2})">
+          <leadingDigits>[57]</leadingDigits>
+          <format>$1 $2 $3 $4</format>
+        </numberFormat>
+        <!-- Format isn't very strictly defined - the yellow pages omits area code and does 2 2 2
              the communications commission uses 2 3 3. Wikipedia says 3 2 3. Some use 2 6. -->
         <numberFormat pattern="(\d{3})(\d{2})(\d{2})(\d{2})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>[348]</leadingDigits>
           <format>$1 $2 $3 $4</format>
-        </numberFormat>
-        <numberFormat pattern="(\d{3})(\d{2})(\d{2})(\d{2})">
-          <leadingDigits>
-            5|
-            79
-          </leadingDigits>
-          <format>$1 $2 $3 $4</format>
-        </numberFormat>
-        <numberFormat pattern="(\d{3})(\d{3})(\d{3})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>7</leadingDigits>
-          <format>$1 $2 $3</format>
         </numberFormat>
       </availableFormats>
       <generalDesc>
@@ -9231,7 +10147,7 @@
         <nationalNumberPattern>706\d{6}</nationalNumberPattern>
       </noInternationalDialling>
       <fixedLine>
-        <possibleLengths national="9" localOnly="6"/>
+        <possibleLengths national="9" localOnly="6,7"/>
         <exampleNumber>322123456</exampleNumber>
         <nationalNumberPattern>
           (?:
@@ -9257,6 +10173,30 @@
         <possibleLengths national="9"/>
         <exampleNumber>555123456</exampleNumber>
         <nationalNumberPattern>
+          5(?:
+            0555[5-9]|
+            757(?:
+              7[7-9]|
+              8[01]
+            )
+          )\d{3}|
+          5(?:
+            000\d|
+            (?:
+              52|
+              75
+            )00|
+            8(?:
+              58[89]|
+              888
+            )
+          )\d{4}|
+          5(?:
+            0050|
+            1111|
+            2222|
+            3333
+          )[0-4]\d{3}|
           (?:
             5(?:
               [14]4|
@@ -9284,7 +10224,7 @@
       </voip>
     </territory>
 
-    <!-- French Guiana (French Dept. of) -->
+    <!-- French Guiana (GF) -->
     <!-- Using a national prefix here as online numbers are formatted with it. -->
     <!-- The 876 prefix is mentioned in the plan, but the plan is from 2006 and in France VOIP
          numbers were changed from 087 to the 09 prefix in 2009. It is likely this occurred here
@@ -9297,12 +10237,17 @@
                mobileNumberPortableRegion="true">
       <availableFormats>
         <numberFormat pattern="(\d{3})(\d{2})(\d{2})(\d{2})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>[56]</leadingDigits>
+          <leadingDigits>[569]</leadingDigits>
           <format>$1 $2 $3 $4</format>
         </numberFormat>
       </availableFormats>
       <generalDesc>
-        <nationalNumberPattern>[56]94\d{6}</nationalNumberPattern>
+        <nationalNumberPattern>
+          (?:
+            [56]94|
+            976
+          )\d{6}
+        </nationalNumberPattern>
       </generalDesc>
       <fixedLine>
         <possibleLengths national="9"/>
@@ -9331,12 +10276,17 @@
           )\d{4}
         </nationalNumberPattern>
       </mobile>
+      <voip>
+        <possibleLengths national="9"/>
+        <exampleNumber>976012345</exampleNumber>
+        <nationalNumberPattern>976\d{6}</nationalNumberPattern>
+      </voip>
     </territory>
 
-    <!-- Guernsey -->
+    <!-- Guernsey (GG) -->
+    <!-- Calling code and formatting shared with 'GB' -->
     <!-- Note that the numbers are fine-grained where needed in order to disambiguate between the
          4 regions i.e UK, Isle of Man, Jersey and Guernsey. -->
-    <!-- Calling code and formatting shared with 'GB' -->
     <!-- http://static.ofcom.org.uk/static/numbering/ -->
     <!-- http://en.wikipedia.org/wiki/Telephone_numbers_in_the_United_Kingdom -->
     <territory id="GG" countryCode="44" internationalPrefix="00" nationalPrefix="0"
@@ -9437,7 +10387,7 @@
       </uan>
     </territory>
 
-    <!-- Ghana -->
+    <!-- Ghana (GH) -->
     <!-- No premiumRate information can be found. -->
     <!-- http://www.itu.int/oth/T0202000052/en -->
     <!-- http://www.nca.org.gh/index.php?option=com_content&view=article&id=90&Itemid=65 -->
@@ -9478,46 +10428,24 @@
         <exampleNumber>302345678</exampleNumber>
         <nationalNumberPattern>
           3(?:
-            0(?:
-              [237]\d|
-              80
-            )|
-            [167](?:
-              2[0-6]|
-              7\d|
-              80
-            )|
-            2(?:
-              2[0-5]|
-              7\d|
-              80
-            )|
-            3(?:
-              2[0-3]|
-              7\d|
-              80
-            )|
+            [167]2[0-6]|
+            22[0-5]|
+            32[0-3]|
             4(?:
               2[013-9]|
-              3[01]|
-              7\d|
-              80
+              3[01]
             )|
-            5(?:
-              2[0-7]|
-              7\d|
-              80
-            )|
-            8(?:
-              2[0-2]|
-              7\d|
-              80
-            )|
-            9(?:
-              [28]0|
-              7\d
-            )
-          )\d{5}
+            52[0-7]|
+            82[0-2]
+          )\d{5}|
+          3(?:
+            [0-8]8|
+            9[28]
+          )0\d{5}|
+          3(?:
+            0[237]|
+            [1-9]7
+          )\d{6}
         </nationalNumberPattern>
       </fixedLine>
       <mobile>
@@ -9528,7 +10456,8 @@
             2[0346-8]\d|
             5(?:
               [0457]\d|
-              6[01]
+              6[01]|
+              9[1-6]
             )
           )\d{6}
         </nationalNumberPattern>
@@ -9542,7 +10471,7 @@
       </tollFree>
     </territory>
 
-    <!-- Gibraltar -->
+    <!-- Gibraltar (GI) -->
     <!-- http://www.gra.gi/communications/numbering-plan -->
     <territory id="GI" countryCode="350" internationalPrefix="00" mobileNumberPortableRegion="true">
       <availableFormats>
@@ -9553,30 +10482,20 @@
         </numberFormat>
       </availableFormats>
       <generalDesc>
-        <nationalNumberPattern>
-          (?:
-            [25]\d\d|
-            629
-          )\d{5}
-        </nationalNumberPattern>
+        <nationalNumberPattern>[256]\d{7}</nationalNumberPattern>
       </generalDesc>
       <fixedLine>
         <possibleLengths national="8"/>
         <exampleNumber>20012345</exampleNumber>
         <nationalNumberPattern>
+          21(?:
+            6[24-7]\d|
+            90[0-2]
+          )\d{3}|
           2(?:
-            (?:
-              00\d|
-              2(?:
-                2[2457]|
-                50
-              )
-            )\d|
-            1(?:
-              6[24-7]\d|
-              90[0-2]
-            )
-          )\d{3}
+            00|
+            2[25]
+          )\d{5}
         </nationalNumberPattern>
       </fixedLine>
       <mobile>
@@ -9584,14 +10503,17 @@
         <exampleNumber>57123456</exampleNumber>
         <nationalNumberPattern>
           (?:
-            5[46-8]\d|
-            629
+            5[146-8]\d|
+            6(?:
+              06|
+              29
+            )
           )\d{5}
         </nationalNumberPattern>
       </mobile>
     </territory>
 
-    <!-- Greenland -->
+    <!-- Greenland (GL) -->
     <!-- http://www.itu.int/oth/T0202000056/en -->
     <territory id="GL" countryCode="299" internationalPrefix="00">
       <availableFormats>
@@ -9647,7 +10569,7 @@
       </voip>
     </territory>
 
-    <!-- Gambia -->
+    <!-- Gambia (GM) -->
     <!-- http://www.itu.int/oth/T020200004F/en -->
     <territory id="GM" countryCode="220" internationalPrefix="00">
       <availableFormats>
@@ -9688,11 +10610,16 @@
       <mobile>
         <possibleLengths national="7"/>
         <exampleNumber>3012345</exampleNumber>
-        <nationalNumberPattern>[23679]\d{6}</nationalNumberPattern>
+        <nationalNumberPattern>
+          (?:
+            [23679]\d|
+            5[0-3]
+          )\d{5}
+        </nationalNumberPattern>
       </mobile>
     </territory>
 
-    <!-- Guinea -->
+    <!-- Guinea (GN) -->
     <!-- http://www.itu.int/oth/T020200005B/en -->
     <territory id="GN" countryCode="224" internationalPrefix="00">
       <availableFormats>
@@ -9745,7 +10672,7 @@
       </voip>
     </territory>
 
-    <!-- Guadeloupe -->
+    <!-- Guadeloupe (GP) -->
     <!-- Main region for 'BL,MF' -->
     <!-- Linked from http://www.arcep.fr/index.php?id=interactivenumeros -->
     <!-- http://www.itu.int/oth/T0202000058/en -->
@@ -9760,7 +10687,7 @@
                nationalPrefix="0" mobileNumberPortableRegion="true">
       <availableFormats>
         <numberFormat pattern="(\d{3})(\d{2})(\d{2})(\d{2})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>[56]</leadingDigits>
+          <leadingDigits>[569]</leadingDigits>
           <format>$1 $2 $3 $4</format>
         </numberFormat>
       </availableFormats>
@@ -9768,7 +10695,8 @@
         <nationalNumberPattern>
           (?:
             590|
-            69\d
+            69\d|
+            976
           )\d{6}
         </nationalNumberPattern>
       </generalDesc>
@@ -9808,9 +10736,14 @@
           )\d{4}
         </nationalNumberPattern>
       </mobile>
+      <voip>
+        <possibleLengths national="9"/>
+        <exampleNumber>976012345</exampleNumber>
+        <nationalNumberPattern>976[01]\d{5}</nationalNumberPattern>
+      </voip>
     </territory>
 
-    <!-- Equatorial Guinea -->
+    <!-- Equatorial Guinea (GQ) -->
     <!-- http://www.itu.int/oth/T0202000041/en -->
     <territory id="GQ" countryCode="240" internationalPrefix="00">
       <availableFormats>
@@ -9825,27 +10758,23 @@
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
+          222\d{6}|
           (?:
-            222|
-            (?:
-              3\d|
-              55|
-              [89]0
-            )\d
-          )\d{6}
+            3\d|
+            55|
+            [89]0
+          )\d{7}
         </nationalNumberPattern>
       </generalDesc>
       <fixedLine>
         <possibleLengths national="9"/>
         <exampleNumber>333091234</exampleNumber>
         <nationalNumberPattern>
+          33[0-24-9]\d[46]\d{4}|
           3(?:
-            3(?:
-              [0-24-9]\d[46]|
-              3\d[7-9]
-            )|
-            5\d\d[7-9]
-          )\d{4}
+            33|
+            5\d
+          )\d[7-9]\d{4}
         </nationalNumberPattern>
       </fixedLine>
       <mobile>
@@ -9873,7 +10802,7 @@
       </premiumRate>
     </territory>
 
-    <!-- Greece -->
+    <!-- Greece (GR) -->
     <!-- http://www.itu.int/oth/T0202000055/en -->
     <!-- http://en.wikipedia.org/wiki/%2B30 -->
     <!-- http://www.eett.gr/opencms/opencms/EETT_EN/Electronic_Communications/Telecoms/Numbering/NumberAssignments.html -->
@@ -9886,23 +10815,32 @@
           </leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
-        <numberFormat pattern="(\d{3})(\d{3})(\d{4})">
-          <leadingDigits>
-            2[3-8]1|
-            [689]
-          </leadingDigits>
-          <format>$1 $2 $3</format>
-        </numberFormat>
         <numberFormat pattern="(\d{4})(\d{6})">
-          <leadingDigits>2</leadingDigits>
+          <leadingDigits>
+            2(?:
+              2|
+              3[2-57-9]|
+              4[2-469]|
+              5[2-59]|
+              6[2-9]|
+              7[2-69]|
+              8[2-49]
+            )|
+            5
+          </leadingDigits>
           <format>$1 $2</format>
+        </numberFormat>
+        <numberFormat pattern="(\d{3})(\d{3})(\d{4})">
+          <leadingDigits>[2689]</leadingDigits>
+          <format>$1 $2 $3</format>
         </numberFormat>
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
+          5005000\d{3}|
           (?:
-            [268]\d|
-            [79]0
+            [2689]\d|
+            70
           )\d{8}
         </nationalNumberPattern>
       </generalDesc>
@@ -9975,10 +10913,11 @@
         <possibleLengths national="10"/>
         <exampleNumber>6912345678</exampleNumber>
         <nationalNumberPattern>
-          6(?:
-            8[57-9]|
-            9\d
-          )\d{7}
+          68[57-9]\d{7}|
+          (?:
+            69|
+            94
+          )\d{8}
         </nationalNumberPattern>
       </mobile>
       <tollFree>
@@ -10009,9 +10948,14 @@
         <exampleNumber>7012345678</exampleNumber>
         <nationalNumberPattern>70\d{8}</nationalNumberPattern>
       </personalNumber>
+      <uan>
+        <possibleLengths national="10"/>
+        <exampleNumber>5005000123</exampleNumber>
+        <nationalNumberPattern>5005000\d{3}</nationalNumberPattern>
+      </uan>
     </territory>
 
-    <!-- Guatemala -->
+    <!-- Guatemala (GT) -->
     <!-- http://www.itu.int/oth/T020200005A/en -->
     <!-- http://www.sit.gob.gt/index.php?page=plan-de-numeracion -->
     <!-- http://en.wikipedia.org/wiki/Telephone_numbers_in_Guatemala -->
@@ -10056,11 +11000,12 @@
       </premiumRate>
     </territory>
 
-    <!-- Guam -->
+    <!-- Guam (GU) -->
     <!-- Calling code and formatting shared with 'US' -->
     <!-- http://www.nationalnanpa.com/nas/public/assigned_code_query_step1.do?method=resetCodeQueryModel -->
     <territory id="GU" countryCode="1" leadingDigits="671" internationalPrefix="011"
-               nationalPrefix="1">
+               nationalPrefix="1" nationalPrefixForParsing="1|([3-9]\d{6})$"
+               nationalPrefixTransformRule="671$1">
       <generalDesc>
         <nationalNumberPattern>
           (?:
@@ -10211,7 +11156,7 @@
       </personalNumber>
     </territory>
 
-    <!-- Guinea-Bissau -->
+    <!-- Guinea-Bissau (GW) -->
     <!-- http://www.itu.int/oth/T020200005C/en -->
     <territory id="GW" countryCode="245" internationalPrefix="00">
       <availableFormats>
@@ -10253,7 +11198,7 @@
       </voip>
     </territory>
 
-    <!-- Guyana -->
+    <!-- Guyana (GY) -->
     <!-- http://www.itu.int/oth/T020200005D/en -->
     <territory id="GY" countryCode="592" internationalPrefix="001">
       <availableFormats>
@@ -10265,15 +11210,13 @@
       <generalDesc>
         <nationalNumberPattern>
           (?:
-            (?:
-              (?:
-                [2-46]\d|
-                77
-              )\d|
-              862
-            )\d|
+            862\d|
             9008
-          )\d{3}
+          )\d{3}|
+          (?:
+            [2-46]\d|
+            77
+          )\d{5}
         </nationalNumberPattern>
       </generalDesc>
       <fixedLine>
@@ -10326,7 +11269,7 @@
       </premiumRate>
     </territory>
 
-    <!-- Hong Kong -->
+    <!-- Hong Kong (HK) -->
     <!-- http://www.ofca.gov.hk/en/industry_focus/telecommunications/portability/index.html -->
     <territory id="HK" countryCode="852" preferredInternationalPrefix="00"
                internationalPrefix="00(?:30|5[09]|[126-9]?)" mobileNumberPortableRegion="true">
@@ -10377,27 +11320,25 @@
         <exampleNumber>21234567</exampleNumber>
         <nationalNumberPattern>
           (?:
-            2(?:
-              [13-8]\d|
-              2[013-9]|
-              9[0-24-9]
-            )\d|
-            3(?:
-              (?:
-                [1569][0-24-9]|
-                4[0-246-9]|
-                7[0-24-69]
-              )\d|
-              8(?:
-                4[04]|
-                9\d
-              )
-            )|
+            384[0-24]|
             58(?:
               0[1-8]|
               1[2-9]
             )
-          )\d{4}
+          )\d{4}|
+          (?:
+            2(?:
+              [13-8]\d|
+              2[013-9]|
+              9[0-24-9]
+            )|
+            3(?:
+              [1569][0-24-9]|
+              4[0-246-9]|
+              7[0-24-69]|
+              89
+            )
+          )\d{5}
         </nationalNumberPattern>
       </fixedLine>
       <!-- Prefixes assigned to 'CMMobile Global Communications Ltd' are on hold as per Ofcom
@@ -10410,46 +11351,36 @@
           (?:
             46(?:
               0[0-6]|
-              10|
+              1[0-2]|
               4[0-57-9]
             )|
+            5730|
+            (?:
+              626|
+              848
+            )[01]|
+            707[1-5]|
+            929[03-9]
+          )\d{4}|
+          (?:
             5(?:
-              (?:
-                [1-59][0-46-9]|
-                6[0-4689]
-              )\d|
-              7(?:
-                [0-2469]\d|
-                30
-              )
+              [1-59][0-46-9]|
+              6[0-4689]|
+              7[0-2469]
             )|
             6(?:
-              (?:
-                0[1-9]|
-                [13-59]\d|
-                [68][0-57-9]|
-                7[0-79]
-              )\d|
-              2(?:
-                [0-57-9]\d|
-                6[01]
-              )
+              0[1-9]|
+              [13-59]\d|
+              [268][0-57-9]|
+              7[0-79]
             )|
-            707[1-5]|
-            8480|
             9(?:
-              (?:
-                0[1-9]|
-                1[02-9]|
-                [358][0-8]|
-                [467]\d
-              )\d|
-              2(?:
-                [0-8]\d|
-                9[03-9]
-              )
+              0[1-9]|
+              1[02-9]|
+              [2358][0-8]|
+              [467]\d
             )
-          )\d{4}
+          )\d{5}
         </nationalNumberPattern>
       </mobile>
       <pager>
@@ -10551,7 +11482,7 @@
       </uan>
     </territory>
 
-    <!-- Honduras -->
+    <!-- Honduras (HN) -->
     <!-- It seems there is no longer a trunk prefix in use, based on websites like
          http://www.howtocallabroad.com/codes.html and on seeing how locals write their numbers in
          national format. -->
@@ -10562,12 +11493,25 @@
           <leadingDigits>[237-9]</leadingDigits>
           <format>$1-$2</format>
         </numberFormat>
+        <numberFormat pattern="(\d{3})(\d{4})(\d{4})">
+          <leadingDigits>8</leadingDigits>
+          <format>$1 $2 $3</format>
+          <intlFormat>NA</intlFormat>
+        </numberFormat>
       </availableFormats>
       <generalDesc>
-        <nationalNumberPattern>[237-9]\d{7}</nationalNumberPattern>
+        <nationalNumberPattern>
+          8\d{10}|
+          [237-9]\d{7}
+        </nationalNumberPattern>
       </generalDesc>
-      <!-- Extra prefixes 2244, 2264, 227[0135689], 228X, 2292, 2407, 2508, 2516, 2540, 2564, 2580,
-           260X, 2617, 263[04] and 2780 were added from numbers found online and user reports. -->
+      <noInternationalDialling>
+        <possibleLengths national="11"/>
+        <nationalNumberPattern>8002\d{7}</nationalNumberPattern>
+      </noInternationalDialling>
+      <!-- Extra prefixes 2244, 226[24], 227[0135689], 228X, 2292, 2407, 250[78], 2516, 2540,
+           256[014], 2580, 260X, 2617, 262[07], 263[04], 2780 and 2791 were added from numbers
+           found online and user reports. -->
       <fixedLine>
         <possibleLengths national="8"/>
         <exampleNumber>22123456</exampleNumber>
@@ -10579,7 +11523,7 @@
               [23]\d|
               4[04-6]|
               5[57]|
-              64|
+              6[24]|
               7[0135689]|
               8[01346-9]|
               9[0-2]
@@ -10592,17 +11536,18 @@
               5[1-35]
             )|
             5(?:
-              08|
+              0[78]|
               16|
               4[03-5]|
               5\d|
-              6[4-6]|
+              6[014-6]|
               74|
               80
             )|
             6(?:
               [056]\d|
               17|
+              2[07]|
               3[04]|
               4[0-378]|
               [78][0-8]|
@@ -10611,7 +11556,8 @@
             7(?:
               6[46-9]|
               7[02-9]|
-              8[034]
+              8[034]|
+              91
             )|
             8(?:
               79|
@@ -10626,9 +11572,14 @@
         <exampleNumber>91234567</exampleNumber>
         <nationalNumberPattern>[37-9]\d{7}</nationalNumberPattern>
       </mobile>
+      <tollFree>
+        <possibleLengths national="11"/>
+        <exampleNumber>80021234567</exampleNumber>
+        <nationalNumberPattern>8002\d{7}</nationalNumberPattern>
+      </tollFree>
     </territory>
 
-    <!-- Croatia -->
+    <!-- Croatia (HR) -->
     <!-- http://www.itu.int/oth/T0202000032/en -->
     <!-- http://en.wikipedia.org/wiki/%2B385 -->
     <territory id="HR" countryCode="385" internationalPrefix="00" nationalPrefix="0"
@@ -10650,10 +11601,6 @@
           <leadingDigits>1</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
-        <numberFormat pattern="(\d{2})(\d{3})(\d{3,4})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>[2-5]</leadingDigits>
-          <format>$1 $2 $3</format>
-        </numberFormat>
         <!-- For 8 and 9 digit numbers of premium, personal and UAN numbers. -->
         <numberFormat pattern="(\d{2})(\d{3})(\d{3,4})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>[67]</leadingDigits>
@@ -10662,6 +11609,10 @@
         <!-- For 8 and 9 digit numbers of mobile. -->
         <numberFormat pattern="(\d{2})(\d{3})(\d{3,4})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>9</leadingDigits>
+          <format>$1 $2 $3</format>
+        </numberFormat>
+        <numberFormat pattern="(\d{2})(\d{3})(\d{3,4})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>[2-5]</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
         <numberFormat pattern="(\d{3})(\d{3})(\d{3})" nationalPrefixFormattingRule="$NP$FG">
@@ -10698,16 +11649,14 @@
         <exampleNumber>921234567</exampleNumber>
         <nationalNumberPattern>
           9(?:
-            (?:
-              01|
-              [12589]\d
-            )\d|
-            7(?:
-              [0679]\d|
-              51
-            )
-          )\d{5}|
-          98\d{6}
+            751\d{5}|
+            8\d{6,7}
+          )|
+          9(?:
+            0[1-9]|
+            [1259]\d|
+            7[0679]
+          )\d{6}
         </nationalNumberPattern>
       </mobile>
       <tollFree>
@@ -10734,15 +11683,13 @@
         <possibleLengths national="8,9"/>
         <exampleNumber>62123456</exampleNumber>
         <nationalNumberPattern>
-          (?:
-            62\d?|
-            72
-          )\d{6}
+          62\d{6,7}|
+          72\d{6}
         </nationalNumberPattern>
       </uan>
     </territory>
 
-    <!-- Haiti -->
+    <!-- Haiti (HT) -->
     <!-- http://www.itu.int/oth/T020200005E/en -->
     <!-- http://www.numberingplans.com/ -->
     <territory id="HT" countryCode="509" internationalPrefix="00">
@@ -10799,20 +11746,31 @@
       </voip>
     </territory>
 
-    <!-- Hungary -->
+    <!-- Hungary (HU) -->
     <!-- http://www.itu.int/oth/T0202000061/en -->
-    <!-- Although the national prefix is necessary for dialling, the preferred format (confirmed
-         by a Hungarian person and following the yellow pages) is to omit this when formatting.
-         Yellow pages: http://www.aranyoldalak.hu -->
+    <!-- As per Wikipedia https://en.wikipedia.org/wiki/Telephone_numbers_in_Hungary format
+         for both fixed line and mobile number should be preceded with national prefix "06". -->
     <territory id="HU" countryCode="36" internationalPrefix="00" nationalPrefix="06"
                mobileNumberPortableRegion="true">
       <availableFormats>
-        <numberFormat pattern="(\d)(\d{3})(\d{4})" nationalPrefixFormattingRule="($FG)">
+        <numberFormat pattern="(\d)(\d{3})(\d{4})" nationalPrefixFormattingRule="($NP $FG)">
           <leadingDigits>1</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
-        <numberFormat pattern="(\d{2})(\d{3})(\d{3,4})" nationalPrefixFormattingRule="($FG)">
-          <leadingDigits>[2-9]</leadingDigits>
+        <numberFormat pattern="(\d{2})(\d{3})(\d{3})" nationalPrefixFormattingRule="($NP $FG)">
+          <leadingDigits>
+            [27][2-9]|
+            3[2-7]|
+            4[24-9]|
+            5[2-79]|
+            6|
+            8[2-57-9]|
+            9[2-69]
+          </leadingDigits>
+          <format>$1 $2 $3</format>
+        </numberFormat>
+        <numberFormat pattern="(\d{2})(\d{3})(\d{3,4})" nationalPrefixFormattingRule="$NP $FG">
+          <leadingDigits>[2-57-9]</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
       </availableFormats>
@@ -10877,12 +11835,11 @@
       </uan>
     </territory>
 
-    <!-- Indonesia -->
+    <!-- Indonesia (ID) -->
     <!-- From 2001, very out of date. -->
     <!-- http://www.itu.int/oth/T0202000064/en -->
     <!-- http://en.wikipedia.org/wiki/%2B62 -->
-    <territory id="ID" countryCode="62" internationalPrefix="0(?:0[17-9]|10(?:00|1[67]))"
-               nationalPrefix="0">
+    <territory id="ID" countryCode="62" internationalPrefix="00[189]" nationalPrefix="0">
       <availableFormats>
         <!-- Short UAN numbers -->
         <numberFormat pattern="(\d)(\d{3})(\d{3})">
@@ -10933,20 +11890,36 @@
           <leadingDigits>8</leadingDigits>
           <format>$1-$2-$3</format>
         </numberFormat>
+        <!-- Format for 13 digit ITFS numbers. -->
+        <numberFormat pattern="(\d{2})(\d{4})(\d{3})(\d{4})">
+          <leadingDigits>0</leadingDigits>
+          <format>$1 $2 $3 $4</format>
+          <intlFormat>NA</intlFormat>
+        </numberFormat>
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
           (?:
-            [1-36]|
-            8\d{5}
+            (?:
+              007803|
+              8\d{4}
+            )\d|
+            [1-36]
           )\d{6}|
           [1-9]\d{8,10}|
           [2-9]\d{7}
         </nationalNumberPattern>
       </generalDesc>
+      <!-- 00798 ITFS numbers can't be dialled internationally. Source:
+           https://support.twilio.com/hc/en-us/articles/115007579027-Toll-free-phone-number-restrictions-and-limitations -->
       <noInternationalDialling>
-        <possibleLengths national="10"/>
-        <nationalNumberPattern>8071\d{6}</nationalNumberPattern>
+        <possibleLengths national="10,13"/>
+        <nationalNumberPattern>
+          (?:
+            007803\d|
+            8071
+          )\d{6}
+        </nationalNumberPattern>
       </noInternationalDialling>
       <!-- Area codes taken from wikipedia, with missing ones added from
            http://www.telkom.co.id/customer-services/area-and-country-code/?type=area.
@@ -10957,21 +11930,30 @@
            http://cms.binus.edu/datapage/file/io/Spring2014SE/International_Student_Handbook_BINUS.pdf
            There seem to be numbers of this length for area code 22 as well based on numbers found
            online. -->
+      <!-- The ITU doc is outdated (2001), and many numbers of different lengths were supported
+           here based on valid numbers found and user report. -->
       <fixedLine>
         <possibleLengths national="[7-11]" localOnly="5,6"/>
         <exampleNumber>218350123</exampleNumber>
         <nationalNumberPattern>
+          2[124]\d{7,8}|
+          619\d{8}|
           2(?:
-            [124]\d{7,8}|
-            (?:
+            1(?:
+              14|
+              500
+            )|
+            2\d{3}
+          )\d{3}|
+          61\d{5,8}|
+          (?:
+            2(?:
               [35][1-4]|
               6[0-8]|
               7[1-6]|
               8\d|
               9[1-8]
-            )\d{5,8}
-          )|
-          (?:
+            )|
             3(?:
               1|
               [25][1-8]|
@@ -11000,6 +11982,11 @@
               5[1-46]|
               6[1-8]
             )|
+            6(?:
+              [25]\d|
+              3[1-69]|
+              4[1-6]
+            )|
             7(?:
               02|
               [125][1-9]|
@@ -11016,25 +12003,7 @@
               7[159]|
               8[01346]
             )
-          )\d{5,8}|
-          6(?:
-            1(?:
-              [0-8]\d{4,7}|
-              9\d{4,8}
-            )|
-            (?:
-              [25]\d|
-              3[1-69]|
-              4[1-6]
-            )\d{5,8}
-          )|
-          2(?:
-            1(?:
-              14|
-              500
-            )|
-            2\d{3}
-          )\d{3}
+          )\d{5,8}
         </nationalNumberPattern>
       </fixedLine>
       <mobile>
@@ -11043,9 +12012,10 @@
         <nationalNumberPattern>8[1-35-9]\d{7,10}</nationalNumberPattern>
       </mobile>
       <tollFree>
-        <possibleLengths national="[8-11]"/>
+        <possibleLengths national="[8-11],13"/>
         <exampleNumber>8001234567</exampleNumber>
         <nationalNumberPattern>
+          007803\d{7}|
           (?:
             177\d|
             800
@@ -11075,7 +12045,7 @@
       </uan>
     </territory>
 
-    <!-- Ireland -->
+    <!-- Ireland (IE) -->
     <!-- http://www.comreg.ie/licensing_and_services/numbering_plan_for_ireland.552.440.html -->
     <!-- http://www.comreg.ie/_fileupload/publications/ComReg1119.pdf -->
     <territory id="IE" countryCode="353" internationalPrefix="00" nationalPrefix="0"
@@ -11107,27 +12077,24 @@
           </leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
-        <numberFormat pattern="(\d{2})(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>
-            76|
-            8[235-9]
-          </leadingDigits>
-          <format>$1 $2 $3</format>
-        </numberFormat>
         <numberFormat pattern="(\d{3})(\d{3})(\d{3})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>7</leadingDigits>
+          <leadingDigits>70</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
         <numberFormat pattern="(\d{3})(\d{3})(\d{3})" nationalPrefixFormattingRule="($NP$FG)">
           <leadingDigits>81</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
-        <numberFormat pattern="(\d{2})(\d{4})(\d{4})" nationalPrefixFormattingRule="($NP$FG)">
-          <leadingDigits>4</leadingDigits>
+        <numberFormat pattern="(\d{2})(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>[78]</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
         <numberFormat pattern="(\d{4})(\d{3})(\d{3})">
           <leadingDigits>1</leadingDigits>
+          <format>$1 $2 $3</format>
+        </numberFormat>
+        <numberFormat pattern="(\d{2})(\d{4})(\d{4})" nationalPrefixFormattingRule="($NP$FG)">
+          <leadingDigits>4</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
         <!-- Voicemail numbers: same as mobile prefixes but the third digit is always 5. Formatting
@@ -11140,10 +12107,13 @@
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
-          [148]\d{9}|
-          [124-9]\d{8}|
-          [124-69]\d{7}|
-          [24-69]\d{6}
+          (?:
+            1\d|
+            [2569]
+          )\d{6,8}|
+          4\d{6,9}|
+          7\d{8}|
+          8\d{8,9}
         </nationalNumberPattern>
       </generalDesc>
       <noInternationalDialling>
@@ -11160,41 +12130,41 @@
         <exampleNumber>2212345</exampleNumber>
         <nationalNumberPattern>
           (?:
-            1\d{2,3}|
-            2(?:
-              [13]\d\d|
-              [24-9]
-            )|
+            1\d|
+            21
+          )\d{6,7}|
+          (?:
+            2[24-9]|
             4(?:
               0[24]|
-              (?:
-                (?:
-                  [1-469]|
-                  8[0-46-9]
-                )\d|
-                5
-              )\d|
+              5\d|
               7
             )|
             5(?:
               0[45]|
-              (?:
-                1|
-                [23679]\d
-              )\d|
+              1\d|
               8
             )|
             6(?:
-              [237-9]|
-              [4-6]\d\d
+              1\d|
+              [237-9]
             )|
-            7[14]\d\d|
             9(?:
-              [04]\d\d|
+              1\d|
               [35-9]
             )
           )\d{5}|
-          [269]1\d{6}
+          (?:
+            23|
+            4(?:
+              [1-469]|
+              8\d
+            )|
+            5[23679]|
+            6[4-6]|
+            7[14]|
+            9[04]
+          )\d{7}
         </nationalNumberPattern>
       </fixedLine>
       <mobile>
@@ -11248,11 +12218,23 @@
       <voicemail>
         <possibleLengths national="10"/>
         <exampleNumber>8551234567</exampleNumber>
-        <nationalNumberPattern>8[35-9]5\d{7}</nationalNumberPattern>
+        <nationalNumberPattern>
+          88210[1-9]\d{4}|
+          8(?:
+            [35-79]5\d\d|
+            8(?:
+              [013-9]\d\d|
+              2(?:
+                [01][1-9]|
+                [2-9]\d
+              )
+            )
+          )\d{5}
+        </nationalNumberPattern>
       </voicemail>
     </territory>
 
-    <!-- Israel -->
+    <!-- Israel (IL) -->
     <!-- Formatting practice following wikipedia, and government sites. -->
     <!-- in Hebrew -->
     <!-- http://www.itu.int/oth/T020200006A/en -->
@@ -11266,14 +12248,14 @@
           <leadingDigits>125</leadingDigits>
           <format>$1-$2</format>
         </numberFormat>
-        <!-- Fixed line. -->
-        <numberFormat pattern="(\d)(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>[2-489]</leadingDigits>
-          <format>$1-$2-$3</format>
-        </numberFormat>
         <!-- 8-digit premium rate. -->
         <numberFormat pattern="(\d{4})(\d{2})(\d{2})">
           <leadingDigits>121</leadingDigits>
+          <format>$1-$2-$3</format>
+        </numberFormat>
+        <!-- Fixed line. -->
+        <numberFormat pattern="(\d)(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>[2-489]</leadingDigits>
           <format>$1-$2-$3</format>
         </numberFormat>
         <!-- Mobile and VOIP. -->
@@ -11301,7 +12283,7 @@
              (maybe a phone number) which is why they are formatted as two separate numbers.
              Note that 153 prefix might be an M2M number (it's listed as a "fax box" service). -->
         <numberFormat pattern="(\d{3})(\d{1,2})(\d{3})(\d{4})">
-          <leadingDigits>1</leadingDigits>
+          <leadingDigits>15</leadingDigits>
           <format>$1-$2 $3-$4</format>
         </numberFormat>
       </availableFormats>
@@ -11326,28 +12308,28 @@
         <possibleLengths national="8,11,12" localOnly="7"/>
         <exampleNumber>21234567</exampleNumber>
         <nationalNumberPattern>
-          (?:
-            153\d\d?|
-            [2-489]
-          )\d{7}
+          153\d{8,9}|
+          [2-489]\d{7}
         </nationalNumberPattern>
       </fixedLine>
       <!-- The ITU document has only some of these prefixes - wikipedia lists more. We are fairly
            sure wikipedia is accurate based on news coverage of the launch of these numbers. Also
            added 5570, 5571, and 5594 prefixes based on confirmations from the carriers. 559[23]
-           ranges belong to Telzar carrier as per confirmation from them. -->
+           ranges belong to Telzar carrier as per confirmation from them. Prefix 5527 is added
+           based on user report. -->
       <mobile>
         <possibleLengths national="9"/>
         <exampleNumber>502345678</exampleNumber>
         <nationalNumberPattern>
           5(?:
             (?:
-              [0-489][2-9]|
+              [0-389][2-9]|
+              4[1-9]|
               6\d
             )\d|
             5(?:
               01|
-              2[2-5]|
+              2[2-7]|
               3[23]|
               4[45]|
               5[05689]|
@@ -11378,16 +12360,14 @@
         <possibleLengths national="8,10"/>
         <exampleNumber>1919123456</exampleNumber>
         <nationalNumberPattern>
+          1212\d{4}|
           1(?:
-            2(?:
-              00\d\d|
-              12
-            )|
+            200|
             9(?:
               0[01]|
               19
-            )\d\d
-          )\d{4}
+            )
+          )\d{6}
         </nationalNumberPattern>
       </premiumRate>
       <sharedCost>
@@ -11402,24 +12382,22 @@
         <possibleLengths national="9"/>
         <exampleNumber>771234567</exampleNumber>
         <nationalNumberPattern>
+          78(?:
+            33|
+            55|
+            77|
+            81
+          )\d{5}|
           7(?:
-            (?:
-              18|
-              2[23]|
-              3[237]|
-              47|
-              6[58]|
-              7\d|
-              9[2357-9]
-            )\d|
-            8(?:
-              2\d|
-              33|
-              55|
-              77|
-              81
-            )
-          )\d{5}
+            18|
+            2[23]|
+            3[237]|
+            47|
+            6[58]|
+            7\d|
+            82|
+            9[235-9]
+          )\d{6}
         </nationalNumberPattern>
       </voip>
       <!-- 1-599 numbers are actually labelled "interactive voicemail" in the ITU document, but
@@ -11438,23 +12416,22 @@
       </voicemail>
     </territory>
 
-    <!-- Isle of Man -->
+    <!-- Isle of Man (IM) -->
+    <!-- Calling code and formatting shared with 'GB' -->
     <!-- Note that the numbers are fine-grained where needed in order to disambiguate between the
          4 regions i.e UK, Isle of Man, Jersey and Guernsey. -->
-    <!-- Calling code and formatting shared with 'GB' -->
     <!-- http://static.ofcom.org.uk/static/numbering/ -->
     <!-- http://en.wikipedia.org/wiki/Telephone_numbers_in_the_United_Kingdom -->
-    <territory id="IM" countryCode="44" internationalPrefix="00" nationalPrefix="0"
+    <territory id="IM" countryCode="44" leadingDigits="74576|(?:16|7[56])24"
+               internationalPrefix="00" nationalPrefix="0"
                nationalPrefixForParsing="0|([5-8]\d{5})$" nationalPrefixTransformRule="1624$1">
       <generalDesc>
         <nationalNumberPattern>
+          1624\d{6}|
           (?:
-            1624|
-            (?:
-              [3578]\d|
-              90
-            )\d\d
-          )\d{6}
+            [3578]\d|
+            90
+          )\d{8}
         </nationalNumberPattern>
       </generalDesc>
       <!-- Specific to IM. -->
@@ -11470,6 +12447,7 @@
         <possibleLengths national="10"/>
         <exampleNumber>7924123456</exampleNumber>
         <nationalNumberPattern>
+          76245[06]\d{4}|
           7(?:
             4576|
             [59]24\d|
@@ -11489,19 +12467,17 @@
         <possibleLengths national="10"/>
         <exampleNumber>9016247890</exampleNumber>
         <nationalNumberPattern>
+          8(?:
+            440[49]06|
+            72299\d
+          )\d{3}|
           (?:
             8(?:
-              4(?:
-                40[49]06|
-                5624\d
-              )|
-              7(?:
-                0624|
-                2299
-              )\d
+              45|
+              70
             )|
-            90[0167]624\d
-          )\d{3}
+            90[0167]
+          )624\d{4}
         </nationalNumberPattern>
       </premiumRate>
       <!-- Other numbers as per GB. -->
@@ -11520,50 +12496,97 @@
         <possibleLengths national="10"/>
         <exampleNumber>5512345678</exampleNumber>
         <nationalNumberPattern>
+          3440[49]06\d{3}|
           (?:
             3(?:
-              (?:
-                08162|
-                3\d{4}|
-                7(?:
-                  0624|
-                  2299
-                )
-              )\d|
-              4(?:
-                40[49]06|
-                5624\d
+              08162|
+              3\d{4}|
+              45624|
+              7(?:
+                0624|
+                2299
               )
             )|
-            55\d{5}
-          )\d{3}
+            55\d{4}
+          )\d{4}
         </nationalNumberPattern>
       </uan>
     </territory>
 
-    <!-- India -->
+    <!-- India (IN) -->
     <!-- http://www.itu.int/oth/T0202000063/en -->
     <!-- http://en.wikipedia.org/wiki/%2B91 -->
     <!-- http://www.bsnl.co.in -->
     <!-- http://dq.ndc.bsnl.co.in/bsnl-web/stdSearch.seam -->
     <!-- http://www.dot.gov.in/access-services/allotment-msc-codes -->
     <territory id="IN" countryCode="91" internationalPrefix="00" nationalPrefix="0"
-               nationalPrefixOptionalWhenFormatting="true" mobileNumberPortableRegion="true">
+               mobileNumberPortableRegion="true">
       <availableFormats>
-        <!-- 8-digit short numbers. Leading digits are more granular to ensure that fixed-line
-             numbers, which should not be formatted this way, fall to the correct formatting rule. -->
-        <numberFormat pattern="(\d{8})">
-          <leadingDigits>5[0236-8]</leadingDigits>
+        <!-- 7-digit "short" numbers. -->
+        <numberFormat pattern="(\d{7})">
+          <leadingDigits>575</leadingDigits>
+          <format>$1</format>
+          <intlFormat>NA</intlFormat>
+        </numberFormat>
+        <!-- 8-digit "short" numbers (optionally diallable with a national prefix). -->
+        <numberFormat pattern="(\d{8})" nationalPrefixOptionalWhenFormatting="true">
+          <leadingDigits>
+            5(?:
+              0|
+              2[23]|
+              3[03]|
+              [67]1|
+              88
+            )
+          </leadingDigits>
+          <leadingDigits>
+            5(?:
+              0|
+              2(?:
+                21|
+                3
+              )|
+              3(?:
+                0|
+                3[23]
+              )|
+              616|
+              717|
+              888
+            )
+          </leadingDigits>
+          <leadingDigits>
+            5(?:
+              0|
+              2(?:
+                21|
+                3
+              )|
+              3(?:
+                0|
+                3[23]
+              )|
+              616|
+              717|
+              8888
+            )
+          </leadingDigits>
           <format>$1</format>
         </numberFormat>
         <!-- 8,9-digit toll free numbers -->
-        <numberFormat pattern="(\d{4})(\d{4,5})">
+        <numberFormat pattern="(\d{4})(\d{4,5})" nationalPrefixOptionalWhenFormatting="true">
           <leadingDigits>180</leadingDigits>
           <leadingDigits>1800</leadingDigits>
           <format>$1 $2</format>
         </numberFormat>
+        <!-- 10 digit UAN numbers -->
+        <numberFormat pattern="(\d{3})(\d{3})(\d{4})" nationalPrefixOptionalWhenFormatting="true">
+          <leadingDigits>140</leadingDigits>
+          <format>$1 $2 $3</format>
+        </numberFormat>
         <!-- 2-digit area codes. -->
-        <numberFormat pattern="(\d{2})(\d{4})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
+        <numberFormat pattern="(\d{2})(\d{4})(\d{4})" nationalPrefixFormattingRule="$NP$FG"
+                      nationalPrefixOptionalWhenFormatting="true">
           <leadingDigits>
             11|
             2[02]|
@@ -11610,13 +12633,13 @@
           <format>$1 $2 $3</format>
         </numberFormat>
         <!-- 3-digit area codes. -->
-        <numberFormat pattern="(\d{3})(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
+        <numberFormat pattern="(\d{3})(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG"
+                      nationalPrefixOptionalWhenFormatting="true">
           <leadingDigits>
             1(?:
               2[0-249]|
               3[0-25]|
               4[145]|
-              [59][14]|
               [68]|
               7[1257]
             )|
@@ -11627,8 +12650,7 @@
               5[0137]|
               6[0158]|
               78|
-              8[1568]|
-              9[14]
+              8[1568]
             )|
             3(?:
               26|
@@ -11641,7 +12663,6 @@
             4(?:
               1[36]|
               2[1-47]|
-              3[15]|
               5[12]|
               6[0-26-9]|
               7[0-24-9]|
@@ -11654,23 +12675,19 @@
               [36][25]|
               4[28]|
               5[12]|
-              [78]1|
-              9[15]
+              [78]1
             )|
             6(?:
               12|
               [2-4]1|
               5[17]|
               6[13]|
-              7[14]|
               80
             )|
             7(?:
               12|
-              2[14]|
               3[134]|
               4[47]|
-              5[15]|
               61|
               88
             )|
@@ -11682,30 +12699,35 @@
               7[078]|
               8[34]|
               91
-            )
+            )|
+            (?:
+              43|
+              59|
+              75
+            )[15]|
+            (?:
+              1[59]|
+              29|
+              67|
+              72
+            )[14]
           </leadingDigits>
           <leadingDigits>
             1(?:
-              2[0-249]|
+              2[0-24]|
               3[0-25]|
               4[145]|
               [59][14]|
-              6(?:
-                0[2-7]|
-                [1-9]
-              )|
+              6[1-9]|
               7[1257]|
-              8(?:
-                [06][2-7]|
-                [1-57-9]
-              )
+              8[1-57-9]
             )|
             2(?:
               1[257]|
               3[013]|
               4[01]|
               5[0137]|
-              6[0158]|
+              6[058]|
               78|
               8[1568]|
               9[14]
@@ -11733,75 +12755,70 @@
               22|
               [36][25]|
               4[28]|
-              5(?:
-                1|
-                2[2-7]
-              )|
-              [78]1|
+              [578]1|
               9[15]
             )|
-            6(?:
-              12[2-7]|
-              [2-4]1|
-              5[17]|
-              6[13]|
-              7[14]|
-              80
-            )|
+            674|
             7(?:
-              12|
               (?:
                 2[14]|
+                3[34]|
                 5[15]
               )[2-6]|
-              3(?:
-                1[2-7]|
-                [34][2-6]
-              )|
-              4[47][2-7]|
               61[346]|
               88[0-8]
             )|
             8(?:
-              (?:
+              70[2-6]|
+              84[235-7]|
+              91[3-7]
+            )|
+            (?:
+              1(?:
+                29|
+                60|
+                8[06]
+              )|
+              261|
+              552|
+              6(?:
+                12|
+                [2-47]1|
+                5[17]|
+                6[13]|
+                80
+              )|
+              7(?:
+                12|
+                31|
+                4[47]
+              )|
+              8(?:
                 16|
                 2[014]|
                 3[126]|
-                6[136]
-              )[2-7]|
-              7(?:
-                0[2-6]|
-                [78][2-7]
-              )|
-              8(?:
-                3[2-7]|
-                4[235-7]
-              )|
-              91[3-7]
-            )
+                6[136]|
+                7[78]|
+                83
+              )
+            )[2-7]
           </leadingDigits>
           <leadingDigits>
             1(?:
-              2[0-249]|
+              2[0-24]|
               3[0-25]|
               4[145]|
               [59][14]|
-              6(?:
-                0[2-7]|
-                [1-9]
-              )|
+              6[1-9]|
               7[1257]|
-              8(?:
-                [06][2-7]|
-                [1-57-9]
-              )
+              8[1-57-9]
             )|
             2(?:
               1[257]|
               3[013]|
               4[01]|
               5[0137]|
-              6[0158]|
+              6[058]|
               78|
               8[1568]|
               9[14]
@@ -11829,11 +12846,7 @@
               22|
               [36][25]|
               4[28]|
-              5(?:
-                1|
-                2[2-7]
-              )|
-              [78]1|
+              [578]1|
               9[15]
             )|
             6(?:
@@ -11841,84 +12854,90 @@
                 [2-6]|
                 7[0-8]
               )|
-              [2-4]1|
-              5[17]|
-              6[13]|
-              7[14]|
-              80
+              74[2-7]
             )|
             7(?:
-              12|
               (?:
                 2[14]|
                 5[15]
               )[2-6]|
-              3(?:
-                1(?:
-                  [2-6]|
-                  71
-                )|
-                [34][2-6]
-              )|
-              4[47](?:
-                [2-6]|
-                7[19]
-              )|
+              3171|
               61[346]|
               88(?:
-                [01][2-7]|
                 [2-7]|
                 82
               )
             )|
             8(?:
-              (?:
-                16|
-                2[014]|
-                3[126]|
-                6[136]
-              )(?:
-                [2-6]|
+              70[2-6]|
+              84(?:
+                [2356]|
                 7[19]
-              )|
-              7(?:
-                0[2-6]|
-                [78](?:
-                  [2-6]|
-                  7[19]
-                )
-              )|
-              8(?:
-                3(?:
-                  [2-6]|
-                  7[19]
-                )|
-                4(?:
-                  [2356]|
-                  7[19]
-                )
               )|
               91(?:
                 [3-6]|
                 7[19]
               )
-            )
+            )|
+            73[134][2-6]|
+            (?:
+              74[47]|
+              8(?:
+                16|
+                2[014]|
+                3[126]|
+                6[136]|
+                7[78]|
+                83
+              )
+            )(?:
+              [2-6]|
+              7[19]
+            )|
+            (?:
+              1(?:
+                29|
+                60|
+                8[06]
+              )|
+              261|
+              552|
+              6(?:
+                [2-4]1|
+                5[17]|
+                6[13]|
+                7(?:
+                  1|
+                  4[0189]
+                )|
+                80
+              )|
+              7(?:
+                12|
+                88[01]
+              )
+            )[2-7]
           </leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
         <!-- 4-digit area codes. -->
-        <numberFormat pattern="(\d{4})(\d{3})(\d{3})" nationalPrefixFormattingRule="$NP$FG">
+        <numberFormat pattern="(\d{4})(\d{3})(\d{3})" nationalPrefixFormattingRule="$NP$FG"
+                      nationalPrefixOptionalWhenFormatting="true">
           <leadingDigits>
             1(?:
-              [23579]|
-              4[236-9]
+              [2-479]|
+              5[0235-9]
             )|
             [2-5]|
             6(?:
               1[1358]|
               2[2457-9]|
               3[2-5]|
-              [4-8]
+              4[235-7]|
+              5[2-689]|
+              6[24578]|
+              7[235689]|
+              8[1-6]
             )|
             7(?:
               1[013-9]|
@@ -11933,8 +12952,8 @@
           </leadingDigits>
           <leadingDigits>
             1(?:
-              [23579]|
-              4[236-9]
+              [2-479]|
+              5[0235-9]
             )|
             [2-5]|
             6(?:
@@ -11948,7 +12967,11 @@
                 [2-4]|
                 55
               )|
-              [4-8]
+              4[235-7]|
+              5[2-689]|
+              6[24578]|
+              7[235689]|
+              8[1-6]
             )|
             7(?:
               1(?:
@@ -11985,30 +13008,48 @@
           </leadingDigits>
           <leadingDigits>
             1(?:
-              [23579]|
-              4[236-9]
+              [2-479]|
+              5(?:
+                [0236-9]|
+                5[013-9]
+              )
             )|
             [2-5]|
             6(?:
-              1[1358]|
               2(?:
-                [2457]|
                 84|
                 95
               )|
-              3(?:
-                [2-4]|
-                55
-              )|
-              [4-8]
+              355|
+              83
             )|
-            7(?:
-              1(?:
-                [013-8]|
-                9[6-9]
-              )|
-              (?:
+            73179|
+            807(?:
+              1|
+              9[1-3]
+            )|
+            (?:
+              1552|
+              6(?:
+                1[1358]|
+                2[2457]|
+                3[2-4]|
+                4[235-7]|
+                5[2-689]|
+                6[24578]|
+                7[235689]|
+                8[124-6]
+              )\d|
+              7(?:
+                1(?:
+                  [013-8]\d|
+                  9[6-9]
+                )|
                 28[6-8]|
+                3(?:
+                  2[0-49]|
+                  9[2-57]
+                )|
                 4(?:
                   1[2-4]|
                   [29][0-7]|
@@ -12028,35 +13069,20 @@
                   5[0-367]
                 )|
                 70[13-7]
-              )[2-7]|
-              3(?:
-                179|
-                (?:
-                  2[0-49]|
-                  9[2-57]
-                )[2-7]
               )
-            )|
-            807(?:
-              1|
-              9[1-3]
-            )
+            )[2-7]
           </leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
         <!-- Mobile format (this can include some fixed-line ranges due to limited precision
              in some ranges). -->
-        <numberFormat pattern="(\d{5})(\d{5})" nationalPrefixFormattingRule="$NP$FG">
+        <numberFormat pattern="(\d{5})(\d{5})" nationalPrefixFormattingRule="$NP$FG"
+                      nationalPrefixOptionalWhenFormatting="true">
           <leadingDigits>[6-9]</leadingDigits>
           <format>$1 $2</format>
         </numberFormat>
-        <!-- 10 digit UAN numbers -->
-        <numberFormat pattern="(\d{3})(\d{3})(\d{4})">
-          <leadingDigits>14</leadingDigits>
-          <format>$1 $2 $3</format>
-        </numberFormat>
         <!-- 10-12 digit toll free and shared cost numbers. -->
-        <numberFormat pattern="(\d{4})(\d{2,4})(\d{4})">
+        <numberFormat pattern="(\d{4})(\d{2,4})(\d{4})" nationalPrefixOptionalWhenFormatting="true">
           <leadingDigits>
             1(?:
               6|
@@ -12071,44 +13097,45 @@
           </leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
-        <!-- 12-digit toll free numbers -->
-        <numberFormat pattern="(\d{2})(\d{3})(\d{4})(\d{3})" nationalPrefixFormattingRule="$NP$FG">
+        <!-- 13-digit ITFS -->
+        <numberFormat pattern="(\d{3})(\d{3})(\d{3})(\d{4})">
           <leadingDigits>0</leadingDigits>
           <format>$1 $2 $3 $4</format>
           <intlFormat>NA</intlFormat>
         </numberFormat>
         <!-- 13 digit toll free and premium rate numbers -->
-        <numberFormat pattern="(\d{4})(\d{3})(\d{3})(\d{3})">
-          <leadingDigits>1</leadingDigits>
+        <numberFormat pattern="(\d{4})(\d{3})(\d{3})(\d{3})"
+                      nationalPrefixOptionalWhenFormatting="true">
+          <leadingDigits>18</leadingDigits>
           <format>$1 $2 $3 $4</format>
         </numberFormat>
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
           (?:
-            00800|
-            1\d{0,5}|
+            000800|
             [2-9]\d\d
-          )\d{7}
+          )\d{7}|
+          1\d{7,12}
         </nationalNumberPattern>
       </generalDesc>
       <noInternationalDialling>
         <possibleLengths national="[8-13]"/>
         <nationalNumberPattern>
+          1(?:
+            600\d{6}|
+            800\d{4,9}
+          )|
           (?:
-            00800\d|
-            1(?:
-              600|
-              8(?:
-                0[03]\d\d|
-                6(?:
-                  0|
-                  [12]\d\d
-                )
-              )\d
+            000800|
+            18(?:
+              03\d\d|
+              6(?:
+                0|
+                [12]\d\d
+              )
             )
-          )\d{6}|
-          1800\d{4,8}
+          )\d{7}
         </nationalNumberPattern>
       </noInternationalDialling>
       <!-- This pattern has 3 parts: 2-digit NDCs, 3-digit NDCs, and 4-digit NDCs. This is because
@@ -12120,316 +13147,204 @@
         <possibleLengths national="10" localOnly="[6-8]"/>
         <exampleNumber>7410410123</exampleNumber>
         <nationalNumberPattern>
+          2717(?:
+            [2-7]\d|
+            95
+          )\d{4}|
+          (?:
+            271[0-689]|
+            782[0-6]
+          )[2-7]\d{5}|
+          (?:
+            170[24]|
+            2(?:
+              (?:
+                [02][2-79]|
+                90
+              )\d|
+              80[13468]
+            )|
+            (?:
+              3(?:
+                23|
+                80
+              )|
+              683|
+              79[1-7]
+            )\d|
+            4(?:
+              20[24]|
+              72[2-8]
+            )|
+            552[1-7]
+          )\d{6}|
+          (?:
+            11|
+            33|
+            4[04]|
+            80
+          )[2-7]\d{7}|
+          (?:
+            342|
+            674|
+            788
+          )(?:
+            [0189][2-7]|
+            [2-7]\d
+          )\d{5}|
           (?:
             1(?:
-              1[2-7]\d\d|
-              2(?:
-                [0-249][2-7]\d|
-                [35-8]\d[2-7]
-              )|
-              3(?:
-                [0-25][2-7]\d|
-                [346-9]\d[2-7]
-              )|
-              4(?:
-                [145][2-7]\d|
-                [236-9]\d[2-7]
-              )|
-              [59](?:
-                [0235-9]\d[2-7]|
-                [14][2-7]\d
-              )|
-              6(?:
-                [014][2-7]\d|
-                [235-9]\d[2-7]
-              )|
-              7(?:
-                (?:
-                  0[24]|
-                  [1257][2-7]
-                )\d|
-                [34689]\d[2-7]
-              )|
-              8(?:
-                [01346][2-7]\d|
-                [257-9]\d[2-7]
-              )
+              2[0-249]|
+              3[0-25]|
+              4[145]|
+              [59][14]|
+              6[014]|
+              7[1257]|
+              8[01346]
             )|
             2(?:
-              [02][2-7]\d\d|
-              1(?:
-                [134689]\d[2-7]|
-                [257][2-7]\d
-              )|
-              3(?:
-                [013][2-7]\d|
-                [24-8]\d[2-7]
-              )|
-              4(?:
-                [01][2-7]\d|
-                [2-8]\d[2-7]
-              )|
-              5(?:
-                [0137][2-7]\d|
-                [25689]\d[2-7]
-              )|
-              6(?:
-                [0158][2-7]\d|
-                [2-4679]\d[2-7]
-              )|
-              7(?:
-                [13-79]\d[2-7]|
-                8[2-7]\d
-              )|
-              8(?:
-                (?:
-                  0[13468]|
-                  [1568][2-7]
-                )\d|
-                [2-479]\d[2-7]
-              )|
-              9(?:
-                (?:
-                  0\d|
-                  [14][2-7]
-                )\d|
-                [235-9]\d[2-7]
-              )
+              1[257]|
+              3[013]|
+              4[01]|
+              5[0137]|
+              6[0158]|
+              78|
+              8[1568]|
+              9[14]
             )|
             3(?:
-              (?:
-                01|
-                1[79]
-              )\d[2-7]|
-              2(?:
-                [1-5]\d[2-7]|
-                6[2-7]\d
-              )|
-              3[2-7]\d\d|
-              4(?:
-                [13][2-7]\d|
-                2(?:
-                  [0189][2-7]|
-                  [2-7]\d
-                )|
-                [5-8]\d[2-7]
-              )|
-              5(?:
-                [125689]\d[2-7]|
-                [34][2-7]\d
-              )|
-              6(?:
-                [01489][2-7]\d|
-                [235-7]\d[2-7]
-              )|
-              7(?:
-                [02-46][2-7]\d|
-                [157-9]\d[2-7]
-              )|
-              8(?:
-                (?:
-                  0\d|
-                  [159][2-7]
-                )\d|
-                [2-46-8]\d[2-7]
-              )
+              26|
+              4[13]|
+              5[34]|
+              6[01489]|
+              7[02-46]|
+              8[159]
             )|
             4(?:
-              [04][2-7]\d\d|
-              1(?:
-                [14578]\d[2-7]|
-                [36][2-7]\d
-              )|
-              2(?:
-                (?:
-                  0[24]|
-                  [1-47][2-7]
-                )\d|
-                [5689]\d[2-7]
-              )|
-              3(?:
-                [15][2-7]\d|
-                [2-467]\d[2-7]
-              )|
-              5(?:
-                [12][2-7]\d|
-                [4-7]\d[2-7]
-              )|
-              6(?:
-                [0-26-9][2-7]\d|
-                [35]\d[2-7]
-              )|
-              7(?:
-                (?:
-                  [014-9][2-7]|
-                  2[2-8]
-                )\d|
-                3\d[2-7]
-              )|
-              8(?:
-                [013-57][2-7]\d|
-                [2689]\d[2-7]
-              )|
-              9(?:
-                [014-7][2-7]\d|
-                [2389]\d[2-7]
-              )
+              1[36]|
+              2[1-47]|
+              3[15]|
+              5[12]|
+              6[0-26-9]|
+              7[014-9]|
+              8[013-57]|
+              9[014-7]
             )|
             5(?:
-              1(?:
-                [025][2-7]\d|
-                [146-9]\d[2-7]
-              )|
-              2(?:
-                [14-8]\d[2-7]|
-                2[2-7]\d
-              )|
-              3(?:
-                [1346]\d[2-7]|
-                [25][2-7]\d
-              )|
-              4(?:
-                [14-69]\d[2-7]|
-                [28][2-7]\d
-              )|
-              5(?:
-                (?:
-                  1[2-7]|
-                  2[1-7]
-                )\d|
-                [46]\d[2-7]
-              )|
-              6(?:
-                [146-9]\d[2-7]|
-                [25][2-7]\d
-              )|
-              7(?:
-                1[2-7]\d|
-                [2-4]\d[2-7]
-              )|
-              8(?:
-                1[2-7]\d|
-                [2-8]\d[2-7]
-              )|
-              9(?:
-                [15][2-7]\d|
-                [246]\d[2-7]
-              )
+              1[025]|
+              22|
+              [36][25]|
+              4[28]|
+              [578]1|
+              9[15]
             )|
             6(?:
-              1(?:
-                [1358]\d[2-7]|
-                2[2-7]\d
-              )|
-              2(?:
-                1[2-7]\d|
-                [2457]\d[2-7]
-              )|
-              3(?:
-                1[2-7]\d|
-                [2-4]\d[2-7]
-              )|
-              4(?:
-                1[2-7]\d|
-                [235-7]\d[2-7]
-              )|
-              5(?:
-                [17][2-7]\d|
-                [2-689]\d[2-7]
-              )|
-              6(?:
-                [13][2-7]\d|
-                [24578]\d[2-7]
-              )|
-              7(?:
-                1[2-7]\d|
-                [235689]\d[2-7]|
-                4(?:
-                  [0189][2-7]|
-                  [2-7]\d
-                )
-              )|
-              8(?:
-                0[2-7]\d|
-                [1-6]\d[2-7]
-              )
+              12|
+              [2-47]1|
+              5[17]|
+              6[13]|
+              80
             )|
             7(?:
-              1(?:
-                [013-9]\d[2-7]|
-                2[2-7]\d
-              )|
-              2(?:
-                [0235-9]\d[2-7]|
-                [14][2-7]\d
-              )|
-              3(?:
-                [134][2-7]\d|
-                [2679]\d[2-7]
-              )|
-              4(?:
-                [1-35689]\d[2-7]|
-                [47][2-7]\d
-              )|
-              5(?:
-                [15][2-7]\d|
-                [2-46-9]\d[2-7]
-              )|
-              [67](?:
-                [02-9]\d[2-7]|
-                1[2-7]\d
-              )|
-              8(?:
-                (?:
-                  [013-7]\d|
-                  2[0-6]
-                )[2-7]|
-                8(?:
-                  [0189][2-7]|
-                  [2-7]\d
-                )
-              )|
-              9(?:
-                [0189]\d[2-7]|
-                [2-7]\d\d
-              )
+              12|
+              2[14]|
+              3[134]|
+              4[47]|
+              5[15]|
+              [67]1
             )|
             8(?:
-              0[2-7]\d\d|
-              1(?:
-                [1357-9]\d[2-7]|
-                6[2-7]\d
-              )|
-              2(?:
-                [014][2-7]\d|
-                [235-8]\d[2-7]
-              )|
-              3(?:
-                [03-57-9]\d[2-7]|
-                [126][2-7]\d
-              )|
-              (?:
-                4[0-24-9]|
-                5\d
-              )\d[2-7]|
-              6(?:
-                [136][2-7]\d|
-                [2457-9]\d[2-7]
-              )|
-              7(?:
-                [078][2-7]\d|
-                [1-6]\d[2-7]
-              )|
-              8(?:
-                [1256]\d[2-7]|
-                [34][2-7]\d
-              )|
-              9(?:
-                1[2-7]\d|
-                [2-4]\d[2-7]
-              )
+              16|
+              2[014]|
+              3[126]|
+              6[136]|
+              7[078]|
+              8[34]|
+              91
             )
-          )\d{5}
+          )[2-7]\d{6}|
+          (?:
+            1(?:
+              2[35-8]|
+              3[346-9]|
+              4[236-9]|
+              [59][0235-9]|
+              6[235-9]|
+              7[34689]|
+              8[257-9]
+            )|
+            2(?:
+              1[134689]|
+              3[24-8]|
+              4[2-8]|
+              5[25689]|
+              6[2-4679]|
+              7[3-79]|
+              8[2-479]|
+              9[235-9]
+            )|
+            3(?:
+              01|
+              1[79]|
+              2[1245]|
+              4[5-8]|
+              5[125689]|
+              6[235-7]|
+              7[157-9]|
+              8[2-46-8]
+            )|
+            4(?:
+              1[14578]|
+              2[5689]|
+              3[2-467]|
+              5[4-7]|
+              6[35]|
+              73|
+              8[2689]|
+              9[2389]
+            )|
+            5(?:
+              [16][146-9]|
+              2[14-8]|
+              3[1346]|
+              4[14-69]|
+              5[46]|
+              7[2-4]|
+              8[2-8]|
+              9[246]
+            )|
+            6(?:
+              1[1358]|
+              2[2457]|
+              3[2-4]|
+              4[235-7]|
+              5[2-689]|
+              6[24578]|
+              7[235689]|
+              8[124-6]
+            )|
+            7(?:
+              1[013-9]|
+              2[0235-9]|
+              3[2679]|
+              4[1-35689]|
+              5[2-46-9]|
+              [67][02-9]|
+              8[013-7]|
+              9[089]
+            )|
+            8(?:
+              1[1357-9]|
+              2[235-8]|
+              3[03-57-9]|
+              4[0-24-9]|
+              5\d|
+              6[2457-9]|
+              7[1-6]|
+              8[1256]|
+              9[2-4]
+            )
+          )\d[2-7]\d{5}
         </nationalNumberPattern>
       </fixedLine>
       <!-- http://en.wikipedia.org/wiki/Mobile_telephone_numbering_in_India -->
@@ -12443,245 +13358,184 @@
            necessary to distinguish between mobile and fixed-line numbers. Extra prefixes added:
            6391, 7317[2-4], 7601, 768[56][1-7], 7695, 81145, 83178, 83287 and 83678. New prefixes
            were also added based on the document provided from mobile carriers:
-           https://github.com/googlei18n/libphonenumber/issues/260 and
-           https://github.com/googlei18n/libphonenumber/pull/692/ -->
+           https://github.com/google/libphonenumber/issues/260 and
+           https://github.com/google/libphonenumber/pull/692/ -->
       <mobile>
         <possibleLengths national="10"/>
         <exampleNumber>8123456789</exampleNumber>
         <nationalNumberPattern>
           (?:
-            6(?:
-              (?:
-                0(?:
-                  0[0-3569]|
-                  26|
-                  33
-                )|
-                2(?:
-                  [06]\d|
-                  3[02589]|
-                  8[0-479]|
-                  9[0-79]
-                )|
-                9(?:
-                  0[019]|
-                  13
-                )
-              )\d|
-              1279|
-              3(?:
-                (?:
-                  0[0-79]|
-                  6[0-4679]|
-                  7[0-24-9]|
-                  [89]\d
-                )\d|
-                5(?:
-                  0[0-6]|
-                  [1-9]\d
-                )
-              )
-            )|
+            61279|
             7(?:
-              (?:
-                0\d\d|
-                19[0-5]
-              )\d|
-              2(?:
-                (?:
-                  [0235-79]\d|
-                  [14][017-9]
-                )\d|
-                8(?:
-                  [0-59]\d|
-                  [6-8][089]
-                )
-              )|
-              3(?:
-                (?:
-                  [05-8]\d|
-                  3[017-9]
-                )\d|
-                1(?:
-                  [089]\d|
-                  11|
-                  7[02-8]
-                )|
-                2(?:
-                  [0-49][089]|
-                  [5-8]\d
-                )|
-                4(?:
-                  [07-9]\d|
-                  11
-                )|
-                9(?:
-                  [016-9]\d|
-                  [2-5][089]
-                )
-              )|
-              4(?:
-                0\d\d|
-                1(?:
-                  [015-9]\d|
-                  [2-4][089]
-                )|
-                [29](?:
-                  [0-7][089]|
-                  [89]\d
-                )|
-                3(?:
-                  [0-8][089]|
-                  9\d
-                )|
-                [47](?:
-                  [089]\d|
-                  11|
-                  7[02-8]
-                )|
-                [56]\d[089]|
-                8(?:
-                  [0-24-7][089]|
-                  [389]\d
-                )
-              )|
-              5(?:
-                (?:
-                  [0346-8]\d|
-                  5[017-9]
-                )\d|
-                1(?:
-                  [07-9]\d|
-                  11
-                )|
-                2(?:
-                  [04-9]\d|
-                  [1-3][089]
-                )|
-                9(?:
-                  [0-6][089]|
-                  [7-9]\d
-                )
-              )|
-              6(?:
-                0(?:
-                  [0-47]\d|
-                  [5689][089]
-                )|
-                (?:
-                  1[0-257-9]|
-                  [6-9]\d
-                )\d|
-                2(?:
-                  [0-4]\d|
-                  [5-9][089]
-                )|
-                3(?:
-                  [02-8][089]|
-                  [19]\d
-                )|
-                4\d[089]|
-                5(?:
-                  [0-367][089]|
-                  [4589]\d
-                )
-              )|
-              7(?:
-                0(?:
-                  0[02-9]|
-                  [13-7][089]|
-                  [289]\d
-                )|
-                [1-9]\d\d
-              )|
-              8(?:
-                [0-79]\d\d|
-                8(?:
-                  [089]\d|
-                  11|
-                  7[02-9]
-                )
-              )|
+              887[02-9]|
               9(?:
-                [089]\d\d|
                 313|
-                7(?:
-                  [02-8]\d|
-                  9[07-9]
-                )
+                79[07-9]
               )
             )|
             8(?:
-              0(?:
-                (?:
-                  [01589]\d|
-                  6[67]
-                )\d|
-                7(?:
-                  [02-8]\d|
-                  9[04-9]
-                )
-              )|
+              079[04-9]|
+              (?:
+                84|
+                91
+              )7[02-8]
+            )
+          )\d{5}|
+          (?:
+            6(?:
+              12|
+              [2-47]1|
+              5[17]|
+              6[13]|
+              80
+            )[0189]|
+            7(?:
               1(?:
-                [0-57-9]\d\d|
-                6(?:
-                  [089]\d|
-                  7[02-8]
-                )
+                2[0189]|
+                9[0-5]
               )|
               2(?:
-                [014](?:
-                  [089]\d|
-                  7[02-8]
-                )|
-                [235-9]\d\d
+                [14][017-9]|
+                8[0-59]
               )|
               3(?:
-                [03-57-9]\d\d|
-                [126](?:
-                  [089]\d|
-                  7[02-8]
-                )
+                2[5-8]|
+                [34][017-9]|
+                9[016-9]
               )|
-              [45]\d{3}|
+              4(?:
+                1[015-9]|
+                [29][89]|
+                39|
+                8[389]
+              )|
+              5(?:
+                [15][017-9]|
+                2[04-9]|
+                9[7-9]
+              )|
               6(?:
-                [02457-9]\d\d|
-                [136](?:
-                  [089]\d|
-                  7[02-8]
-                )
+                0[0-47]|
+                1[0-257-9]|
+                2[0-4]|
+                3[19]|
+                5[4589]
               )|
+              70[0289]|
+              88[089]|
+              97[02-8]
+            )|
+            8(?:
+              0(?:
+                6[67]|
+                7[02-8]
+              )|
+              70[017-9]|
+              84[01489]|
+              91[0-289]
+            )
+          )\d{6}|
+          (?:
+            7(?:
+              31|
+              4[47]
+            )|
+            8(?:
+              16|
+              2[014]|
+              3[126]|
+              6[136]|
+              7[78]|
+              83
+            )
+          )(?:
+            [0189]\d|
+            7[02-8]
+          )\d{5}|
+          (?:
+            6(?:
+              [09]\d|
+              1[04679]|
+              2[03689]|
+              3[05-9]|
+              4[0489]|
+              50|
+              6[069]|
+              7[07]|
+              8[7-9]
+            )|
+            7(?:
+              0\d|
+              2[0235-79]|
+              3[05-8]|
+              40|
+              5[0346-8]|
+              6[6-9]|
+              7[1-9]|
+              8[0-79]|
+              9[089]
+            )|
+            8(?:
+              0[01589]|
+              1[0-57-9]|
+              2[235-9]|
+              3[03-57-9]|
+              [45]\d|
+              6[02457-9]|
+              7[1-69]|
+              8[0-25-9]|
+              9[02-9]
+            )|
+            9\d\d
+          )\d{7}|
+          (?:
+            6(?:
+              (?:
+                1[1358]|
+                2[2457]|
+                3[2-4]|
+                4[235-7]|
+                5[2-689]|
+                6[24578]|
+                8[124-6]
+              )\d|
               7(?:
-                (?:
-                  0[07-9]|
-                  [1-69]\d
-                )\d|
-                [78](?:
-                  [089]\d|
-                  7[02-8]
-                )
-              )|
-              8(?:
-                [0-25-9]\d\d|
-                3(?:
-                  [089]\d|
-                  7[02-8]
-                )|
-                4(?:
-                  [0489]\d|
-                  7[02-8]
-                )
-              )|
-              9(?:
-                [02-9]\d\d|
-                1(?:
-                  [0289]\d|
-                  7[02-8]
-                )
+                [235689]\d|
+                4[0189]
               )
             )|
-            9\d{4}
-          )\d{5}
+            7(?:
+              1(?:
+                [013-8]\d|
+                9[6-9]
+              )|
+              28[6-8]|
+              3(?:
+                2[0-49]|
+                9[2-5]
+              )|
+              4(?:
+                1[2-4]|
+                [29][0-7]|
+                3[0-8]|
+                [56]\d|
+                8[0-24-7]
+              )|
+              5(?:
+                2[1-3]|
+                9[0-6]
+              )|
+              6(?:
+                0[5689]|
+                2[5-9]|
+                3[02-8]|
+                4\d|
+                5[0-367]
+              )|
+              70[13-7]|
+              881
+            )
+          )[0189]\d{5}
         </nationalNumberPattern>
       </mobile>
       <!-- Information gathered from sites such as
@@ -12692,14 +13546,14 @@
         <possibleLengths national="[8-13]"/>
         <exampleNumber>1800123456</exampleNumber>
         <nationalNumberPattern>
-          (?:
-            00800\d|
-            1(?:
-              600|
-              80[03]\d{3}
+          000800\d{7}|
+          1(?:
+            600\d{6}|
+            80(?:
+              0\d{4,9}|
+              3\d{9}
             )
-          )\d{6}|
-          1800\d{4,8}
+          )
         </nationalNumberPattern>
       </tollFree>
       <!-- Only televoting numbers are covered here for now. The 900 numbers are not covered
@@ -12728,7 +13582,7 @@
       </uan>
     </territory>
 
-    <!-- British Indian Ocean Territory / Diego Garcia -->
+    <!-- British Indian Ocean Territory (IO) -->
     <!-- http://www.itu.int/oth/T0202000039/en -->
     <territory id="IO" countryCode="246" internationalPrefix="00">
       <availableFormats>
@@ -12752,7 +13606,7 @@
       </mobile>
     </territory>
 
-    <!-- Iraq -->
+    <!-- Iraq (IQ) -->
     <!-- No tollFree or premiumRate information can be found. -->
     <!-- https://www.itu.int/oth/T0202000067/en -->
     <!-- http://en.wikipedia.org/wiki/%2B964 -->
@@ -12776,9 +13630,9 @@
         <nationalNumberPattern>
           (?:
             1|
-            [2-6]\d?|
             7\d\d
-          )\d{7}
+          )\d{7}|
+          [2-6]\d{7,8}
         </nationalNumberPattern>
       </generalDesc>
       <fixedLine>
@@ -12802,12 +13656,16 @@
       </mobile>
     </territory>
 
-    <!-- Iran, Islamic Republic of -->
+    <!-- Iran (IR) -->
     <!-- http://en.wikipedia.org/wiki/%2B98 -->
     <!-- http://www.itu.int/oth/T0202000066/en -->
     <!-- http://www.tct.ir/?siteid=1&pageid=195 -->
     <!-- http://118.tct.ir/citycode.htm -->
-    <territory id="IR" countryCode="98" internationalPrefix="00" nationalPrefix="0">
+    <!-- Prefix 9950 is mentioned as Public trunk with variable length 5 to 10 digits in ITU doc.
+         As we are unaware of the exact usage of this range and no online references we are not
+         adding it. -->
+    <territory id="IR" countryCode="98" internationalPrefix="00" nationalPrefix="0"
+               mobileNumberPortableRegion="true">
       <availableFormats>
         <!-- Format for short UAN numbers 096XX and 096XXX (we only need this format so the
              national prefix formatting rule is inherited properly). -->
@@ -12855,10 +13713,7 @@
         <possibleLengths national="4,5,10"/>
         <nationalNumberPattern>
           9(?:
-            4(?:
-              11[1-7]|
-              440
-            )\d{5}|
+            4440\d{5}|
             6(?:
               0[12]|
               2[16-8]|
@@ -12930,32 +13785,6 @@
         <exampleNumber>2123456789</exampleNumber>
         <nationalNumberPattern>
           (?:
-            (?:
-              1[137]|
-              2[13-68]|
-              3[1458]|
-              4[145]|
-              5[1468]|
-              6[16]|
-              7[1467]|
-              8[13467]
-            )\d{4}|
-            94(?:
-              (?:
-                000|
-                (?:
-                  11|
-                  2\d
-                )\d|
-                30[01]
-              )\d|
-              4(?:
-                111|
-                40\d
-              )
-            )
-          )\d{4}|
-          (?:
             1[137]|
             2[13-68]|
             3[1458]|
@@ -12965,11 +13794,31 @@
             7[1467]|
             8[13467]
           )(?:
-            [16]|
-            [289]\d?
-          )\d{3}
+            [03-57]\d{7}|
+            [16]\d{3}(?:
+              \d{4}
+            )?|
+            [289]\d{3}(?:
+              \d(?:
+                \d{3}
+              )?
+            )?
+          )|
+          94(?:
+            000[09]|
+            2(?:
+              121|
+              [2689]0\d
+            )|
+            30[0-2]\d|
+            4(?:
+              111|
+              40\d
+            )
+          )\d{4}
         </nationalNumberPattern>
       </fixedLine>
+      <!-- 992 prefix is been supported based on user report. -->
       <mobile>
         <possibleLengths national="10"/>
         <exampleNumber>9123456789</exampleNumber>
@@ -12987,12 +13836,12 @@
             )\d|
             9(?:
               (?:
-                [01]\d|
+                [0-2]\d|
                 44
               )\d|
-              510|
+              5[15]0|
               8(?:
-                1[01]|
+                1\d|
                 88
               )|
               9(?:
@@ -13041,8 +13890,7 @@
       </uan>
     </territory>
 
-    <!-- Iceland -->
-    <!-- As per new update from Iceland added carrier selection codes as international prefixes. -->
+    <!-- Iceland (IS) -->
     <!-- http://www.pta.is/default.aspx?cat_id=85 -->
     <!-- http://www.pfs.is/default.aspx?cat_id=14&module_id=210&element_id=4 -->
     <!-- http://www.pfs.is/english/telecom-affairs/numbering/ -->
@@ -13091,7 +13939,7 @@
               8[0-35-9]|
               9[013-689]
             )|
-            87[23]
+            872
           )\d{4}
         </nationalNumberPattern>
       </fixedLine>
@@ -13115,13 +13963,11 @@
             )|
             7(?:
               5[057]|
-              [6-8]\d|
-              9[0-3]
+              [6-9]\d
             )|
             8(?:
               2[0-59]|
-              [3469]\d|
-              5[1-9]|
+              [3-69]\d|
               8[28]
             )
           )\d{4}
@@ -13133,17 +13979,28 @@
       <tollFree>
         <possibleLengths national="7"/>
         <exampleNumber>8001234</exampleNumber>
-        <nationalNumberPattern>800\d{4}</nationalNumberPattern>
+        <nationalNumberPattern>80[08]\d{4}</nationalNumberPattern>
       </tollFree>
       <premiumRate>
         <possibleLengths national="7"/>
-        <exampleNumber>9011234</exampleNumber>
-        <nationalNumberPattern>90\d{5}</nationalNumberPattern>
+        <exampleNumber>9001234</exampleNumber>
+        <nationalNumberPattern>
+          90(?:
+            0\d|
+            1[5-79]|
+            2[015-79]|
+            3[135-79]|
+            4[125-7]|
+            5[25-79]|
+            7[1-37]|
+            8[0-35-7]
+          )\d{3}
+        </nationalNumberPattern>
       </premiumRate>
       <voip>
         <possibleLengths national="7"/>
         <exampleNumber>4921234</exampleNumber>
-        <nationalNumberPattern>49\d{5}</nationalNumberPattern>
+        <nationalNumberPattern>49[0-24-79]\d{4}</nationalNumberPattern>
       </voip>
       <uan>
         <possibleLengths national="7"/>
@@ -13157,7 +14014,7 @@
           (?:
             689|
             8(?:
-              7[0189]|
+              7[18]|
               80
             )|
             95[48]
@@ -13166,13 +14023,44 @@
       </voicemail>
     </territory>
 
-    <!-- Italy -->
+    <!-- Italy (IT) -->
     <!-- Main region for 'VA' -->
     <!-- http://en.wikipedia.org/wiki/%2B39 -->
     <!-- https://www.agcom.it/piano-di-numerazione -->
     <territory id="IT" mainCountryForCode="true" countryCode="39" internationalPrefix="00"
                mobileNumberPortableRegion="true">
       <availableFormats>
+        <!-- Shortcodes (4-5 digits). -->
+        <numberFormat pattern="(\d{4,5})">
+          <leadingDigits>
+            1(?:
+              0|
+              9[246]
+            )
+          </leadingDigits>
+          <leadingDigits>
+            1(?:
+              0|
+              9(?:
+                2[2-9]|
+                [46]
+              )
+            )
+          </leadingDigits>
+          <format>$1</format>
+          <intlFormat>NA</intlFormat>
+        </numberFormat>
+        <!-- Shortcodes (6 digits). -->
+        <numberFormat pattern="(\d{6})">
+          <leadingDigits>
+            1(?:
+              1|
+              92
+            )
+          </leadingDigits>
+          <format>$1</format>
+          <intlFormat>NA</intlFormat>
+        </numberFormat>
         <numberFormat pattern="(\d{2})(\d{4,6})">
           <leadingDigits>0[26]</leadingDigits>
           <format>$1 $2</format>
@@ -13223,21 +14111,13 @@
         </numberFormat>
         <numberFormat pattern="(\d{3})(\d{3})(\d{3,4})">
           <leadingDigits>
-            1(?:
-              44|
-              [67]|
-              99
-            )|
+            1[4679]|
             [38]
           </leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
         <numberFormat pattern="(\d{3})(\d{3,4})(\d{4})">
           <leadingDigits>0[13-57-9][0159]</leadingDigits>
-          <format>$1 $2 $3</format>
-        </numberFormat>
-        <numberFormat pattern="(\d{3})(\d{4})(\d{4})">
-          <leadingDigits>3</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
         <numberFormat pattern="(\d{2})(\d{4})(\d{5})">
@@ -13248,20 +14128,23 @@
           <leadingDigits>0</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
+        <numberFormat pattern="(\d{3})(\d{4})(\d{4,5})">
+          <leadingDigits>3</leadingDigits>
+          <format>$1 $2 $3</format>
+        </numberFormat>
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
-          0\d{6}(?:
-            \d{4}
+          0\d{5,10}|
+          3[0-8]\d{7,10}|
+          55\d{8}|
+          8\d{5}(?:
+            \d{2,4}
           )?|
-          3[0-8]\d{9}|
           (?:
-            [0138]\d?|
-            55
-          )\d{8}|
-          [08]\d{5}(?:
-            \d{2}
-          )?
+            1\d|
+            39
+          )\d{7,8}
         </nationalNumberPattern>
       </generalDesc>
       <noInternationalDialling>
@@ -13276,82 +14159,77 @@
         <possibleLengths national="[6-11]"/>
         <exampleNumber>0212345678</exampleNumber>
         <nationalNumberPattern>
+          0669[0-79]\d{1,6}|
           0(?:
-            (?:
-              1(?:
-                [0159]\d|
-                [27][1-5]|
-                31|
-                4[1-4]|
-                6[1356]|
-                8[2-57]
-              )|
-              2\d\d|
-              3(?:
-                [0159]\d|
-                2[1-4]|
-                3[12]|
-                [48][1-6]|
-                6[2-59]|
-                7[1-7]
-              )|
-              4(?:
-                [0159]\d|
-                [23][1-9]|
-                4[245]|
-                6[1-5]|
-                7[1-4]|
-                81
-              )|
-              5(?:
-                [0159]\d|
-                2[1-5]|
-                3[2-6]|
-                4[1-79]|
-                6[4-6]|
-                7[1-578]|
-                8[3-8]
-              )|
-              7(?:
-                [0159]\d|
-                2[12]|
-                3[1-7]|
-                4[2-46]|
-                6[13569]|
-                7[13-6]|
-                8[1-59]
-              )|
-              8(?:
-                [0159]\d|
-                2[3-578]|
-                3[1-356]|
-                [6-8][1-5]
-              )|
-              9(?:
-                [0159]\d|
-                [238][1-5]|
-                4[12]|
-                6[1-8]|
-                7[1-6]
-              )
-            )\d|
+            1(?:
+              [0159]\d|
+              [27][1-5]|
+              31|
+              4[1-4]|
+              6[1356]|
+              8[2-57]
+            )|
+            2\d\d|
+            3(?:
+              [0159]\d|
+              2[1-4]|
+              3[12]|
+              [48][1-6]|
+              6[2-59]|
+              7[1-7]
+            )|
+            4(?:
+              [0159]\d|
+              [23][1-9]|
+              4[245]|
+              6[1-5]|
+              7[1-4]|
+              81
+            )|
+            5(?:
+              [0159]\d|
+              2[1-5]|
+              3[2-6]|
+              4[1-79]|
+              6[4-6]|
+              7[1-578]|
+              8[3-8]
+            )|
             6(?:
-              [0-57-9]\d\d|
-              6(?:
-                [0-8]\d|
-                9[0-79]
-              )
+              [0-57-9]\d|
+              6[0-8]
+            )|
+            7(?:
+              [0159]\d|
+              2[12]|
+              3[1-7]|
+              4[2-46]|
+              6[13569]|
+              7[13-6]|
+              8[1-59]
+            )|
+            8(?:
+              [0159]\d|
+              2[3-578]|
+              3[1-356]|
+              [6-8][1-5]
+            )|
+            9(?:
+              [0159]\d|
+              [238][1-5]|
+              4[12]|
+              6[1-8]|
+              7[1-6]
             )
-          )\d{1,6}
+          )\d{2,7}
         </nationalNumberPattern>
       </fixedLine>
       <!-- User reported the existence of new 11 digit long numbers for TIM with the prefix 33X, so
            it is also supported. -->
       <mobile>
-        <possibleLengths national="[9-11]"/>
+        <possibleLengths national="9,10"/>
         <exampleNumber>3123456789</exampleNumber>
         <nationalNumberPattern>
-          33\d{9}|
           3[1-9]\d{8}|
           3[2-9]\d{7}
         </nationalNumberPattern>
@@ -13375,25 +14253,23 @@
         <exampleNumber>899123456</exampleNumber>
         <nationalNumberPattern>
           (?:
-            (?:
-              0878|
-              1(?:
-                44|
-                6[346]
-              )\d
-            )\d\d|
+            0878\d\d|
             89(?:
               2|
-              (?:
-                4[5-9]|
-                (?:
-                  5[5-9]|
-                  9
-                )\d\d
-              )\d
+              4[5-9]\d
             )
           )\d{3}|
-          89[45][0-4]\d\d
+          89[45][0-4]\d\d|
+          (?:
+            1(?:
+              44|
+              6[346]
+            )|
+            89(?:
+              5[5-9]|
+              9
+            )
+          )\d{6}
         </nationalNumberPattern>
       </premiumRate>
       <sharedCost>
@@ -13421,12 +14297,17 @@
         <exampleNumber>5512345678</exampleNumber>
         <nationalNumberPattern>55\d{8}</nationalNumberPattern>
       </voip>
+      <voicemail>
+        <possibleLengths national="11,12"/>
+        <exampleNumber>33101234501</exampleNumber>
+        <nationalNumberPattern>3[2-8]\d{9,10}</nationalNumberPattern>
+      </voicemail>
     </territory>
 
-    <!-- Jersey -->
+    <!-- Jersey (JE) -->
+    <!-- Calling code and formatting shared with 'GB' -->
     <!-- Note that the numbers are fine-grained where needed in order to disambiguate between the
          4 regions i.e UK, Isle of Man, Jersey and Guernsey. -->
-    <!-- Calling code and formatting shared with 'GB' -->
     <!-- http://static.ofcom.org.uk/static/numbering/ -->
     <!-- http://en.wikipedia.org/wiki/Telephone_numbers_in_the_United_Kingdom -->
     <!-- http://www.jcra.je/cms3/v2/public/cmsChild.asp?pageID=1024&childID=1036 -->
@@ -13434,13 +14315,11 @@
                nationalPrefixForParsing="0|([0-24-8]\d{5})$" nationalPrefixTransformRule="1534$1">
       <generalDesc>
         <nationalNumberPattern>
+          1534\d{6}|
           (?:
-            1534|
-            (?:
-              [3578]\d|
-              90
-            )\d\d
-          )\d{6}
+            [3578]\d|
+            90
+          )\d{8}
         </nationalNumberPattern>
       </generalDesc>
       <!-- Specific to JE. -->
@@ -13592,7 +14471,7 @@
       </uan>
     </territory>
 
-    <!-- Jamaica -->
+    <!-- Jamaica (JM) -->
     <!-- Calling code and formatting shared with 'US' -->
     <!-- http://www.itu.int/oth/T020200006C/en -->
     <territory id="JM" countryCode="1" leadingDigits="658|876" internationalPrefix="011"
@@ -13612,10 +14491,16 @@
         <exampleNumber>8765230123</exampleNumber>
         <nationalNumberPattern>
           (?:
-            658[2-9]\d\d|
+            658(?:
+              2(?:
+                [0-8]\d|
+                9[0-46-9]
+              )|
+              [3-9]\d\d
+            )|
             876(?:
               5(?:
-                0[12]|
+                02|
                 1[0-468]|
                 2[35]|
                 63
@@ -13656,25 +14541,29 @@
         <possibleLengths national="10" localOnly="7"/>
         <exampleNumber>8762101234</exampleNumber>
         <nationalNumberPattern>
-          876(?:
-            (?:
-              2[14-9]|
-              [348]\d
-            )\d|
-            5(?:
-              0[3-9]|
-              [2-57-9]\d|
-              6[0-24-9]
-            )|
-            7(?:
-              0[07]|
-              7\d|
-              8[1-47-9]|
-              9[0-36-9]
-            )|
-            9(?:
-              [01]9|
-              9[0579]
+          (?:
+            658295|
+            876(?:
+              (?:
+                2[14-9]|
+                [348]\d
+              )\d|
+              5(?:
+                0[13-9]|
+                17|
+                [2-57-9]\d|
+                6[0-24-9]
+              )|
+              7(?:
+                0[07]|
+                7\d|
+                8[1-47-9]|
+                9[0-36-9]
+              )|
+              9(?:
+                [01]9|
+                9[0579]
+              )
             )
           )\d{4}
         </nationalNumberPattern>
@@ -13717,7 +14606,7 @@
       </personalNumber>
     </territory>
 
-    <!-- Jordan -->
+    <!-- Jordan (JO) -->
     <!-- http://www.trc.gov.jo/images/stories/pdf/NNP_ver200[1].pdf?lang=english -->
     <!-- http://www.itu.int/oth/T020200006E/en -->
     <!-- http://en.wikipedia.org/wiki/%2B962 -->
@@ -13735,28 +14624,26 @@
           <leadingDigits>[89]</leadingDigits>
           <format>$1 $2</format>
         </numberFormat>
-        <numberFormat pattern="(\d)(\d{4})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>7[457-9]</leadingDigits>
-          <format>$1 $2 $3</format>
-        </numberFormat>
         <numberFormat pattern="(\d{2})(\d{7})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>7</leadingDigits>
+          <leadingDigits>70</leadingDigits>
           <format>$1 $2</format>
+        </numberFormat>
+        <numberFormat pattern="(\d)(\d{4})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>7</leadingDigits>
+          <format>$1 $2 $3</format>
         </numberFormat>
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
+          900\d{5}|
           (?:
             (?:
-              (?:
-                [268]|
-                7\d
-              )\d|
-              32|
-              53
+              [268]|
+              7\d
             )\d|
-            900
-          )\d{5}
+            32|
+            53
+          )\d{6}
         </nationalNumberPattern>
       </generalDesc>
       <fixedLine>
@@ -13803,7 +14690,10 @@
               9[0-36-9]
             )|
             6(?:
-              2[05]0|
+              2(?:
+                [05]0|
+                22
+              )|
               3(?:
                 00|
                 33
@@ -13845,7 +14735,8 @@
             55[0-49]|
             (?:
               7[025-9]|
-              [89][0-25-9]
+              8[0-25-9]|
+              9\d
             )\d
           )\d{5}
         </nationalNumberPattern>
@@ -13894,7 +14785,7 @@
       </uan>
     </territory>
 
-    <!-- Japan -->
+    <!-- Japan (JP) -->
     <!-- http://www.soumu.go.jp/main_sosiki/joho_tsusin/top/tel_number/number_shitei.html -->
     <!-- https://www.itu.int/oth/T020200006D/en -->
     <!-- http://www.numberingplans.com/?page=dialling&sub=areacodes&ac=JP -->
@@ -13955,15 +14846,11 @@
                 7[247]|
                 9[278]
               )|
-              4(?:
-                5[67]|
-                66
-              )|
+              466|
               5(?:
                 47|
                 58|
-                64|
-                8[67]
+                64
               )|
               6(?:
                 3[245]|
@@ -13993,7 +14880,11 @@
                 1[23]|
                 69
               )
-            )
+            )|
+            1(?:
+              45|
+              58
+            )[67]
           </leadingDigits>
           <leadingDigits>
             1(?:
@@ -14002,15 +14893,11 @@
                 7[247]|
                 9[278]
               )|
-              4(?:
-                5[67]|
-                66
-              )|
+              466|
               5(?:
                 47|
                 58|
-                64|
-                8[67]
+                64
               )|
               6(?:
                 3[245]|
@@ -14040,580 +14927,16 @@
                 1[23]|
                 69
               )
-            )
-          </leadingDigits>
-          <format>$1-$2-$3</format>
-        </numberFormat>
-        <numberFormat pattern="(\d{3})(\d{2})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>
+            )|
             1(?:
-              [2-46]|
-              5[2-8]|
-              7[2-689]|
-              8[2-7]|
-              9[1-578]
-            )|
-            2(?:
-              2[03-689]|
-              3[3-58]|
-              4[0-468]|
-              5[04-8]|
-              6[013-8]|
-              7[06-9]|
-              8[02-57-9]|
-              9[13]
-            )|
-            4(?:
-              2[28]|
-              3[689]|
-              6[035-7]|
-              7[05689]|
-              80|
-              9[3-5]
-            )|
-            5(?:
-              3[1-36-9]|
-              4[4578]|
-              5[013-8]|
-              [67]|
-              8[14-7]|
-              9[4-9]
-            )|
-            7(?:
-              2[15]|
-              3[5-9]|
-              4|
-              6[135-8]|
-              7[0-4689]|
-              9[014-9]
-            )|
-            8(?:
-              2[49]|
-              3[3-8]|
-              4[5-8]|
-              5[2-9]|
-              6[35-9]|
-              7[579]|
-              8[03-579]|
-              9[2-8]
-            )|
-            9(?:
-              [23]0|
-              4[02-46-9]|
-              5[024-79]|
-              6[4-9]|
-              7[2-47-9]|
-              8[02-7]|
-              9[3-7]
-            )
-          </leadingDigits>
-          <leadingDigits>
-            1(?:
-              [2-46]|
-              5(?:
-                [236-8]|
-                [45][2-69]
-              )|
-              7[2-689]|
-              8[2-7]|
-              9[1-578]
-            )|
-            2(?:
-              2(?:
-                [04-689]|
-                3[23]
-              )|
-              3[3-58]|
-              4[0-468]|
-              5(?:
-                [0468][2-9]|
-                5[78]|
-                7[2-4]
-              )|
-              6(?:
-                [0135-8]|
-                4[2-5]
-              )|
-              7(?:
-                [0679]|
-                8[2-7]
-              )|
-              8(?:
-                [024578]|
-                3[25-9]|
-                9[6-9]
-              )|
-              9(?:
-                11|
-                3[2-4]
-              )
-            )|
-            4(?:
-              2(?:
-                2[2-9]|
-                8[237-9]
-              )|
-              3[689]|
-              6[035-7]|
-              7(?:
-                [059][2-8]|
-                [68]
-              )|
-              80|
-              9[3-5]
-            )|
-            5(?:
-              3[1-36-9]|
-              4[4578]|
-              5[013-8]|
-              [67]|
-              8[14-7]|
-              9(?:
-                [4-7]|
-                [89][2-8]
-              )
-            )|
-            7(?:
-              2[15]|
-              3[5-9]|
-              4|
-              6[135-8]|
-              7[0-4689]|
-              9(?:
-                [017-9]|
-                4[6-8]|
-                5[2-478]|
-                6[2-589]
-              )
-            )|
-            8(?:
-              2(?:
-                4[4-8]|
-                9[2-8]
-              )|
-              3(?:
-                [3-6][2-9]|
-                7[2-6]|
-                8[2-5]
-              )|
-              4[5-8]|
-              5[2-9]|
-              6(?:
-                [37]|
-                5[4-7]|
-                6[2-9]|
-                8[2-8]|
-                9[236-9]
-              )|
-              7[579]|
-              8[03-579]|
-              9[2-8]
-            )|
-            9(?:
-              [23]0|
-              4[02-46-9]|
-              5[024-79]|
-              6[4-9]|
-              7[2-47-9]|
-              8[02-7]|
-              9(?:
-                3[34]|
-                4[2-69]|
-                [5-7]
-              )
-            )
-          </leadingDigits>
-          <leadingDigits>
-            1(?:
-              [2-46]|
-              5(?:
-                [236-8]|
-                [45][2-69]
-              )|
-              7[2-689]|
-              8[2-7]|
-              9[1-578]
-            )|
-            2(?:
-              2(?:
-                [04-689]|
-                3[23]
-              )|
-              3[3-58]|
-              4[0-468]|
-              5(?:
-                [0468][2-9]|
-                5[78]|
-                7[2-4]
-              )|
-              6(?:
-                [0135-8]|
-                4[2-5]
-              )|
-              7(?:
-                [0679]|
-                8[2-7]
-              )|
-              8(?:
-                [024578]|
-                3[25-9]|
-                9[6-9]
-              )|
-              9(?:
-                11|
-                3[2-4]
-              )
-            )|
-            4(?:
-              2(?:
-                2[2-9]|
-                8[237-9]
-              )|
-              3[689]|
-              6[035-7]|
-              7(?:
-                [059][2-8]|
-                [68]
-              )|
-              80|
-              9[3-5]
-            )|
-            5(?:
-              3[1-36-9]|
-              4[4578]|
-              5[013-8]|
-              [67]|
-              8[14-7]|
-              9(?:
-                [4-7]|
-                [89][2-8]
-              )
-            )|
-            7(?:
-              2[15]|
-              3[5-9]|
-              4|
-              6[135-8]|
-              7[0-4689]|
-              9(?:
-                [017-9]|
-                4[6-8]|
-                5[2-478]|
-                6[2-589]
-              )
-            )|
-            8(?:
-              2(?:
-                4[4-8]|
-                9(?:
-                  20|
-                  [3578]|
-                  4[04-9]|
-                  6[56]
-                )
-              )|
-              3(?:
-                [3-6][2-9]|
-                7(?:
-                  [2-5]|
-                  6[0-59]
-                )|
-                8[2-5]
-              )|
-              4[5-8]|
-              5[2-9]|
-              6(?:
-                [37]|
-                5(?:
-                  [467]|
-                  5[014-9]
-                )|
-                6(?:
-                  [2-8]|
-                  9[02-69]
-                )|
-                8[2-8]|
-                9(?:
-                  [236-8]|
-                  9[23]
-                )
-              )|
-              7[579]|
-              8[03-579]|
-              9[2-8]
-            )|
-            9(?:
-              [23]0|
-              4[02-46-9]|
-              5[024-79]|
-              6[4-9]|
-              7[2-47-9]|
-              8[02-7]|
-              9(?:
-                3(?:
-                  3[02-9]|
-                  4[0-24689]
-                )|
-                4[2-69]|
-                [5-7]
-              )
-            )
-          </leadingDigits>
-          <leadingDigits>
-            1(?:
-              [2-46]|
-              5(?:
-                [236-8]|
-                [45][2-69]
-              )|
-              7[2-689]|
-              8[2-7]|
-              9[1-578]
-            )|
-            2(?:
-              2(?:
-                [04-689]|
-                3[23]
-              )|
-              3[3-58]|
-              4[0-468]|
-              5(?:
-                [0468][2-9]|
-                5[78]|
-                7[2-4]
-              )|
-              6(?:
-                [0135-8]|
-                4[2-5]
-              )|
-              7(?:
-                [0679]|
-                8[2-7]
-              )|
-              8(?:
-                [024578]|
-                3[25-9]|
-                9[6-9]
-              )|
-              9(?:
-                11|
-                3[2-4]
-              )
-            )|
-            4(?:
-              2(?:
-                2[2-9]|
-                8[237-9]
-              )|
-              3[689]|
-              6[035-7]|
-              7(?:
-                [059][2-8]|
-                [68]
-              )|
-              80|
-              9[3-5]
-            )|
-            5(?:
-              3[1-36-9]|
-              4[4578]|
-              5[013-8]|
-              [67]|
-              8[14-7]|
-              9(?:
-                [4-7]|
-                [89][2-8]
-              )
-            )|
-            7(?:
-              2[15]|
-              3[5-9]|
-              4|
-              6[135-8]|
-              7[0-4689]|
-              9(?:
-                [017-9]|
-                4[6-8]|
-                5[2-478]|
-                6[2-589]
-              )
-            )|
-            8(?:
-              2(?:
-                4[4-8]|
-                9(?:
-                  20|
-                  [3578]|
-                  4[04-9]|
-                  6(?:
-                    5[25]|
-                    60
-                  )
-                )
-              )|
-              3(?:
-                [3-6][2-9]|
-                7(?:
-                  [2-5]|
-                  6[0-59]
-                )|
-                8[2-5]
-              )|
-              4[5-8]|
-              5[2-9]|
-              6(?:
-                [37]|
-                5(?:
-                  [467]|
-                  5[014-9]
-                )|
-                6(?:
-                  [2-8]|
-                  9[02-69]
-                )|
-                8[2-8]|
-                9(?:
-                  [236-8]|
-                  9[23]
-                )
-              )|
-              7[579]|
-              8[03-579]|
-              9[2-8]
-            )|
-            9(?:
-              [23]0|
-              4[02-46-9]|
-              5[024-79]|
-              6[4-9]|
-              7[2-47-9]|
-              8[02-7]|
-              9(?:
-                3(?:
-                  3[02-9]|
-                  4[0-24689]
-                )|
-                4[2-69]|
-                [5-7]
-              )
-            )
+              45|
+              58
+            )[67]
           </leadingDigits>
           <format>$1-$2-$3</format>
         </numberFormat>
         <numberFormat pattern="(\d{2})(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>
-            1|
-            2(?:
-              2[37]|
-              5[5-9]|
-              64|
-              78|
-              8[39]|
-              91
-            )|
-            4(?:
-              2[2689]|
-              64|
-              7[347]
-            )|
-            5[2-589]|
-            60|
-            8(?:
-              2[124589]|
-              3[279]|
-              [46-9]
-            )|
-            9(?:
-              [235-8]|
-              93
-            )
-          </leadingDigits>
-          <leadingDigits>
-            1|
-            2(?:
-              2[37]|
-              5(?:
-                [57]|
-                [68]0|
-                9[19]
-              )|
-              64|
-              78|
-              8[39]|
-              917
-            )|
-            4(?:
-              2(?:
-                20|
-                [68]|
-                9[178]
-              )|
-              64|
-              7[347]
-            )|
-            5[2-589]|
-            60|
-            8(?:
-              2[124589]|
-              3[279]|
-              [46-9]
-            )|
-            9(?:
-              [235-8]|
-              93[34]
-            )
-          </leadingDigits>
-          <leadingDigits>
-            1|
-            2(?:
-              2[37]|
-              5(?:
-                [57]|
-                [68]0|
-                9(?:
-                  17|
-                  99
-                )
-              )|
-              64|
-              78|
-              8[39]|
-              917
-            )|
-            4(?:
-              2(?:
-                20|
-                [68]|
-                9[178]
-              )|
-              64|
-              7[347]
-            )|
-            5[2-589]|
-            60|
-            8(?:
-              2[124589]|
-              3[279]|
-              [46-9]
-            )|
-            9(?:
-              [235-8]|
-              93[34]
-            )
-          </leadingDigits>
-          <format>$1-$2-$3</format>
-        </numberFormat>
-        <numberFormat pattern="(\d{3})(\d{2})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>
-            2(?:
-              [34]7|
-              [56]9|
-              74|
-              9[14-79]
-            )|
-            82|
-            993
-          </leadingDigits>
+          <leadingDigits>60</leadingDigits>
           <format>$1-$2-$3</format>
         </numberFormat>
         <numberFormat pattern="(\d)(\d{4})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
@@ -14624,14 +14947,525 @@
               7[01]
             )
           </leadingDigits>
+          <leadingDigits>
+            [36]|
+            4(?:
+              2(?:
+                0|
+                9[02-69]
+              )|
+              7(?:
+                0[019]|
+                1
+              )
+            )
+          </leadingDigits>
           <format>$1-$2-$3</format>
         </numberFormat>
         <numberFormat pattern="(\d{2})(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>
-            2[2-9]|
-            4|
-            7[235-9]|
-            9[49]
+            1(?:
+              1|
+              5[45]|
+              77|
+              88|
+              9[69]
+            )|
+            2(?:
+              2[1-37]|
+              3[0-269]|
+              4[59]|
+              5|
+              6[24]|
+              7[1-358]|
+              8[1369]|
+              9[0-38]
+            )|
+            4(?:
+              [28][1-9]|
+              3[0-57]|
+              [45]|
+              6[248]|
+              7[2-579]|
+              9[29]
+            )|
+            5(?:
+              2|
+              3[045]|
+              4[0-369]|
+              5[29]|
+              8[02389]|
+              9[0-389]
+            )|
+            7(?:
+              2[02-46-9]|
+              34|
+              [58]|
+              6[0249]|
+              7[57]|
+              9[2-6]
+            )|
+            8(?:
+              2[124589]|
+              3[279]|
+              49|
+              6[0-24-689]|
+              7[0-468]|
+              8[68]|
+              9[019]
+            )|
+            9(?:
+              [23][1-9]|
+              4[15]|
+              5[138]|
+              6[1-3]|
+              7[156]|
+              8[189]|
+              9[1-489]
+            )
+          </leadingDigits>
+          <leadingDigits>
+            1(?:
+              1|
+              5(?:
+                4[018]|
+                5[017]
+              )|
+              77|
+              88|
+              9[69]
+            )|
+            2(?:
+              2(?:
+                [127]|
+                3[014-9]
+              )|
+              3[0-269]|
+              4[59]|
+              5(?:
+                [0468][01]|
+                [1-3]|
+                5[0-69]|
+                9[19]
+              )|
+              62|
+              7(?:
+                [1-35]|
+                8[0189]
+              )|
+              8(?:
+                [16]|
+                3[0134]|
+                9[0-5]
+              )|
+              9(?:
+                [028]|
+                17
+              )
+            )|
+            4(?:
+              2(?:
+                [13-79]|
+                2[01]|
+                8[014-6]
+              )|
+              3[0-57]|
+              [45]|
+              6[248]|
+              7[2-47]|
+              8[1-9]
+            )|
+            5(?:
+              2|
+              3[045]|
+              4[0-369]|
+              8[02389]|
+              9[0-3]
+            )|
+            7(?:
+              2[02-46-9]|
+              34|
+              [58]|
+              6[0249]|
+              7[57]|
+              9(?:
+                [23]|
+                4[0-59]|
+                5[01569]|
+                6[0167]
+              )
+            )|
+            8(?:
+              2(?:
+                [1258]|
+                4[0-39]|
+                9[0-2469]
+              )|
+              49|
+              6(?:
+                [0-24]|
+                5[0-3589]|
+                9[01459]
+              )|
+              7[0-468]|
+              8[68]
+            )|
+            9(?:
+              [23][1-9]|
+              4[15]|
+              5[138]|
+              6[1-3]|
+              7[156]|
+              8[189]|
+              9(?:
+                [1289]|
+                3[34]|
+                4[0178]
+              )
+            )|
+            (?:
+              49|
+              55|
+              83
+            )[29]|
+            (?:
+              264|
+              837
+            )[016-9]|
+            2(?:
+              57|
+              93
+            )[015-9]|
+            (?:
+              47[59]|
+              59[89]|
+              8(?:
+                6[68]|
+                9
+              )
+            )[019]
+          </leadingDigits>
+          <leadingDigits>
+            1(?:
+              1|
+              5(?:
+                4[018]|
+                5[017]
+              )|
+              77|
+              88|
+              9[69]
+            )|
+            2(?:
+              2[127]|
+              3[0-269]|
+              4[59]|
+              5(?:
+                [0468][01]|
+                [1-3]|
+                5[0-69]|
+                9(?:
+                  17|
+                  99
+                )
+              )|
+              6(?:
+                2|
+                4[016-9]
+              )|
+              7(?:
+                [1-35]|
+                8[0189]
+              )|
+              8(?:
+                [16]|
+                3[0134]|
+                9[0-5]
+              )|
+              9(?:
+                [028]|
+                17
+              )
+            )|
+            4(?:
+              2(?:
+                [13-79]|
+                2[01]|
+                8[014-6]
+              )|
+              3[0-57]|
+              [45]|
+              6[248]|
+              7[2-47]|
+              9[29]
+            )|
+            5(?:
+              2|
+              3[045]|
+              4[0-369]|
+              5[29]|
+              8[02389]|
+              9[0-3]
+            )|
+            7(?:
+              2[02-46-9]|
+              34|
+              [58]|
+              6[0249]|
+              7[57]|
+              9(?:
+                [23]|
+                4[0-59]|
+                5[01569]|
+                6[0167]
+              )
+            )|
+            8(?:
+              2(?:
+                [1258]|
+                4[0-39]|
+                9[0169]
+              )|
+              3(?:
+                [29]|
+                7(?:
+                  [017-9]|
+                  6[6-8]
+                )
+              )|
+              49|
+              6(?:
+                [0-24]|
+                5(?:
+                  [0-389]|
+                  5[23]
+                )|
+                6(?:
+                  [01]|
+                  9[178]
+                )|
+                9[0145]
+              )|
+              7[0-468]|
+              8[68]
+            )|
+            9(?:
+              4[15]|
+              5[138]|
+              7[156]|
+              8[189]|
+              9(?:
+                [1289]|
+                3(?:
+                  31|
+                  4[357]
+                )|
+                4[0178]
+              )
+            )|
+            (?:
+              8294|
+              96
+            )[1-3]|
+            2(?:
+              57|
+              93
+            )[015-9]|
+            (?:
+              223|
+              8699
+            )[014-9]|
+            (?:
+              48|
+              8292|
+              9[23]
+            )[1-9]|
+            (?:
+              47[59]|
+              59[89]|
+              8(?:
+                68|
+                9
+              )
+            )[019]
+          </leadingDigits>
+          <leadingDigits>
+            1(?:
+              1|
+              5(?:
+                4[018]|
+                5[017]
+              )|
+              77|
+              88|
+              9[69]
+            )|
+            2(?:
+              2[127]|
+              3[0-269]|
+              4[59]|
+              5(?:
+                [0468][01]|
+                [1-3]|
+                5[0-69]|
+                7[015-9]|
+                9(?:
+                  17|
+                  99
+                )
+              )|
+              6(?:
+                2|
+                4[016-9]
+              )|
+              7(?:
+                [1-35]|
+                8[0189]
+              )|
+              8(?:
+                [16]|
+                3[0134]|
+                9[0-5]
+              )|
+              9(?:
+                [028]|
+                17|
+                3[015-9]
+              )
+            )|
+            4(?:
+              2(?:
+                [13-79]|
+                2[01]|
+                8[014-6]
+              )|
+              3[0-57]|
+              [45]|
+              6[248]|
+              7[2-47]|
+              9[29]
+            )|
+            5(?:
+              2|
+              3[045]|
+              4[0-369]|
+              5[29]|
+              8[02389]|
+              9[0-3]
+            )|
+            7(?:
+              2[02-46-9]|
+              34|
+              [58]|
+              6[0249]|
+              7[57]|
+              9(?:
+                [23]|
+                4[0-59]|
+                5[01569]|
+                6[0167]
+              )
+            )|
+            8(?:
+              2(?:
+                [1258]|
+                4[0-39]|
+                9(?:
+                  [019]|
+                  4[1-3]|
+                  6(?:
+                    [0-47-9]|
+                    5[01346-9]
+                  )
+                )
+              )|
+              3(?:
+                [29]|
+                7(?:
+                  [017-9]|
+                  6[6-8]
+                )
+              )|
+              49|
+              6(?:
+                [0-24]|
+                5(?:
+                  [0-389]|
+                  5[23]
+                )|
+                6(?:
+                  [01]|
+                  9[178]
+                )|
+                9[0145]
+              )|
+              7[0-468]|
+              8[68]
+            )|
+            9(?:
+              4[15]|
+              5[138]|
+              6[1-3]|
+              7[156]|
+              8[189]|
+              9(?:
+                [1289]|
+                3(?:
+                  31|
+                  4[357]
+                )|
+                4[0178]
+              )
+            )|
+            (?:
+              223|
+              8699
+            )[014-9]|
+            (?:
+              48|
+              829(?:
+                2|
+                66
+              )|
+              9[23]
+            )[1-9]|
+            (?:
+              47[59]|
+              59[89]|
+              8(?:
+                68|
+                9
+              )
+            )[019]
+          </leadingDigits>
+          <format>$1-$2-$3</format>
+        </numberFormat>
+        <numberFormat pattern="(\d{3})(\d{2})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>
+            [14]|
+            [29][2-9]|
+            5[3-9]|
+            7[2-4679]|
+            8(?:
+              [246-9]|
+              3[3-8]|
+              5[2-9]
+            )
+          </leadingDigits>
+          <leadingDigits>
+            [14]|
+            [29][2-9]|
+            5[3-9]|
+            7[2-4679]|
+            8(?:
+              [246-9]|
+              3(?:
+                [3-6][2-9]|
+                7|
+                8[2-5]
+              )|
+              5[2-9]
+            )
           </leadingDigits>
           <format>$1-$2-$3</format>
         </numberFormat>
@@ -14640,14 +15474,14 @@
           <format>$1-$2-$3</format>
           <intlFormat>NA</intlFormat>
         </numberFormat>
-        <numberFormat pattern="(\d{3})(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>800</leadingDigits>
-          <format>$1-$2-$3</format>
-        </numberFormat>
         <numberFormat pattern="(\d{4})(\d{2})(\d{4})">
           <leadingDigits>008</leadingDigits>
           <format>$1-$2-$3</format>
           <intlFormat>NA</intlFormat>
+        </numberFormat>
+        <numberFormat pattern="(\d{3})(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>800</leadingDigits>
+          <format>$1-$2-$3</format>
         </numberFormat>
         <numberFormat pattern="(\d{2})(\d{4})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>
@@ -14692,10 +15526,6 @@
         <possibleLengths national="[8-17]"/>
         <nationalNumberPattern>
           00(?:
-            (?:
-              37|
-              66
-            )\d{4,11}|
             777(?:
               [01]|
               (?:
@@ -14704,7 +15534,11 @@
               )\d
             )|
             882[1245]\d\d
-          )\d\d
+          )\d\d|
+          00(?:
+            37|
+            66
+          )\d{6,13}
         </nationalNumberPattern>
       </noInternationalDialling>
       <fixedLine>
@@ -14778,12 +15612,12 @@
         <possibleLengths national="[8-17]"/>
         <exampleNumber>120123456</exampleNumber>
         <nationalNumberPattern>
-          (?:
-            00(?:
-              (?:
-                37|
-                66
-              )\d{4,11}|
+          00(?:
+            (?:
+              37|
+              66
+            )\d{6,13}|
+            (?:
               777(?:
                 [01]|
                 (?:
@@ -14792,12 +15626,12 @@
                 )\d
               )|
               882[1245]\d\d
-            )|
-            (?:
-              120|
-              800\d
-            )\d{4}
-          )\d\d
+            )\d\d
+          )|
+          (?:
+            120|
+            800\d
+          )\d{6}
         </nationalNumberPattern>
       </tollFree>
       <premiumRate>
@@ -14823,7 +15657,7 @@
       </uan>
     </territory>
 
-    <!-- Kenya -->
+    <!-- Kenya (KE) -->
     <!-- http://www.ca.go.ke/index.php/numbering -->
     <!-- https://www.itu.int/oth/T0202000070/en -->
     <!-- http://en.wikipedia.org/wiki/+254 -->
@@ -14835,7 +15669,7 @@
           <format>$1 $2</format>
         </numberFormat>
         <numberFormat pattern="(\d{3})(\d{6})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>7</leadingDigits>
+          <leadingDigits>[17]</leadingDigits>
           <format>$1 $2</format>
         </numberFormat>
         <numberFormat pattern="(\d{3})(\d{3})(\d{3,4})" nationalPrefixFormattingRule="$NP$FG">
@@ -14846,46 +15680,57 @@
       <generalDesc>
         <nationalNumberPattern>
           (?:
-            (?:
-              2|
-              80
-            )0\d?|
-            [4-7]\d\d|
+            [17]\d\d|
             900
           )\d{6}|
-          [4-6]\d{6,7}
+          (?:
+            2|
+            80
+          )0\d{6,7}|
+          [4-6]\d{6,8}
         </nationalNumberPattern>
       </generalDesc>
       <!-- The prefixes 046, 050, 058, and 066 may appear online in less than 9 digits but
            calling them has confirmed these are outdated. However a 7-digit 068 number was
-           dialed successfully so we consider these valid despite the plan. -->
+           dialed successfully so we consider these valid despite the plan. Range 65 is still
+           supported based on ca.go.ke's doc even though its not mentioned in ITU doc. -->
       <fixedLine>
         <possibleLengths national="[7-9]"/>
         <exampleNumber>202012345</exampleNumber>
         <nationalNumberPattern>
-          20\d{6,7}|
-          (?:
-            4[0-6]|
-            5\d|
-            6[0-24-9]
-          )\d{7}|
-          (?:
-            4[0245]|
-            6[014-9]
-          )\d{6}|
-          5[1-79]\d{5,6}|
           (?:
             4[245]|
+            5[2-79]|
             6[01457-9]
-          )\d{5}
+          )\d{5,7}|
+          (?:
+            4[136]|
+            5[08]|
+            62
+          )\d{7}|
+          (?:
+            [24]0|
+            51|
+            66
+          )\d{6,7}
         </nationalNumberPattern>
       </fixedLine>
       <!-- Per www.ca.go.ke range 1\d{8} is mobile. The range has not been assigned to an operator
-           yet and no working numbers were found online. Not adding the range for now. -->
+           yet and no working numbers were found online. Not adding the range for now.
+           As per Communication authority of Kenya range 10[0-2] is assigned to "Airtel" and 11[01]
+           is assigned to "Safaricom". -->
       <mobile>
         <possibleLengths national="9"/>
         <exampleNumber>712123456</exampleNumber>
-        <nationalNumberPattern>7\d{8}</nationalNumberPattern>
+        <nationalNumberPattern>
+          (?:
+            1(?:
+              0[0-2]|
+              1[01]
+            )|
+            7\d\d
+          )\d{6}
+        </nationalNumberPattern>
       </mobile>
       <!-- Longer numbers have been found than the plan suggests, so we support them here too. -->
       <!-- The plan suggests 0844 and 0845 may belong here, but these are short numbers rather
@@ -14905,21 +15750,26 @@
       </premiumRate>
     </territory>
 
-    <!-- Kyrgyzstan -->
+    <!-- Kyrgyzstan (KG) -->
     <!-- No premiumRate information can be found. -->
     <!-- http://www.itu.int/oth/T0202000074/en -->
     <territory id="KG" countryCode="996" internationalPrefix="00" nationalPrefix="0">
       <availableFormats>
+        <numberFormat pattern="(\d{4})(\d{5})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>
+            3(?:
+              1[346]|
+              [24-79]
+            )
+          </leadingDigits>
+          <format>$1 $2</format>
+        </numberFormat>
         <numberFormat pattern="(\d{3})(\d{3})(\d{3})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>
-            [25-79]|
-            31[25]
+            [235-79]|
+            88
           </leadingDigits>
           <format>$1 $2 $3</format>
-        </numberFormat>
-        <numberFormat pattern="(\d{4})(\d{5})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>3</leadingDigits>
-          <format>$1 $2</format>
         </numberFormat>
         <numberFormat pattern="(\d{3})(\d{3})(\d)(\d{2,3})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>8</leadingDigits>
@@ -14928,11 +15778,11 @@
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
+          8\d{9}|
           (?:
-            [235-7]\d|
+            [235-8]\d|
             99
-          )\d{7}|
-          800\d{6,7}
+          )\d{7}
         </nationalNumberPattern>
       </generalDesc>
       <!-- Extra area codes found on Web Search: 3147. -->
@@ -14940,12 +15790,20 @@
         <possibleLengths national="9" localOnly="5,6"/>
         <exampleNumber>312123456</exampleNumber>
         <nationalNumberPattern>
+          312(?:
+            5[0-79]\d|
+            9(?:
+              [0-689]\d|
+              7[0-24-9]
+            )
+          )\d{3}|
           (?:
             3(?:
               1(?:
-                [256]\d|
+                2[0-46-8]|
                 3[1-9]|
-                47
+                47|
+                [56]\d
               )|
               2(?:
                 22|
@@ -14994,6 +15852,13 @@
         <exampleNumber>700123456</exampleNumber>
         <nationalNumberPattern>
           (?:
+            312(?:
+              58\d|
+              973
+            )|
+            8801\d\d
+          )\d{3}|
+          (?:
             2(?:
               0[0-35]|
               2\d
@@ -15003,7 +15868,7 @@
               [07]\d|
               55
             )|
-            99[69]
+            99[05-9]
           )\d{6}
         </nationalNumberPattern>
       </mobile>
@@ -15016,7 +15881,7 @@
       </tollFree>
     </territory>
 
-    <!-- Cambodia -->
+    <!-- Cambodia (KH) -->
     <!-- http://www.itu.int/oth/T0202000023/en -->
     <!-- http://en.wikipedia.org/wiki/+855 -->
     <territory id="KH" countryCode="855" internationalPrefix="00[14-9]" nationalPrefix="0">
@@ -15048,35 +15913,27 @@
         <possibleLengths national="8,9" localOnly="6,7"/>
         <exampleNumber>23756789</exampleNumber>
         <nationalNumberPattern>
-          (?:
-            2(?:
-              3(?:
-                4(?:
-                  [2-4]|
-                  [56]\d
-                )|
-                [568]\d\d
-              )|
-              [4-6](?:
-                4[56]|
-                [56]\d
-              )\d
-            )|
-            (?:
-              3[2-6]|
-              4[2-4]|
-              [5-7][2-5]
-            )(?:
-              4[56]|
+          23(?:
+            4(?:
+              [2-4]|
               [56]\d
-            )\d
+            )|
+            [568]\d\d
           )\d{4}|
+          23[236-9]\d{5}|
           (?:
-            2[3-6]|
+            2[4-6]|
             3[2-6]|
             4[2-4]|
             [5-7][2-5]
-          )[236-9]\d{5}
+          )(?:
+            (?:
+              [237-9]|
+              4[56]|
+              5\d
+            )\d{5}|
+            6\d{5,6}
+          )
         </nationalNumberPattern>
       </fixedLine>
       <!-- SMART uses prefixes 01[056], 070, 08[167] and 09[368].
@@ -15092,37 +15949,30 @@
         <nationalNumberPattern>
           (?:
             (?:
-              (?:
-                1[28]|
-                9[67]
-              )\d|
-              8(?:
-                [013-79]|
-                8\d
-              )
+              1[28]|
+              3[18]|
+              9[67]
             )\d|
-            (?:
-              2[3-6]|
-              4[2-4]|
-              [56][2-5]
-            )48|
-            3(?:
-              [18]\d\d|
-              [2-6]48
-            )|
+            6[016-9]|
             7(?:
-              (?:
-                [07-9]|
-                [16]\d
-              )\d|
-              [2-5]48
+              [07-9]|
+              [16]\d
+            )|
+            8(?:
+              [013-79]|
+              8\d
             )
-          )\d{5}|
+          )\d{6}|
           (?:
             1\d|
-            6[016-9]|
             9[0-57-9]
-          )\d{6}
+          )\d{6}|
+          (?:
+            2[3-6]|
+            3[2-6]|
+            4[2-4]|
+            [5-7][2-5]
+          )48\d{5}
         </nationalNumberPattern>
       </mobile>
       <!-- Adding extra prefix 180021 used by tollfreetc.com.kh. -->
@@ -15148,13 +15998,12 @@
       </premiumRate>
     </territory>
 
-    <!-- Kiribati -->
+    <!-- Kiribati (KI) -->
     <!-- We include the national prefix for parsing here just in case numbers can be dialled with a
          leading 0 - no numbers online have been found formatted this way, but the ITU document
          lists it as a national dialling prefix. -->
     <!-- http://www.itu.int/oth/T0202000071/en -->
-    <territory id="KI" countryCode="686" internationalPrefix="00" nationalPrefix="0"
-               nationalPrefixOptionalWhenFormatting="true">
+    <territory id="KI" countryCode="686" internationalPrefix="00" nationalPrefix="0">
       <generalDesc>
         <nationalNumberPattern>
           (?:
@@ -15211,19 +16060,12 @@
         <possibleLengths national="8"/>
         <exampleNumber>72001234</exampleNumber>
         <nationalNumberPattern>
+          73140\d{3}|
           (?:
-            6(?:
-              200[01]|
-              30[01]\d
-            )|
-            7(?:
-              200[01]|
-              3(?:
-                0[0-5]\d|
-                140
-              )
-            )
-          )\d{3}
+            630[01]|
+            730[0-5]
+          )\d{4}|
+          [67]200[01]\d{3}
         </nationalNumberPattern>
       </mobile>
       <!-- ITU refers to these as "Overseas Operator" (used to call Phone Group's usage
@@ -15243,7 +16085,7 @@
       </voip>
     </territory>
 
-    <!-- Comoros -->
+    <!-- Comoros (KM) -->
     <!-- http://www.itu.int/oth/T020200002D/en -->
     <territory id="KM" countryCode="269" internationalPrefix="00">
       <availableFormats>
@@ -15258,7 +16100,7 @@
       <!-- CDMA phones are included here, as they are considered as an extension of fixed line:
            http://www.comorestelecom.km/presentationcdma.php -->
       <fixedLine>
-        <possibleLengths national="7"/>
+        <possibleLengths national="7" localOnly="4"/>
         <exampleNumber>7712345</exampleNumber>
         <nationalNumberPattern>7[4-7]\d{5}</nationalNumberPattern>
       </fixedLine>
@@ -15276,11 +16118,12 @@
       </premiumRate>
     </territory>
 
-    <!-- Saint Kitts and Nevis -->
+    <!-- St. Kitts & Nevis (KN) -->
     <!-- Calling code and formatting shared with 'US' -->
     <!-- http://www.itu.int/oth/T02020000B0/en -->
     <territory id="KN" countryCode="1" leadingDigits="869" internationalPrefix="011"
-               nationalPrefix="1">
+               nationalPrefix="1" nationalPrefixForParsing="1|([2-7]\d{6})$"
+               nationalPrefixTransformRule="869$1">
       <generalDesc>
         <nationalNumberPattern>
           (?:
@@ -15362,16 +16205,16 @@
       </personalNumber>
     </territory>
 
-    <!-- Korea, Dem. People's Rep. of -->
+    <!-- North Korea (KP) -->
     <!-- http://en.wikipedia.org/wiki/%2B850 -->
     <territory id="KP" countryCode="850" internationalPrefix="00|99" nationalPrefix="0">
       <availableFormats>
-        <numberFormat pattern="(\d)(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>2</leadingDigits>
-          <format>$1 $2 $3</format>
-        </numberFormat>
         <numberFormat pattern="(\d{2})(\d{3})(\d{3})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>8</leadingDigits>
+          <format>$1 $2 $3</format>
+        </numberFormat>
+        <numberFormat pattern="(\d)(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>2</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
         <numberFormat pattern="(\d{3})(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
@@ -15381,26 +16224,22 @@
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
+          85\d{6}|
           (?:
-            (?:
-              19\d|
-              2
-            )\d|
-            85
-          )\d{6}
+            19\d|
+            2
+          )\d{7}
         </nationalNumberPattern>
       </generalDesc>
       <!-- For numbers starting with 2, only the 2381 range can be dialed internationally. -->
       <noInternationalDialling>
         <possibleLengths national="8"/>
         <nationalNumberPattern>
+          238[02-9]\d{4}|
           2(?:
-            [0-24-9]\d\d|
-            3(?:
-              [0-79]\d|
-              8[02-9]
-            )
-          )\d{4}
+            [0-24-9]\d|
+            3[0-79]
+          )\d{5}
         </nationalNumberPattern>
       </noInternationalDialling>
       <!-- Covers only numbers from Pyongyang and Rason Economic Special Zone. According to
@@ -15424,7 +16263,7 @@
       </mobile>
     </territory>
 
-    <!-- Korea (Rep. of) -->
+    <!-- South Korea (KR) -->
     <!-- Exceptions :
          internationalPrefix
              0031, 0033, 0071, 0073 - Special services of KT and DACOM, ignorable.
@@ -15440,12 +16279,20 @@
     <!-- http://www.telecentro.co.kr/sub/index.php?job=detail&ebcf_id=faq&page=1&mid=0503&eb_seq=36 -->
     <territory id="KR" countryCode="82"
                internationalPrefix="00(?:[125689]|3(?:[46]5|91)|7(?:00|27|3|55|6[126]))"
-               nationalPrefix="0" nationalPrefixForParsing="0(8[1-46-8]|85\d{2})?"
-               nationalPrefixFormattingRule="$NP$FG" carrierCodeFormattingRule="$NP$CC-$FG"
+               nationalPrefix="0" nationalPrefixForParsing="0(8(?:[1-46-8]|5\d\d))?"
                mobileNumberPortableRegion="true">
       <availableFormats>
+        <!-- Format for 5 digit short codes. -->
+        <numberFormat pattern="(\d{5})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>1[016-9]1</leadingDigits>
+          <leadingDigits>1[016-9]11</leadingDigits>
+          <leadingDigits>1[016-9]114</leadingDigits>
+          <format>$1</format>
+          <intlFormat>NA</intlFormat>
+        </numberFormat>
         <!-- Fixed-line number ranges with 5-6 digits. -->
-        <numberFormat pattern="(\d{2})(\d{3,4})">
+        <numberFormat pattern="(\d{2})(\d{3,4})" nationalPrefixFormattingRule="$NP$FG"
+                      carrierCodeFormattingRule="$NP$CC-$FG">
           <leadingDigits>
             (?:
               3[1-3]|
@@ -15456,136 +16303,83 @@
           <format>$1-$2</format>
         </numberFormat>
         <!-- UAN numbers. -->
-        <numberFormat pattern="(\d{4})(\d{4})" nationalPrefixFormattingRule="$FG">
-          <leadingDigits>
-            1(?:
-              5[246-9]|
-              6[046-8]|
-              8[03579]
-            )
-          </leadingDigits>
-          <leadingDigits>
-            1(?:
-              5(?:
-                22|
-                44|
-                66|
-                77|
-                88|
-                99
-              )|
-              6(?:
-                [07]0|
-                44|
-                6[16]|
-                88
-              )|
-              8(?:
-                00|
-                33|
-                55|
-                77|
-                99
-              )
-            )
-          </leadingDigits>
+        <numberFormat pattern="(\d{4})(\d{4})">
+          <leadingDigits>1</leadingDigits>
           <format>$1-$2</format>
         </numberFormat>
-        <numberFormat pattern="(\d{5})">
-          <leadingDigits>1[016-9]1</leadingDigits>
-          <leadingDigits>1[016-9]11</leadingDigits>
-          <leadingDigits>1[016-9]114</leadingDigits>
-          <format>$1</format>
-        </numberFormat>
         <!-- Fixed-line number ranges with 8-9 digits. -->
-        <numberFormat pattern="(\d)(\d{3,4})(\d{4})">
-          <leadingDigits>2[1-9]</leadingDigits>
+        <numberFormat pattern="(\d)(\d{3,4})(\d{4})" nationalPrefixFormattingRule="$NP$FG"
+                      carrierCodeFormattingRule="$NP$CC-$FG">
+          <leadingDigits>2</leadingDigits>
           <format>$1-$2-$3</format>
         </numberFormat>
         <!-- Premium-rate and 9-digit toll-free numbers. -->
-        <numberFormat pattern="(\d{2})(\d{3})(\d{4})">
+        <numberFormat pattern="(\d{2})(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG"
+                      carrierCodeFormattingRule="$NP$CC-$FG">
           <leadingDigits>
-            60[2-9]|
-            80
+            60|
+            8
           </leadingDigits>
           <format>$1-$2-$3</format>
         </numberFormat>
         <!-- Mobile, pager, and fixed-line number ranges with 9-10 digits. -->
-        <numberFormat pattern="(\d{2})(\d{3,4})(\d{4})">
+        <numberFormat pattern="(\d{2})(\d{3,4})(\d{4})" nationalPrefixFormattingRule="$NP$FG"
+                      carrierCodeFormattingRule="$NP$CC-$FG">
           <leadingDigits>
-            1[0-25-9]|
-            (?:
-              3[1-3]|
-              [46][1-4]|
-              5[1-5]
-            )[1-9]
+            [1346]|
+            5[1-5]
           </leadingDigits>
           <format>$1-$2-$3</format>
         </numberFormat>
         <!-- 10 digit personal and VOIP numbers. -->
-        <numberFormat pattern="(\d{2})(\d{4})(\d{4})">
-          <leadingDigits>[57]0</leadingDigits>
-          <format>$1-$2-$3</format>
-        </numberFormat>
-        <!-- 11 digit personal numbers. -->
-        <numberFormat pattern="(\d{2})(\d{5})(\d{4})">
-          <leadingDigits>50</leadingDigits>
+        <numberFormat pattern="(\d{2})(\d{4})(\d{4})" nationalPrefixFormattingRule="$NP$FG"
+                      carrierCodeFormattingRule="$NP$CC-$FG">
+          <leadingDigits>[57]</leadingDigits>
           <format>$1-$2-$3</format>
         </numberFormat>
         <!-- Toll-free numbers with 11 digits. -->
-        <numberFormat pattern="(\d{5})(\d{3})(\d{3})" nationalPrefixFormattingRule="$FG">
+        <numberFormat pattern="(\d{5})(\d{3})(\d{3})">
           <leadingDigits>003</leadingDigits>
           <leadingDigits>0030</leadingDigits>
-          <leadingDigits>00308</leadingDigits>
           <format>$1 $2 $3</format>
           <intlFormat>NA</intlFormat>
         </numberFormat>
+        <!-- 11 digit personal numbers. -->
+        <numberFormat pattern="(\d{2})(\d{5})(\d{4})" nationalPrefixFormattingRule="$NP$FG"
+                      carrierCodeFormattingRule="$NP$CC-$FG">
+          <leadingDigits>5</leadingDigits>
+          <format>$1-$2-$3</format>
+        </numberFormat>
         <!-- Toll-free numbers with 12-13 digits. -->
-        <numberFormat pattern="(\d{5})(\d{3,4})(\d{4})" nationalPrefixFormattingRule="$FG">
-          <leadingDigits>00[37]</leadingDigits>
-          <leadingDigits>
-            00(?:
-              36|
-              79
-            )
-          </leadingDigits>
-          <leadingDigits>
-            00(?:
-              36|
-              79
-            )8
-          </leadingDigits>
+        <numberFormat pattern="(\d{5})(\d{3,4})(\d{4})">
+          <leadingDigits>0</leadingDigits>
           <format>$1 $2 $3</format>
           <intlFormat>NA</intlFormat>
         </numberFormat>
         <!-- Toll-free numbers with 14 digits. -->
-        <numberFormat pattern="(\d{5})(\d{2})(\d{3})(\d{4})" nationalPrefixFormattingRule="$FG">
-          <leadingDigits>007</leadingDigits>
-          <leadingDigits>0079</leadingDigits>
-          <leadingDigits>00798</leadingDigits>
+        <numberFormat pattern="(\d{5})(\d{2})(\d{3})(\d{4})">
+          <leadingDigits>0</leadingDigits>
           <format>$1 $2 $3 $4</format>
           <intlFormat>NA</intlFormat>
         </numberFormat>
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
+          00[1-9]\d{8,11}|
           (?:
-            00[1-9]\d{2,4}|
             [12]|
             5\d{3}
           )\d{7}|
-          (?:
-            (?:
-              00|
-              [13-6]
-            )\d|
-            70
-          )\d{8}|
+          [13-6]\d{9}|
           (?:
             [1-6]\d|
             80
           )\d{7}|
-          [3-6]\d{4,5}
+          [3-6]\d{4,5}|
+          (?:
+            00|
+            7
+          )0\d{8}
         </nationalNumberPattern>
       </generalDesc>
       <!-- 00798 ITFS numbers can't be dialled internationally. -->
@@ -15596,35 +16390,52 @@
         <nationalNumberPattern>
           00(?:
             3(?:
-              08|
-              68\d
+              08\d{6,7}|
+              68\d{7}
             )|
-            798\d{1,3}
-          )\d{6}
+            798\d{7,9}
+          )
         </nationalNumberPattern>
       </noInternationalDialling>
       <!-- We omit 049, supposedly for Kaesong Industrial Region, since real numbers can't be
            found, and it is in North Korea anyway. We support 7-8 digits long subscriber numbers
-           starting with 1 based on evidence of real numbers found online. -->
+           starting with 1 based on evidence of real numbers found online. Some short codes
+           (1\d{2,3}) can be dialled with area codes. So we are supporting them when they are
+           prefixed with valid area codes. -->
       <fixedLine>
-        <possibleLengths national="5,6,[8-10]" localOnly="3,7"/>
+        <possibleLengths national="5,6,[8-10]" localOnly="3,4,7"/>
         <exampleNumber>22123456</exampleNumber>
         <nationalNumberPattern>
-          2[1-9]\d{6,7}|
+          (?:
+            2|
+            3[1-3]|
+            [46][1-4]|
+            5[1-5]
+          )[1-9]\d{6,7}|
           (?:
             3[1-3]|
             [46][1-4]|
             5[1-5]
-          )(?:
-            1\d{2,3}|
-            [1-9]\d{6,7}
-          )
+          )1\d{2,3}
         </nationalNumberPattern>
       </fixedLine>
       <mobile>
         <possibleLengths national="9,10"/>
-        <exampleNumber>1000000000</exampleNumber>
-        <nationalNumberPattern>1[0-26-9]\d{7,8}</nationalNumberPattern>
+        <exampleNumber>1020000000</exampleNumber>
+        <nationalNumberPattern>
+          1(?:
+            05(?:
+              [0-8]\d|
+              9[1-5]
+            )|
+            22[13]\d
+          )\d{4,5}|
+          1(?:
+            0[1-46-9]|
+            [16-9]\d|
+            2[013-9]
+          )\d{6,7}
+        </nationalNumberPattern>
       </mobile>
       <pager>
         <possibleLengths national="9,10"/>
@@ -15635,16 +16446,14 @@
         <possibleLengths national="9,[11-14]"/>
         <exampleNumber>801234567</exampleNumber>
         <nationalNumberPattern>
+          00(?:
+            308\d{6,7}|
+            798\d{7,9}
+          )|
           (?:
-            00(?:
-              3(?:
-                08|
-                68\d
-              )|
-              798\d{1,3}
-            )|
-            80\d
-          )\d{6}
+            00368|
+            80
+          )\d{7}
         </nationalNumberPattern>
       </tollFree>
       <!-- The information below is provided by a Korean person. -->
@@ -15679,10 +16488,9 @@
               99
             )|
             6(?:
-              00|
+              [07]0|
               44|
               6[16]|
-              70|
               88
             )|
             8(?:
@@ -15697,7 +16505,7 @@
       </uan>
     </territory>
 
-    <!-- Kuwait -->
+    <!-- Kuwait (KW) -->
     <!-- No tollFree or premiumRate information can be found. -->
     <!-- http://www.itu.int/oth/T0202000073/en -->
     <territory id="KW" countryCode="965" internationalPrefix="00" mobileNumberPortableRegion="true">
@@ -15755,49 +16563,46 @@
         <nationalNumberPattern>
           (?:
             5(?:
-              (?:
-                [05]\d|
-                1[0-7]|
-                6[56]
-              )\d|
               2(?:
                 22|
                 5[25]
-              )
+              )|
+              88[58]
             )|
             6(?:
-              (?:
-                0[034679]|
-                5[015-9]|
-                6\d
-              )\d|
               222|
-              7(?:
-                0[013-9]|
-                [67]\d
-              )|
-              9(?:
-                [069]\d|
-                3[039]
-              )
+              444|
+              70[013-9]|
+              888|
+              93[039]
             )|
             9(?:
-              (?:
-                0[09]|
-                22|
-                4[01479]|
-                55|
-                6[0679]|
-                8[057-9]|
-                9\d
-              )\d|
               11[01]|
-              7(?:
-                02|
-                [1-9]\d
-              )
+              333|
+              500
             )
-          )\d{4}
+          )\d{4}|
+          (?:
+            5(?:
+              [05]\d|
+              1[0-7]|
+              6[56]
+            )|
+            6(?:
+              0[034679]|
+              5[015-9]|
+              6\d|
+              7[67]|
+              9[069]
+            )|
+            9(?:
+              0[09]|
+              22|
+              [4679]\d|
+              55|
+              8[057-9]
+            )
+          )\d{5}
         </nationalNumberPattern>
       </mobile>
       <!-- 18XX XXX was earlier assigned to Fixedline but the latest ITU Doc and also citra.gov.kw
@@ -15809,11 +16614,12 @@
       </tollFree>
     </territory>
 
-    <!-- Cayman Islands -->
+    <!-- Cayman Islands (KY) -->
     <!-- Calling code and formatting shared with 'US' -->
     <!-- http://www.itu.int/oth/T0202000027/en -->
     <territory id="KY" countryCode="1" leadingDigits="345" internationalPrefix="011"
-               nationalPrefix="1" mobileNumberPortableRegion="true">
+               nationalPrefix="1" nationalPrefixForParsing="1|([2-9]\d{6})$"
+               nationalPrefixTransformRule="345$1" mobileNumberPortableRegion="true">
       <generalDesc>
         <nationalNumberPattern>
           (?:
@@ -15933,7 +16739,7 @@
       </personalNumber>
     </territory>
 
-    <!-- Kazakhstan -->
+    <!-- Kazakhstan (KZ) -->
     <!-- Calling code and formatting shared with 'RU' -->
     <!-- http://www.itu.int/oth/T020200006F/en -->
     <!-- https://telecom.kz/en/catalog/kazahstan.171777/5 -->
@@ -15941,13 +16747,11 @@
                internationalPrefix="810" nationalPrefix="8">
       <generalDesc>
         <nationalNumberPattern>
+          33622\d{5}|
           (?:
-            33622|
-            (?:
-              7\d|
-              80
-            )\d{3}
-          )\d{5}
+            7\d|
+            80
+          )\d{8}
         </nationalNumberPattern>
       </generalDesc>
       <noInternationalDialling>
@@ -15958,7 +16762,7 @@
            22), which is within Kazakhstan but in fact rented and administered by Russia at the
            moment. Added 7279 from numbers found online. -->
       <fixedLine>
-        <possibleLengths national="10"/>
+        <possibleLengths national="10" localOnly="5,6"/>
         <exampleNumber>7123456789</exampleNumber>
         <nationalNumberPattern>
           (?:
@@ -16069,7 +16873,7 @@
         <exampleNumber>7710009998</exampleNumber>
         <nationalNumberPattern>
           7(?:
-            0[0-2578]|
+            0[0-25-8]|
             47|
             6[02-4]|
             7[15-8]|
@@ -16100,7 +16904,7 @@
       </voip>
     </territory>
 
-    <!-- Lao People's Dem. Rep. -->
+    <!-- Laos (LA) -->
     <!-- Seems incomplete -->
     <!-- http://www.itu.int/oth/T0202000075/en -->
     <!-- http://en.wikipedia.org/wiki/+856 -->
@@ -16156,10 +16960,9 @@
         <exampleNumber>2023123456</exampleNumber>
         <nationalNumberPattern>
           20(?:
-            2[2389]|
+            [29]\d|
             5[24-689]|
-            7[6-8]|
-            9[1-35-9]
+            7[6-8]
           )\d{6}
         </nationalNumberPattern>
       </mobile>
@@ -16173,7 +16976,7 @@
       </uan>
     </territory>
 
-    <!-- Lebanon -->
+    <!-- Lebanon (LB) -->
     <!-- http://www.itu.int/oth/T0202000077/en -->
     <!-- http://en.wikipedia.org/wiki/%2B961 -->
     <territory id="LB" countryCode="961" internationalPrefix="00" nationalPrefix="0">
@@ -16226,6 +17029,10 @@
         <possibleLengths national="7,8"/>
         <exampleNumber>71123456</exampleNumber>
         <nationalNumberPattern>
+          793(?:
+            [01]\d|
+            2[0-4]
+          )\d{3}|
           (?:
             (?:
               3|
@@ -16235,7 +17042,7 @@
               [01]\d|
               6[013-9]|
               8[89]|
-              9[1-3]
+              9[12]
             )
           )\d{5}
         </nationalNumberPattern>
@@ -16252,11 +17059,12 @@
       </sharedCost>
     </territory>
 
-    <!-- Saint Lucia -->
+    <!-- St. Lucia (LC) -->
     <!-- Calling code and formatting shared with 'US' -->
     <!-- http://www.itu.int/oth/T02020000B1/en -->
     <territory id="LC" countryCode="1" leadingDigits="758" internationalPrefix="011"
-               nationalPrefix="1">
+               nationalPrefix="1" nationalPrefixForParsing="1|([2-7]\d{6})$"
+               nationalPrefixTransformRule="758$1">
       <generalDesc>
         <nationalNumberPattern>
           (?:
@@ -16345,13 +17153,13 @@
       </personalNumber>
     </territory>
 
-    <!-- Liechtenstein -->
+    <!-- Liechtenstein (LI) -->
     <!-- The national prefix of "0" is only used for 0800 and 0900 numbers. Three carrier-selection
          codes are in use. -->
     <!-- http://www.llv.li/#/11193 -->
     <!-- https://www.itu.int/oth/T020200007B/en -->
     <territory id="LI" countryCode="423" internationalPrefix="00" nationalPrefix="0"
-               nationalPrefixForParsing="0|(10(?:01|20|66))">
+               nationalPrefixForParsing="0|(1001)">
       <availableFormats>
         <!-- Number format for national mobile services, fixed-line, toll-free, UAN and premium rate services.
              Some different patterns for tollfree and shared cost numbers may be found by searching
@@ -16360,26 +17168,24 @@
           <leadingDigits>[237-9]</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
-        <!-- Number format for international mobile services. -->
-        <numberFormat pattern="(\d{3})(\d{3})(\d{3})" carrierCodeFormattingRule="$CC $FG">
-          <leadingDigits>6[56]</leadingDigits>
-          <format>$1 $2 $3</format>
-        </numberFormat>
         <!-- Number format for voicemail services. -->
         <numberFormat pattern="(\d{2})(\d{3})(\d{4})" carrierCodeFormattingRule="$CC $FG">
+          <leadingDigits>69</leadingDigits>
+          <format>$1 $2 $3</format>
+        </numberFormat>
+        <!-- Number format for international mobile services. -->
+        <numberFormat pattern="(\d{3})(\d{3})(\d{3})" carrierCodeFormattingRule="$CC $FG">
           <leadingDigits>6</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
+          90\d{5}|
           (?:
-            (?:
-              [2378]|
-              6\d\d
-            )\d|
-            90
-          )\d{5}
+            [2378]|
+            6\d\d
+          )\d{6}
         </nationalNumberPattern>
       </generalDesc>
       <fixedLine>
@@ -16390,11 +17196,14 @@
             2(?:
               01|
               1[27]|
+              22|
               3\d|
               6[02-578]|
               96
             )|
             3(?:
+              33|
+              40|
               7[0135-7]|
               8[048]|
               9[0269]
@@ -16408,13 +17217,13 @@
         <nationalNumberPattern>
           (?:
             6(?:
-              5(?:
-                09|
-                1\d|
-                20
+              4(?:
+                89|
+                9\d
               )|
+              5[0-3]\d|
               6(?:
-                0[0-6]|
+                0[0-7]|
                 10|
                 2[06-9]|
                 39
@@ -16477,20 +17286,20 @@
       </voicemail>
     </territory>
 
-    <!-- Sri Lanka -->
+    <!-- Sri Lanka (LK) -->
     <!-- http://en.wikipedia.org/wiki/%2B94 -->
     <!-- http://www.itu.int/oth/T02020000C3/en -->
     <territory id="LK" countryCode="94" internationalPrefix="00" nationalPrefix="0">
       <availableFormats>
+        <!-- Format for mobile numbers. -->
+        <numberFormat pattern="(\d{2})(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>7</leadingDigits>
+          <format>$1 $2 $3</format>
+        </numberFormat>
         <!-- Format for fixed-line numbers. The two digit area code and single digit operator
              codes are grouped as it is the most common way of writing fixed-line numbers in LK. -->
         <numberFormat pattern="(\d{3})(\d{3})(\d{3})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>[1-689]</leadingDigits>
-          <format>$1 $2 $3</format>
-        </numberFormat>
-        <!-- Format for mobile numbers. -->
-        <numberFormat pattern="(\d{2})(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>7</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
       </availableFormats>
@@ -16537,7 +17346,7 @@
       </uan>
     </territory>
 
-    <!-- Liberia -->
+    <!-- Liberia (LR) -->
     <!-- http://www.itu.int/oth/T0202000079/en -->
     <territory id="LR" countryCode="231" internationalPrefix="00" nationalPrefix="0">
       <availableFormats>
@@ -16552,22 +17361,20 @@
           <format>$1 $2 $3</format>
         </numberFormat>
         <numberFormat pattern="(\d{2})(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>[23578]</leadingDigits>
+          <leadingDigits>[3578]</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
           (?:
-            [25]\d|
+            2|
             33|
+            5\d|
             77|
             88
           )\d{7}|
-          (?:
-            2\d|
-            [45]
-          )\d{6}
+          [45]\d{6}
         </nationalNumberPattern>
       </generalDesc>
       <fixedLine>
@@ -16587,13 +17394,12 @@
         <nationalNumberPattern>
           (?:
             (?:
+              330|
+              555|
               (?:
-                20|
                 77|
                 88
-              )\d|
-              330|
-              555
+              )\d
             )\d|
             4[67]
           )\d{5}|
@@ -16612,7 +17418,7 @@
       </premiumRate>
     </territory>
 
-    <!-- Lesotho -->
+    <!-- Lesotho (LS) -->
     <!-- http://www.itu.int/oth/T0202000078/en -->
     <territory id="LS" countryCode="266" internationalPrefix="00">
       <availableFormats>
@@ -16647,22 +17453,29 @@
       </tollFree>
     </territory>
 
-    <!-- Lithuania -->
+    <!-- Lithuania (LT) -->
     <!-- Note that Lithuania is switching to a national prefix of 0. We support
          both 0 and 8 when parsing until this switch is complete. -->
     <!-- http://www.itu.int/oth/T020200007C/en -->
     <!-- National Prefix formatting rule from http://www.yellowpages.lt -->
     <territory id="LT" countryCode="370" internationalPrefix="00" nationalPrefix="8"
-               nationalPrefixForParsing="[08]" nationalPrefixOptionalWhenFormatting="true"
-               mobileNumberPortableRegion="true">
+               nationalPrefixForParsing="[08]" mobileNumberPortableRegion="true">
       <availableFormats>
         <!-- 1 digit area code (fixed line only) -->
-        <numberFormat pattern="(\d)(\d{3})(\d{4})" nationalPrefixFormattingRule="($NP-$FG)">
+        <numberFormat pattern="(\d)(\d{3})(\d{4})" nationalPrefixFormattingRule="($NP-$FG)"
+                      nationalPrefixOptionalWhenFormatting="true">
           <leadingDigits>52[0-79]</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
+        <!-- Non-geographic numbers (toll free, UAN etc.) -->
+        <numberFormat pattern="(\d{3})(\d{2})(\d{3})" nationalPrefixFormattingRule="$NP $FG"
+                      nationalPrefixOptionalWhenFormatting="true">
+          <leadingDigits>[7-9]</leadingDigits>
+          <format>$1 $2 $3</format>
+        </numberFormat>
         <!-- 2 digit area codes (fixed line only) -->
-        <numberFormat pattern="(\d{2})(\d{6})" nationalPrefixFormattingRule="($NP-$FG)">
+        <numberFormat pattern="(\d{2})(\d{6})" nationalPrefixFormattingRule="($NP-$FG)"
+                      nationalPrefixOptionalWhenFormatting="true">
           <leadingDigits>
             37|
             4(?:
@@ -16673,14 +17486,10 @@
           <format>$1 $2</format>
         </numberFormat>
         <!-- 3 digit area codes and other formats (mobile etc.) -->
-        <numberFormat pattern="(\d{3})(\d{5})" nationalPrefixFormattingRule="($NP-$FG)">
+        <numberFormat pattern="(\d{3})(\d{5})" nationalPrefixFormattingRule="($NP-$FG)"
+                      nationalPrefixOptionalWhenFormatting="true">
           <leadingDigits>[3-6]</leadingDigits>
           <format>$1 $2</format>
-        </numberFormat>
-        <!-- Non-geographic numbers (toll free, UAN etc.) -->
-        <numberFormat pattern="(\d{3})(\d{2})(\d{3})" nationalPrefixFormattingRule="$NP $FG">
-          <leadingDigits>[7-9]</leadingDigits>
-          <format>$1 $2 $3</format>
         </numberFormat>
       </availableFormats>
       <generalDesc>
@@ -16741,7 +17550,7 @@
       </uan>
     </territory>
 
-    <!-- Luxembourg -->
+    <!-- Luxembourg (LU) -->
     <!-- https://web.ilr.lu/FR/Professionnels/Communications-electroniques/Pages/HomePage.aspx -->
     <!-- http://legilux.public.lu/eli/etat/leg/rilr/2014/07/14/n2/jo -->
     <territory id="LU" countryCode="352" internationalPrefix="00"
@@ -16755,11 +17564,7 @@
               0[2-689]|
               [2-9]
             )|
-            3(?:
-              [0-46-9]|
-              5[013-9]
-            )|
-            [457]|
+            [3-57]|
             8(?:
               0[2-9]|
               [13-9]
@@ -16779,11 +17584,7 @@
               0[2-689]|
               [2-9]
             )|
-            3(?:
-              [0-46-9]|
-              5[013-9]
-            )|
-            [457]|
+            [3-57]|
             8(?:
               0[2-9]|
               [13-9]
@@ -16800,12 +17601,11 @@
           <leadingDigits>20[2-689]</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
-        <!-- This format is for 8 digit fixed-line ranges. -->
+        <!-- This format is for 7 and 8 digit fixed-line ranges. -->
         <numberFormat pattern="(\d{2})(\d{2})(\d{2})(\d{1,2})" carrierCodeFormattingRule="$CC $FG">
           <leadingDigits>
             2(?:
-              0[1-689]|
-              [367]|
+              [0367]|
               4[3-8]
             )
           </leadingDigits>
@@ -16821,7 +17621,7 @@
         </numberFormat>
         <!-- This format is for 9 digit fixed-line ranges. -->
         <numberFormat pattern="(\d{2})(\d{2})(\d{2})(\d{3})" carrierCodeFormattingRule="$CC $FG">
-          <leadingDigits>20[2-689]</leadingDigits>
+          <leadingDigits>20</leadingDigits>
           <format>$1 $2 $3 $4</format>
         </numberFormat>
         <!-- Format for mobile numbers. -->
@@ -16834,47 +17634,38 @@
                       carrierCodeFormattingRule="$CC $FG">
           <leadingDigits>
             2(?:
-              0[2-689]|
-              [367]|
+              [0367]|
               4[3-8]
             )
           </leadingDigits>
           <format>$1 $2 $3 $4 $5</format>
         </numberFormat>
-        <!-- This format is for some 7 to 11 digit fixed-line ranges. We consider numbers starting
-             with 240 and 249 valid, but we do not format them, as we found no examples of
-             such numbers online. -->
+        <!-- This format is for 7 to 11 digit fixed-line ranges. -->
         <numberFormat pattern="(\d{2})(\d{2})(\d{2})(\d{1,5})" carrierCodeFormattingRule="$CC $FG">
           <leadingDigits>
-            2[2-9]|
-            3(?:
-              [0-46-9]|
-              5[013-9]
-            )|
-            [457]|
-            8(?:
-              0[2-9]|
-              [13-9]
-            )|
+            [3-57]|
+            8[13-9]|
             9(?:
               0[89]|
               [2-579]
-            )
+            )|
+            (?:
+              2|
+              80
+            )[2-9]
           </leadingDigits>
           <format>$1 $2 $3 $4</format>
         </numberFormat>
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
-          [2457-9]\d{3,10}|
-          3(?:
-            [0-46-9]\d{2,9}|
-            5(?:
-              [013-9]\d{1,8}|
-              2\d{1,3}
-            )
-          )|
-          6\d{8}
+          35[013-9]\d{4,8}|
+          6\d{8}|
+          35\d{2,4}|
+          (?:
+            [2457-9]\d|
+            3[0-46-9]
+          )\d{2,9}
         </nationalNumberPattern>
       </generalDesc>
       <!-- Even though 20 is listed in the fixed-line plan, other documentation clarify that it is
@@ -16886,23 +17677,17 @@
         <exampleNumber>27123456</exampleNumber>
         <nationalNumberPattern>
           (?:
-            (?:
-              2[2-9]|
-              [457]\d
-            )\d|
-            3(?:
-              [0-46-9]\d|
-              5[013-9]
-            )|
-            8(?:
-              0[2-9]|
-              [13-9]\d
-            )|
-            9(?:
-              0[89]|
-              [2-579]\d
-            )
-          )\d{1,8}
+            35[013-9]|
+            80[2-9]|
+            90[89]
+          )\d{1,8}|
+          (?:
+            2[2-9]|
+            3[0-46-9]|
+            [457]\d|
+            8[13-9]|
+            9[2-579]
+          )\d{2,9}
         </nationalNumberPattern>
       </fixedLine>
       <!-- 679 (9 digit) are mentioned as "special mobile services" in ilr.lu's doc. Supporting here
@@ -16954,7 +17739,7 @@
       </voip>
     </territory>
 
-    <!-- Latvia -->
+    <!-- Latvia (LV) -->
     <!-- http://www.itu.int/oth/T0202000076/en -->
     <!-- http://en.wikipedia.org/wiki/+371 -->
     <territory id="LV" countryCode="371" internationalPrefix="00" mobileNumberPortableRegion="true">
@@ -17002,7 +17787,7 @@
       </sharedCost>
     </territory>
 
-    <!-- Libya (Soc. People’s Libyan Arab Jamahiriya) -->
+    <!-- Libya (LY) -->
     <!-- Status as of 21 Jan 2011: a lot of outdated information on the web including on wikipedia
          and itu.int. The new area codes are on the Arabic website of the main telecommunication
          operator (Hatef Libya). A new mobile operator Aljeel Aljadeed for Technology will start
@@ -17012,28 +17797,55 @@
     <territory id="LY" countryCode="218" internationalPrefix="00" nationalPrefix="0">
       <availableFormats>
         <numberFormat pattern="(\d{2})(\d{7})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>[25-79]</leadingDigits>
+          <leadingDigits>[2-9]</leadingDigits>
           <format>$1-$2</format>
         </numberFormat>
       </availableFormats>
       <generalDesc>
-        <nationalNumberPattern>
-          (?:
-            [2569]\d|
-            71
-          )\d{7}
-        </nationalNumberPattern>
+        <nationalNumberPattern>[2-9]\d{8}</nationalNumberPattern>
       </generalDesc>
       <fixedLine>
         <possibleLengths national="9" localOnly="7"/>
         <exampleNumber>212345678</exampleNumber>
         <nationalNumberPattern>
           (?:
-            2[13-5]|
-            5[1347]|
-            6[1-479]|
-            71
-          )\d{7}
+            2(?:
+              0[56]|
+              [1-6]\d|
+              7[124579]|
+              8[124]
+            )|
+            3(?:
+              1\d|
+              2[2356]
+            )|
+            4(?:
+              [17]\d|
+              2[1-357]|
+              5[2-4]|
+              8[124]
+            )|
+            5(?:
+              [1347]\d|
+              2[1-469]|
+              5[13-5]|
+              8[1-4]
+            )|
+            6(?:
+              [1-479]\d|
+              5[2-57]|
+              8[1-5]
+            )|
+            7(?:
+              [13]\d|
+              2[13-79]
+            )|
+            8(?:
+              [124]\d|
+              5[124]|
+              84
+            )
+          )\d{6}
         </nationalNumberPattern>
       </fixedLine>
       <!-- The prefix 094 has been added on the strength of numbers found online, and numbers
@@ -17045,7 +17857,7 @@
       </mobile>
     </territory>
 
-    <!-- Morocco -->
+    <!-- Morocco (MA) -->
     <!-- Main region for 'EH' -->
     <!-- http://www.itu.int/oth/T0202000090/en -->
     <!-- http://en.wikipedia.org/wiki/+212 -->
@@ -17054,15 +17866,25 @@
     <territory id="MA" mainCountryForCode="true" countryCode="212" internationalPrefix="00"
                nationalPrefix="0" mobileNumberPortableRegion="true">
       <availableFormats>
-        <numberFormat pattern="(\d{3})(\d{6})" nationalPrefixFormattingRule="$NP$FG">
+        <numberFormat pattern="(\d{5})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>
             5(?:
-              2[015-7]|
-              3[0-4]
-            )|
-            [67]
+              29|
+              38
+            )
+          </leadingDigits>
+          <leadingDigits>
+            5(?:
+              29|
+              38
+            )[89]
           </leadingDigits>
           <format>$1-$2</format>
+        </numberFormat>
+        <!-- This format is added based on online references found. -->
+        <numberFormat pattern="(\d{3})(\d{2})(\d{2})(\d{2})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>5[45]</leadingDigits>
+          <format>$1 $2 $3 $4</format>
         </numberFormat>
         <numberFormat pattern="(\d{4})(\d{5})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>
@@ -17073,56 +17895,43 @@
             )|
             892
           </leadingDigits>
-          <leadingDigits>
-            5(?:
-              2(?:
-                [2-48]|
-                9[0-7]
-              )|
-              3(?:
-                [5-79]|
-                8[0-7]
-              )|
-              9
-            )|
-            892
-          </leadingDigits>
           <format>$1-$2</format>
-        </numberFormat>
-        <numberFormat pattern="(\d{5})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>5[23]</leadingDigits>
-          <format>$1-$2</format>
-        </numberFormat>
-        <!-- This format is added based on online references found. -->
-        <numberFormat pattern="(\d{3})(\d{2})(\d{2})(\d{2})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>5</leadingDigits>
-          <format>$1 $2 $3 $4</format>
         </numberFormat>
         <numberFormat pattern="(\d{2})(\d{7})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>8</leadingDigits>
+          <format>$1-$2</format>
+        </numberFormat>
+        <numberFormat pattern="(\d{3})(\d{6})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>[5-7]</leadingDigits>
           <format>$1-$2</format>
         </numberFormat>
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>[5-8]\d{8}</nationalNumberPattern>
       </generalDesc>
-      <!-- Prefix 5364 was added from a user report. -->
+      <!-- Prefix 5220 and 5364 was added from a user report. -->
       <fixedLine>
         <possibleLengths national="9"/>
         <exampleNumber>520123456</exampleNumber>
         <nationalNumberPattern>
           5(?:
+            29|
+            38
+          )[89]0\d{4}|
+          5(?:
             2(?:
-              [015-79]\d|
+              [015-7]\d|
               2[02-9]|
-              3[2-57]|
-              4[2-8]|
-              8[235-7]
+              3[2-578]|
+              4[2-46-8]|
+              8[235-7]|
+              90
             )|
             3(?:
-              [0-48]\d|
+              [0-4]\d|
               [57][2-9]|
               6[2-8]|
+              80|
               9[3-9]
             )|
             (?:
@@ -17143,9 +17952,9 @@
               8[0-247-9]
             )|
             7(?:
-              0[067]|
+              0[06-8]|
               6[1267]|
-              7[017]
+              7[0-27]
             )
           )\d{6}
         </nationalNumberPattern>
@@ -17164,11 +17973,16 @@
       <voip>
         <possibleLengths national="9"/>
         <exampleNumber>592401234</exampleNumber>
-        <nationalNumberPattern>5924[01]\d{4}</nationalNumberPattern>
+        <nationalNumberPattern>
+          592(?:
+            4[0-2]|
+            93
+          )\d{4}
+        </nationalNumberPattern>
       </voip>
     </territory>
 
-    <!-- Monaco -->
+    <!-- Monaco (MC) -->
     <!-- We support Kosovo mobile numbers (044, 045) with a Monaco calling code here, while Kosovo
          numbers all move over to the +383 plan. Kosovo numbers are still under several calling
          codes. It also seems that the national prefix is only used for mobile numbers, not
@@ -17182,6 +17996,12 @@
           <format>$1 $2 $3</format>
           <intlFormat>NA</intlFormat>
         </numberFormat>
+        <!-- Alternate format for mobile ranges starting with 4.
+             4X mobile numbers are actually used by Kosovo, which might explain the format difference. -->
+        <numberFormat pattern="(\d{2})(\d{3})(\d{3})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>4</leadingDigits>
+          <format>$1 $2 $3</format>
+        </numberFormat>
         <!-- Fixed line and some mobile ranges formatting.
              This formatting was found online rather than in the ITU document example.
              For the mobile prefix 3, we could not get authoritative information, so following
@@ -17189,12 +18009,6 @@
         <numberFormat pattern="(\d{2})(\d{2})(\d{2})(\d{2})">
           <leadingDigits>[39]</leadingDigits>
           <format>$1 $2 $3 $4</format>
-        </numberFormat>
-        <!-- Alternate format for mobile ranges starting with 4.
-             4X mobile numbers are actually used by Kosovo, which might explain the format difference. -->
-        <numberFormat pattern="(\d{2})(\d{3})(\d{3})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>4</leadingDigits>
-          <format>$1 $2 $3</format>
         </numberFormat>
         <!-- 9-digit mobile numbers. -->
         <numberFormat pattern="(\d)(\d{2})(\d{2})(\d{2})(\d{2})"
@@ -17205,13 +18019,11 @@
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
+          870\d{5}|
           (?:
-            (?:
-              [349]|
-              6\d
-            )\d\d|
-            870
-          )\d{5}
+            [349]|
+            6\d
+          )\d{7}
         </nationalNumberPattern>
       </generalDesc>
       <noInternationalDialling>
@@ -17234,16 +18046,14 @@
         <possibleLengths national="8,9"/>
         <exampleNumber>612345678</exampleNumber>
         <nationalNumberPattern>
+          4(?:
+            4\d|
+            5[1-9]
+          )\d{5}|
           (?:
-            (?:
-              3|
-              6\d
-            )\d\d|
-            4(?:
-              4\d|
-              5[1-9]
-            )
-          )\d{5}
+            3|
+            6\d
+          )\d{7}
         </nationalNumberPattern>
       </mobile>
       <tollFree>
@@ -17253,7 +18063,7 @@
       </tollFree>
     </territory>
 
-    <!-- Moldova, Rep. of -->
+    <!-- Moldova (MD) -->
     <!-- As per the ITU doc, 1010 – 1099 are carrier access codes in Moldova, but we are not sure
          of their usage, such as whether they're used for national or international calls. -->
     <!-- Announcements -->
@@ -17264,6 +18074,10 @@
     <territory id="MD" countryCode="373" internationalPrefix="00" nationalPrefix="0"
                mobileNumberPortableRegion="true">
       <availableFormats>
+        <numberFormat pattern="(\d{3})(\d{5})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>[89]</leadingDigits>
+          <format>$1 $2</format>
+        </numberFormat>
         <numberFormat pattern="(\d{2})(\d{3})(\d{3})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>
             22|
@@ -17274,10 +18088,6 @@
         <numberFormat pattern="(\d{3})(\d{2})(\d{3})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>[25-7]</leadingDigits>
           <format>$1 $2 $3</format>
-        </numberFormat>
-        <numberFormat pattern="(\d{3})(\d{5})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>[89]</leadingDigits>
-          <format>$1 $2</format>
         </numberFormat>
       </availableFormats>
       <generalDesc>
@@ -17309,15 +18119,11 @@
         <possibleLengths national="8"/>
         <exampleNumber>62112345</exampleNumber>
         <nationalNumberPattern>
+          562\d{5}|
           (?:
-            562|
-            6\d\d|
-            7(?:
-              [189]\d|
-              6[07]|
-              7[457-9]
-            )
-          )\d{5}
+            6\d|
+            7[16-9]
+          )\d{6}
         </nationalNumberPattern>
       </mobile>
       <tollFree>
@@ -17349,7 +18155,7 @@
       </uan>
     </territory>
 
-    <!-- Montenegro -->
+    <!-- Montenegro (ME) -->
     <!-- According to EKIP, the detailed phone number assignments are published on their
          website (regulation:
          http://www.ekip.me/download/Law%20on%20Electronic%20Communications%20(updated)%204.9.2013%20(1)nova%20verzija.pdf
@@ -17368,9 +18174,9 @@
         <nationalNumberPattern>
           (?:
             20|
-            [3-79]\d|
-            80\d?
-          )\d{6}
+            [3-79]\d
+          )\d{6}|
+          80\d{6,7}
         </nationalNumberPattern>
       </generalDesc>
       <!-- Fixed line numbers have prefix 20,30,31,32,33,40,41,50,51,52 followed by 6 digits.
@@ -17447,7 +18253,7 @@
       </uan>
     </territory>
 
-    <!-- Saint-Martin, French Antilles -->
+    <!-- St. Martin (MF) -->
     <!-- Calling code and formatting shared with 'GP' -->
     <!-- Linked from http://www.arcep.fr/index.php?id=interactivenumeros -->
     <!-- http://www.itu.int/oth/T0202000058/en -->
@@ -17459,7 +18265,8 @@
         <nationalNumberPattern>
           (?:
             590|
-            69\d
+            69\d|
+            976
           )\d{6}
         </nationalNumberPattern>
       </generalDesc>
@@ -17496,11 +18303,17 @@
           )\d{4}
         </nationalNumberPattern>
       </mobile>
+      <voip>
+        <possibleLengths national="9"/>
+        <exampleNumber>976012345</exampleNumber>
+        <nationalNumberPattern>976[01]\d{5}</nationalNumberPattern>
+      </voip>
     </territory>
 
-    <!-- Madagascar -->
+    <!-- Madagascar (MG) -->
     <!-- http://www.itu.int/oth/T020200007F/en -->
-    <territory id="MG" countryCode="261" internationalPrefix="00" nationalPrefix="0">
+    <territory id="MG" countryCode="261" internationalPrefix="00" nationalPrefix="0"
+               nationalPrefixForParsing="0|([24-9]\d{6})$" nationalPrefixTransformRule="20$1">
       <availableFormats>
         <numberFormat pattern="(\d{2})(\d{2})(\d{3})(\d{2})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>[23]</leadingDigits>
@@ -17517,20 +18330,16 @@
         <possibleLengths national="9" localOnly="7"/>
         <exampleNumber>202123456</exampleNumber>
         <nationalNumberPattern>
+          2072[29]\d{4}|
           20(?:
-            (?:
-              2\d|
-              4[47]|
-              5[3467]|
-              6[279]|
-              8[268]|
-              9[245]
-            )\d|
-            7(?:
-              2[29]|
-              [35]\d
-            )
-          )\d{4}
+            2\d|
+            4[47]|
+            5[3467]|
+            6[279]|
+            7[35]|
+            8[268]|
+            9[245]
+          )\d{5}
         </nationalNumberPattern>
       </fixedLine>
       <!-- The numbering plan suggests the third digit, Z, should be 24-9, but this is not borne
@@ -17548,7 +18357,7 @@
       </voip>
     </territory>
 
-    <!-- Marshall Islands -->
+    <!-- Marshall Islands (MH) -->
     <!-- http://www.itu.int/oth/T0202000085/en -->
     <territory id="MH" countryCode="692" internationalPrefix="011" nationalPrefix="1">
       <availableFormats>
@@ -17559,13 +18368,11 @@
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
+          329\d{4}|
           (?:
-            (?:
-              [256]\d|
-              45
-            )\d|
-            329
-          )\d{4}
+            [256]\d|
+            45
+          )\d{5}
         </nationalNumberPattern>
       </generalDesc>
       <fixedLine>
@@ -17601,7 +18408,7 @@
       </voip>
     </territory>
 
-    <!-- Macedonia, Former Yugoslav Rep. of -->
+    <!-- North Macedonia (MK) -->
     <!-- http://www.itu.int/oth/T02020000CE/en -->
     <!-- https://e-agencija.aek.mk/aek-crm-portal/Pages/Public/PublicFreeSeries/PublicFreeSeries -->
     <territory id="MK" countryCode="389" internationalPrefix="00" nationalPrefix="0"
@@ -17668,7 +18475,10 @@
               3[2-4]|
               9[23]
             )\d|
-            421
+            4(?:
+              21|
+              60
+            )
           )\d{4}
         </nationalNumberPattern>
       </mobile>
@@ -17694,7 +18504,7 @@
       </sharedCost>
     </territory>
 
-    <!-- Mali -->
+    <!-- Mali (ML) -->
     <!-- http://www.itu.int/oth/T0202000083/en -->
     <!-- http://crt-mali.org/pdf/plan_num -->
     <territory id="ML" countryCode="223" internationalPrefix="00">
@@ -17723,10 +18533,7 @@
           <intlFormat>NA</intlFormat>
         </numberFormat>
         <numberFormat pattern="(\d{2})(\d{2})(\d{2})(\d{2})">
-          <leadingDigits>
-            [24-79]|
-            8[0239]
-          </leadingDigits>
+          <leadingDigits>[24-9]</leadingDigits>
           <format>$1 $2 $3 $4</format>
         </numberFormat>
       </availableFormats>
@@ -17746,39 +18553,35 @@
         <possibleLengths national="8"/>
         <exampleNumber>20212345</exampleNumber>
         <nationalNumberPattern>
+          2(?:
+            07[0-8]|
+            12[67]
+          )\d{4}|
           (?:
             2(?:
-              0(?:
-                2\d|
-                7[0-8]
-              )|
-              1(?:
-                2[67]|
-                [4-689]\d
-              )
+              02|
+              1[4-689]
             )|
             4(?:
               0[0-4]|
               4[1-39]
-            )\d
-          )\d{4}
+            )
+          )\d{5}
         </nationalNumberPattern>
       </fixedLine>
       <mobile>
         <possibleLengths national="8"/>
         <exampleNumber>65012345</exampleNumber>
         <nationalNumberPattern>
+          2(?:
+            079|
+            17\d
+          )\d{4}|
           (?:
-            2(?:
-              079|
-              17\d
-            )|
-            (?:
-              50|
-              [679]\d|
-              8[239]
-            )\d\d
-          )\d{4}
+            50|
+            [679]\d|
+            8[239]
+          )\d{6}
         </nationalNumberPattern>
       </mobile>
       <!-- Online examples have not been found, but this seems to follow the prescriptions in the
@@ -17790,7 +18593,7 @@
       </tollFree>
     </territory>
 
-    <!-- Myanmar -->
+    <!-- Myanmar (Burma) (MM) -->
     <!-- http://www.itu.int/oth/T0202000092/en -->
     <territory id="MM" countryCode="95" internationalPrefix="00" nationalPrefix="0">
       <availableFormats>
@@ -17847,6 +18650,11 @@
           <leadingDigits>2</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
+        <!-- Toll-free, see: http://mpt.com.mm/en/first-toll-free-call-service-myanmar-mpt/ -->
+        <numberFormat pattern="(\d{3})(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>8</leadingDigits>
+          <format>$1 $2 $3</format>
+        </numberFormat>
         <!-- Following majority of numbers found online. -->
         <numberFormat pattern="(\d)(\d{3})(\d{3})(\d{3})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>92</leadingDigits>
@@ -17856,24 +18664,19 @@
           <leadingDigits>9</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
-        <!-- Toll-free, see: http://mpt.com.mm/en/first-toll-free-call-service-myanmar-mpt/ -->
-        <numberFormat pattern="(\d{3})(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>8</leadingDigits>
-          <format>$1 $2 $3</format>
-        </numberFormat>
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
+          1\d{5,7}|
+          95\d{6}|
           (?:
-            1|
-            [24-7]\d
-          )\d{5,7}|
-          8\d{6,9}|
-          9(?:
-            [0-46-9]\d{6,8}|
-            5\d{6}
-          )|
-          2\d{5}
+            [4-7]|
+            9[0-46-9]
+          )\d{6,8}|
+          (?:
+            2|
+            8\d
+          )\d{5,8}
         </nationalNumberPattern>
       </generalDesc>
       <fixedLine>
@@ -17890,8 +18693,10 @@
               4(?:
                 2[2-469]|
                 39|
+                46|
                 6[25]|
-                7[01]
+                7[0-3]|
+                83
               )|
               6
             )|
@@ -17904,45 +18709,28 @@
                 0\d|
                 2[246]|
                 39|
+                46|
                 62|
-                7[01]
+                7[0-3]|
+                83
               )|
               51\d\d
             )|
             4(?:
               2(?:
                 2\d\d|
-                480
+                48[0-3]
               )|
               3(?:
                 20\d|
-                470|
+                4(?:
+                  70|
+                  83
+                )|
                 56
               )|
               420\d|
               5470
-            )|
-            5(?:
-              2(?:
-                2\d\d?|
-                470
-              )|
-              4(?:
-                2(?:
-                  1|
-                  86
-                )|
-                470
-              )|
-              522\d|
-              7(?:
-                20\d|
-                480
-              )|
-              [89](?:
-                20\d|
-                470
-              )
             )|
             6(?:
               0(?:
@@ -17951,12 +18739,16 @@
               )|
               (?:
                 124|
-                42[04]|
                 [56]2\d
               )\d|
+              247[23]|
               3(?:
                 20\d|
                 470
+              )|
+              4(?:
+                2[04]\d|
+                47[23]
               )|
               7(?:
                 (?:
@@ -17965,16 +18757,48 @@
                 )\d|
                 4(?:
                   39|
-                  [67]0
+                  60|
+                  7[013]
                 )
               )
+            )
+          )\d{4}|
+          5(?:
+            2(?:
+              2\d{5,6}|
+              47[023]\d{4}
             )|
-            7(?:
-              0470|
-              1(?:
-                20\d?|
+            (?:
+              347[23]|
+              4(?:
+                2(?:
+                  1|
+                  86
+                )|
                 470
               )|
+              522\d|
+              6(?:
+                20\d|
+                483
+              )|
+              7(?:
+                20\d|
+                48[0-2]
+              )|
+              8(?:
+                20\d|
+                47[02]
+              )|
+              9(?:
+                20\d|
+                47[01]
+              )
+            )\d{4}
+          )|
+          7(?:
+            (?:
+              0470|
               4(?:
                 25\d|
                 470
@@ -17984,57 +18808,82 @@
                 470|
                 96\d
               )
+            )\d{4}|
+            1(?:
+              20\d{4,5}|
+              4(?:
+                70|
+                83
+              )\d{4}
+            )
+          )|
+          8(?:
+            1(?:
+              2\d{5,6}|
+              4(?:
+                10|
+                7[01]\d
+              )\d{3}
             )|
-            8(?:
-              [13](?:
+            2(?:
+              2\d{5,6}|
+              (?:
+                320|
+                490\d
+              )\d{3}
+            )|
+            (?:
+              3(?:
                 2\d\d|
                 470
               )|
-              [25]2\d\d
+              4[24-7]|
+              5(?:
+                2\d|
+                4[1-9]|
+                51
+              )\d|
+              6[23]
+            )\d{4}
+          )|
+          (?:
+            1[2-6]\d|
+            4(?:
+              2[24-8]|
+              3[2-7]|
+              [46][2-6]|
+              5[3-5]
+            )|
+            5(?:
+              [27][2-8]|
+              3[2-68]|
+              4[24-8]|
+              5[23]|
+              6[2-4]|
+              8[24-7]|
+              9[2-7]
+            )|
+            6(?:
+              [19]20|
+              42[03-6]|
+              (?:
+                52|
+                7[45]
+              )\d
+            )|
+            7(?:
+              [04][24-8]|
+              [15][2-7]|
+              22|
+              3[2-4]
+            )|
+            8(?:
+              1[2-689]|
+              2[2-8]|
+              [35]2\d
             )
           )\d{4}|
-          (?:
-            (?:
-              1[2-6]\d|
-              4(?:
-                2[24-8]|
-                3[2-7]|
-                [46][2-6]|
-                5[3-5]
-              )|
-              5(?:
-                [27][2-8]|
-                3[2-68]|
-                4[24-8]|
-                5[23]|
-                6[2-4]|
-                8[24-7]|
-                9[2-7]
-              )|
-              6(?:
-                [19]20|
-                42[03-6]|
-                (?:
-                  52|
-                  7[45]
-                )\d
-              )|
-              7(?:
-                [04][24-8]|
-                [15][2-7]|
-                22|
-                3[2-4]
-              )
-            )\d|
-            25\d{2,3}|
-            8(?:
-              [135]2\d\d|
-              2(?:
-                2\d\d|
-                320
-              )
-            )
-          )\d{3}|
+          25\d{5,6}|
           (?:
             2[2-9]|
             6(?:
@@ -18048,12 +18897,8 @@
               9[24]
             )|
             8(?:
-              1[2-689]|
-              2[2-8]|
               3[24]|
-              4[24-7]|
-              5[245]|
-              6[23]
+              5[245]
             )
           )\d{4}
         </nationalNumberPattern>
@@ -18069,41 +18914,42 @@
             9(?:
               2(?:
                 [0-4]|
-                (?:
-                  5\d|
-                  6[0-5]
-                )\d
+                [56]\d\d
               )|
               (?:
                 3(?:
                   [0-36]|
-                  4[069]
+                  4\d
                 )|
-                [68]9\d|
+                6(?:
+                  6[0-2]|
+                  [7-9]\d
+                )|
                 7(?:
                   3|
-                  5[0-2]|
-                  [6-9]\d
-                )
+                  [5-9]\d
+                )|
+                8(?:
+                  8[4-9]|
+                  9\d
+                )|
+                9[5-8]\d
               )\d|
               4(?:
                 (?:
-                  0[0-4]|
-                  [1379]|
-                  [25]\d|
-                  4[0-589]
+                  [0245]\d|
+                  [1379]
                 )\d|
                 88
               )|
-              5[0-6]|
-              9(?:
-                [089]|
-                [5-7]\d\d
-              )
+              5[0-6]
             )\d
           )\d{4}|
           9[69]1\d{6}|
-          9[68]\d{6}
+          9(?:
+            [68]\d|
+            9[089]
+          )\d{5}
         </nationalNumberPattern>
       </mobile>
       <tollFree>
@@ -18120,18 +18966,13 @@
         <possibleLengths national="8"/>
         <exampleNumber>13331234</exampleNumber>
         <nationalNumberPattern>
-          (?:
-            1(?:
-              333|
-              468
-            )|
-            2468
-          )\d{4}
+          1333\d{4}|
+          [12]468\d{4}
         </nationalNumberPattern>
       </voip>
     </territory>
 
-    <!-- Mongolia -->
+    <!-- Mongolia (MN) -->
     <!-- http://www.itu.int/oth/T020200008E/en -->
     <!-- http://www.crc.gov.mn/k/4L/36 -->
     <territory id="MN" countryCode="976" internationalPrefix="001" nationalPrefix="0">
@@ -18182,8 +19023,8 @@
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
-          [12]\d{8,9}|
-          [1257-9]\d{7}
+          [12]\d{7,9}|
+          [57-9]\d{7}
         </nationalNumberPattern>
       </generalDesc>
       <!-- Note the leading digit is the access code: 1 is used by Mongolia Telecom subscribers
@@ -18196,19 +19037,28 @@
         <possibleLengths national="[8-10]" localOnly="[4-6]"/>
         <exampleNumber>50123456</exampleNumber>
         <nationalNumberPattern>
+          [12](?:
+            3[2-8]|
+            4[2-68]|
+            5[1-4689]
+          )\d{6,7}|
           (?:
-            [12](?:
-              1|
-              2[1-37]|
-              (?:
-                3[2-8]|
-                4[2-68]|
-                5[1-4689]
-              )\d?
+            11(?:
+              3\d|
+              4[568]
             )|
-            5[0568]
-          )\d{6}|
-          [12]2[1-3]\d{5}
+            (?:
+              (?:
+                21|
+                5[0568]
+              )\d|
+              70[0-5]
+            )\d
+          )\d{4}|
+          [12]2(?:
+            [1-3]\d{5,6}|
+            7\d{6}
+          )
         </nationalNumberPattern>
       </fixedLine>
       <mobile>
@@ -18220,7 +19070,11 @@
               [05689]\d|
               3[01]
             )|
-            9[013-9]\d
+            9(?:
+              [014-9]\d|
+              20|
+              3[0-4]
+            )
           )\d{5}
         </nationalNumberPattern>
       </mobile>
@@ -18229,12 +19083,27 @@
            online. -->
       <voip>
         <possibleLengths national="8"/>
-        <exampleNumber>75123456</exampleNumber>
-        <nationalNumberPattern>7[05-8]\d{6}</nationalNumberPattern>
+        <exampleNumber>75153456</exampleNumber>
+        <nationalNumberPattern>
+          7(?:
+            100|
+            5(?:
+              0[0579]|
+              1[015]|
+              [389]5|
+              [57][57]
+            )|
+            (?:
+              6[0167]|
+              7\d|
+              8[01]
+            )\d
+          )\d{4}
+        </nationalNumberPattern>
       </voip>
     </territory>
 
-    <!-- Macao, China -->
+    <!-- Macao (MO) -->
     <!-- No tollFree or premiumRate information can be found. -->
     <!-- http://www.itu.int/oth/T020200007E/en -->
     <!-- http://www.dsrt.gov.mo/web/en/generalinfo/allocatednum -->
@@ -18284,21 +19153,20 @@
       </mobile>
     </territory>
 
-    <!-- Northern Mariana Islands -->
+    <!-- Northern Mariana Islands (MP) -->
     <!-- Calling code and formatting shared with 'US' -->
     <!-- http://www.itu.int/oth/T02020000EE/en -->
     <!-- http://www.cnmiphonebook.com/ -->
     <territory id="MP" countryCode="1" leadingDigits="670" internationalPrefix="011"
-               nationalPrefix="1">
+               nationalPrefix="1" nationalPrefixForParsing="1|([2-9]\d{6})$"
+               nationalPrefixTransformRule="670$1">
       <generalDesc>
         <nationalNumberPattern>
+          [58]\d{9}|
           (?:
-            [58]\d\d|
-            (?:
-              67|
-              90
-            )0
-          )\d{7}
+            67|
+            90
+          )0\d{7}
         </nationalNumberPattern>
       </generalDesc>
       <!-- Extra exchange codes 232, 289, 355, 472, 633, 637, 646, 647, 649, 653, 687, 734 and 828
@@ -18405,7 +19273,7 @@
       </personalNumber>
     </territory>
 
-    <!-- Martinique (French Dept. of) -->
+    <!-- Martinique (MQ) -->
     <!-- The 876 prefix is mentioned in the plan, but the plan is from 2006 and in France VOIP
          numbers were changed from 087 to the 09 prefix in 2009. It is likely this occurred here
          too. -->
@@ -18415,16 +19283,17 @@
                mobileNumberPortableRegion="true">
       <availableFormats>
         <numberFormat pattern="(\d{3})(\d{2})(\d{2})(\d{2})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>[56]</leadingDigits>
+          <leadingDigits>[569]</leadingDigits>
           <format>$1 $2 $3 $4</format>
         </numberFormat>
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
+          69\d{7}|
           (?:
-            596|
-            69\d
-          )\d{6}
+            59|
+            97
+          )6\d{6}
         </nationalNumberPattern>
       </generalDesc>
       <fixedLine>
@@ -18459,9 +19328,19 @@
           )\d{4}
         </nationalNumberPattern>
       </mobile>
+      <voip>
+        <possibleLengths national="9"/>
+        <exampleNumber>976612345</exampleNumber>
+        <nationalNumberPattern>
+          976(?:
+            6[1-9]|
+            7[0-367]
+          )\d{4}
+        </nationalNumberPattern>
+      </voip>
     </territory>
 
-    <!-- Mauritania -->
+    <!-- Mauritania (MR) -->
     <!-- http://www.itu.int/oth/T0202000087/en -->
     <!-- http://are.mr/pdfs/pnn2010.pdf -->
     <territory id="MR" countryCode="222" internationalPrefix="00">
@@ -18490,7 +19369,7 @@
           )\d{5}
         </nationalNumberPattern>
       </fixedLine>
-      <!-- Added "49\d" in response to https://github.com/googlei18n/libphonenumber/issues/529
+      <!-- Added "49\d" in response to https://github.com/google/libphonenumber/issues/529
            which might be overly permissive, but we don't have an official documentation for this
            and only a small number of numbers were found online. At least 492 and 495 are valid. -->
       <mobile>
@@ -18505,20 +19384,19 @@
       </tollFree>
     </territory>
 
-    <!-- Montserrat -->
+    <!-- Montserrat (MS) -->
     <!-- Calling code and formatting shared with 'US' -->
     <!-- http://www.itu.int/oth/T020200008F/en -->
     <territory id="MS" countryCode="1" leadingDigits="664" internationalPrefix="011"
-               nationalPrefix="1">
+               nationalPrefix="1" nationalPrefixForParsing="1|(4\d{6})$"
+               nationalPrefixTransformRule="664$1">
       <generalDesc>
         <nationalNumberPattern>
+          66449\d{5}|
           (?:
-            (?:
-              [58]\d\d|
-              900
-            )\d\d|
-            66449
-          )\d{5}
+            [58]\d\d|
+            900
+          )\d{7}
         </nationalNumberPattern>
       </generalDesc>
       <fixedLine>
@@ -18569,7 +19447,7 @@
       </personalNumber>
     </territory>
 
-    <!-- Malta -->
+    <!-- Malta (MT) -->
     <!-- Numbering link in the LHS menu - has more up-to-date allocations -->
     <!-- http://www.itu.int/oth/T0202000084/en -->
     <!-- http://www.mca.org.mt/regulatory/numbering/numbering-plans -->
@@ -18582,13 +19460,11 @@
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
+          3550\d{4}|
           (?:
-            (?:
-              [2579]\d\d|
-              800
-            )\d|
-            3550
-          )\d{4}
+            [2579]\d\d|
+            800
+          )\d{5}
         </nationalNumberPattern>
       </generalDesc>
       <fixedLine>
@@ -18597,8 +19473,9 @@
         <nationalNumberPattern>
           2(?:
             0(?:
-              [169]\d|
-              3[1-4]
+              [19]\d|
+              3[1-4]|
+              6[059]
             )|
             [1-357]\d\d
           )\d{4}
@@ -18673,7 +19550,7 @@
       </uan>
     </territory>
 
-    <!-- Mauritius -->
+    <!-- Mauritius (MU) -->
     <!-- Preferred international prefix is expected to standardize on just '00' -->
     <!-- http://www.icta.mu/telecommunications/numbering.htm -->
     <territory id="MU" countryCode="230" preferredInternationalPrefix="020"
@@ -18682,11 +19559,7 @@
         <numberFormat pattern="(\d{3})(\d{4})">
           <leadingDigits>
             [2-46]|
-            8(?:
-              0[0-2]|
-              14|
-              3[129]
-            )
+            8[013]
           </leadingDigits>
           <format>$1 $2</format>
         </numberFormat>
@@ -18720,7 +19593,7 @@
               2[4-7]
             )|
             54(?:
-              4\d|
+              [34]\d|
               71
             )|
             6\d\d|
@@ -18736,21 +19609,19 @@
         <exampleNumber>52512345</exampleNumber>
         <nationalNumberPattern>
           5(?:
-            (?:
-              2[589]|
-              7\d|
-              9[0-8]
-            )\d|
             4(?:
               2[1-389]|
-              [489]\d|
               7[1-9]
             )|
-            8(?:
-              [0-689]\d|
-              7[15-8]
-            )
-          )\d{4}
+            87[15-8]
+          )\d{4}|
+          5(?:
+            2[589]|
+            4[3489]|
+            7\d|
+            8[0-689]|
+            9[0-8]
+          )\d{5}
         </nationalNumberPattern>
       </mobile>
       <tollFree>
@@ -18775,7 +19646,7 @@
       </voip>
     </territory>
 
-    <!-- Maldives -->
+    <!-- Maldives (MV) -->
     <!-- http://www.itu.int/oth/T0202000082/en -->
     <!-- http://www.dhiraagu.com.mv -->
     <territory id="MV" countryCode="960" preferredInternationalPrefix="00"
@@ -18783,12 +19654,8 @@
       <availableFormats>
         <numberFormat pattern="(\d{3})(\d{4})">
           <leadingDigits>
-            [367]|
-            4(?:
-              00|
-              [56]
-            )|
-            9[14-9]
+            [3467]|
+            9[13-9]
           </leadingDigits>
           <format>$1-$2</format>
         </numberFormat>
@@ -18835,13 +19702,11 @@
         <possibleLengths national="7"/>
         <exampleNumber>7712345</exampleNumber>
         <nationalNumberPattern>
+          46[46]\d{4}|
           (?:
-            46[46]|
-            (?:
-              7[2-9]|
-              9[14-9]
-            )\d
-          )\d{4}
+            7[2-9]|
+            9[13-9]
+          )\d{5}
         </nationalNumberPattern>
       </mobile>
       <tollFree>
@@ -18863,7 +19728,7 @@
       </uan>
     </territory>
 
-    <!-- Malawi -->
+    <!-- Malawi (MW) -->
     <!-- The plan doesn't state that a national prefix exists, but numbers found on the internet are
          consistent in having one. -->
     <!-- http://www.itu.int/oth/T0202000080/en -->
@@ -18877,13 +19742,13 @@
           <leadingDigits>2</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
-        <numberFormat pattern="(\d{3})(\d{2})(\d{2})(\d{2})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>[17-9]</leadingDigits>
-          <format>$1 $2 $3 $4</format>
-        </numberFormat>
         <numberFormat pattern="(\d{2})(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>3</leadingDigits>
           <format>$1 $2 $3</format>
+        </numberFormat>
+        <numberFormat pattern="(\d{3})(\d{2})(\d{2})(\d{2})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>[17-9]</leadingDigits>
+          <format>$1 $2 $3 $4</format>
         </numberFormat>
       </availableFormats>
       <generalDesc>
@@ -18916,14 +19781,12 @@
         <possibleLengths national="9"/>
         <exampleNumber>991234567</exampleNumber>
         <nationalNumberPattern>
+          111\d{6}|
           (?:
-            111|
-            (?:
-              77|
-              88|
-              99
-            )\d
-          )\d{6}
+            77|
+            88|
+            99
+          )\d{7}
         </nationalNumberPattern>
       </mobile>
       <voip>
@@ -18933,7 +19796,7 @@
       </voip>
     </territory>
 
-    <!-- Mexico -->
+    <!-- Mexico (MX) -->
     <!-- http://www.itu.int/oth/T020200008A/en -->
     <!-- http://en.wikipedia.org/wiki/%2B52 -->
     <!-- http://en.wikipedia.org/wiki/Premium-rate_telephone_number#Mexico -->
@@ -18944,12 +19807,16 @@
          national format (leading 044/045), will be parsed into the same form. -->
     <territory id="MX" countryCode="52" preferredInternationalPrefix="00"
                internationalPrefix="0[09]" nationalPrefix="01"
-               nationalPrefixForParsing="0[12]|04[45]([2-9]\d{9})$"
-               nationalPrefixTransformRule="1$1" mobileNumberPortableRegion="true">
+               nationalPrefixForParsing="0(?:[12]|4[45])|1" mobileNumberPortableRegion="true">
       <availableFormats>
+        <!-- 5-digit shortcodes (very rare). -->
+        <numberFormat pattern="(\d{5})">
+          <leadingDigits>53</leadingDigits>
+          <format>$1</format>
+          <intlFormat>NA</intlFormat>
+        </numberFormat>
         <!-- Fixed line (2-digit area codes). -->
-        <numberFormat pattern="(\d{2})(\d{4})(\d{4})" nationalPrefixFormattingRule="$NP $FG"
-                      nationalPrefixOptionalWhenFormatting="true">
+        <numberFormat pattern="(\d{2})(\d{4})(\d{4})" nationalPrefixOptionalWhenFormatting="true">
           <leadingDigits>
             33|
             5[56]|
@@ -18958,13 +19825,13 @@
           <format>$1 $2 $3</format>
         </numberFormat>
         <!-- Fixed line (3-digit area codes) and other non-mobile numbers. -->
-        <numberFormat pattern="(\d{3})(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP $FG"
-                      nationalPrefixOptionalWhenFormatting="true">
+        <numberFormat pattern="(\d{3})(\d{3})(\d{4})" nationalPrefixOptionalWhenFormatting="true">
           <leadingDigits>[2-9]</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
-        <!-- Mobile version of fixed line 2-digit area codes (prepends mobile token). -->
-        <numberFormat pattern="(\d)(\d{2})(\d{4})(\d{4})" nationalPrefixFormattingRule="044 $FG">
+        <!-- Mobile version of fixed line 2-digit area codes and removing former mobile token 1. -->
+        <numberFormat pattern="(\d)(\d{2})(\d{4})(\d{4})"
+                      nationalPrefixOptionalWhenFormatting="true">
           <leadingDigits>
             1(?:
               33|
@@ -18973,28 +19840,31 @@
             )
           </leadingDigits>
           <format>$2 $3 $4</format>
-          <intlFormat>$1 $2 $3 $4</intlFormat>
         </numberFormat>
-        <!-- Mobile version of fixed line 3-digit area codes (prepends mobile token). -->
-        <numberFormat pattern="(\d)(\d{3})(\d{3})(\d{4})" nationalPrefixFormattingRule="044 $FG">
+        <!-- Mobile version of fixed line 3-digit area codes and removing former mobile token 1. -->
+        <numberFormat pattern="(\d)(\d{3})(\d{3})(\d{4})"
+                      nationalPrefixOptionalWhenFormatting="true">
           <leadingDigits>1</leadingDigits>
           <format>$2 $3 $4</format>
-          <intlFormat>$1 $2 $3 $4</intlFormat>
         </numberFormat>
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
           (?:
-            1\d|
-            [2-9]
-          )\d{9}
+            1(?:
+              [01467]\d|
+              [2359][1-9]|
+              8[1-79]
+            )|
+            [2-9]\d
+          )\d{8}
         </nationalNumberPattern>
       </generalDesc>
       <!-- http://en.wikipedia.org/wiki/Area_codes_in_Mexico_by_code -->
       <!-- Also covering fixed satellite service numbers (prefixes: 200 and 201). -->
       <fixedLine>
         <possibleLengths national="10" localOnly="7,8"/>
-        <exampleNumber>2221234567</exampleNumber>
+        <exampleNumber>2001234567</exampleNumber>
         <nationalNumberPattern>
           (?:
             2(?:
@@ -19064,10 +19934,72 @@
       <!-- Fixed satellite service numbers are not included here, although many other prefixes from
            the fixedLine pattern are. -->
       <mobile>
-        <possibleLengths national="11"/>
+        <possibleLengths national="10,11" localOnly="7,8"/>
         <exampleNumber>12221234567</exampleNumber>
         <nationalNumberPattern>
-          1(?:
+          (?:
+            1(?:
+              2(?:
+                2[1-9]|
+                3[1-35-8]|
+                4[13-9]|
+                7[1-689]|
+                8[1-578]|
+                9[467]
+              )|
+              3(?:
+                1[1-79]|
+                [2458][1-9]|
+                3\d|
+                7[1-8]|
+                9[1-5]
+              )|
+              4(?:
+                1[1-57-9]|
+                [24-7][1-9]|
+                3[1-8]|
+                8[1-35-9]|
+                9[2-689]
+              )|
+              5(?:
+                [56]\d|
+                88|
+                9[1-79]
+              )|
+              6(?:
+                1[2-68]|
+                [2-4][1-9]|
+                5[1-3689]|
+                6[1-57-9]|
+                7[1-7]|
+                8[67]|
+                9[4-8]
+              )|
+              7(?:
+                [1-467][1-9]|
+                5[13-9]|
+                8[1-69]|
+                9[17]
+              )|
+              8(?:
+                1\d|
+                2[13-689]|
+                3[1-6]|
+                4[124-6]|
+                6[1246-9]|
+                7[1-378]|
+                9[12479]
+              )|
+              9(?:
+                1[346-9]|
+                2[1-4]|
+                3[2-46-8]|
+                5[1348]|
+                [69][1-9]|
+                7[12]|
+                8[1-8]
+              )
+            )|
             2(?:
               2[1-9]|
               3[1-35-8]|
@@ -19158,7 +20090,7 @@
       </personalNumber>
     </territory>
 
-    <!-- Malaysia -->
+    <!-- Malaysia (MY) -->
     <!-- http://en.wikipedia.org/wiki/%2B60 -->
     <!-- https://www.mcmc.gov.my/sectors/celco/numbering-management/numbering-management/numbers-assignment -->
     <territory id="MY" countryCode="60" internationalPrefix="00" nationalPrefix="0"
@@ -19173,8 +20105,8 @@
         <numberFormat pattern="(\d{2})(\d{3})(\d{3,4})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>
             1(?:
-              [0249]|
-              [367][2-9]|
+              [02469]|
+              [37][2-9]|
               8[1-9]
             )|
             8
@@ -19186,6 +20118,11 @@
           <leadingDigits>3</leadingDigits>
           <format>$1-$2 $3</format>
         </numberFormat>
+        <!-- Variable cost (premium rate, toll free etc.) -->
+        <numberFormat pattern="(\d)(\d{3})(\d{2})(\d{4})">
+          <leadingDigits>1[36-8]</leadingDigits>
+          <format>$1-$2-$3-$4</format>
+        </numberFormat>
         <!-- 10 digit mobile or voip ranges -->
         <numberFormat pattern="(\d{3})(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>15</leadingDigits>
@@ -19193,19 +20130,14 @@
         </numberFormat>
         <!-- 10 digit mobile ranges -->
         <numberFormat pattern="(\d{2})(\d{4})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>11</leadingDigits>
-          <format>$1-$2 $3</format>
-        </numberFormat>
-        <!-- Variable cost (premium rate, toll free etc.) -->
-        <numberFormat pattern="(\d)(\d{3})(\d{2})(\d{4})">
           <leadingDigits>1</leadingDigits>
-          <format>$1-$2-$3-$4</format>
+          <format>$1-$2 $3</format>
         </numberFormat>
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
+          1\d{8,9}|
           (?:
-            1\d\d?|
             3\d|
             [4-9]
           )\d{7}
@@ -19283,47 +20215,48 @@
         <exampleNumber>123456789</exampleNumber>
         <nationalNumberPattern>
           1(?:
+            4400|
+            8(?:
+              47|
+              8[27]
+            )[0-4]
+          )\d{4}|
+          1(?:
+            0(?:
+              [23568]\d|
+              4[0-6]|
+              7[016-9]|
+              9[0-8]
+            )|
+            1(?:
+              [1-5]\d\d|
+              6(?:
+                0[5-9]|
+                [1-9]\d
+              )|
+              7(?:
+                0[3-9]|
+                1[01]
+              )
+            )|
             (?:
-              0(?:
-                [23568]\d|
-                4[0-6]|
-                7[016-9]|
-                9[0-8]
-              )|
-              1(?:
-                [1-5]\d\d|
-                6(?:
-                  0[5-9]|
-                  [1-9]\d
-                )
-              )|
+              [2379][2-9]|
+              4[235-9]|
               (?:
-                [23679][2-9]|
-                59\d
+                59|
+                6
               )\d
             )\d|
-            4(?:
-              [235-9]\d\d|
-              400
-            )|
             8(?:
-              (?:
-                1[23]|
-                [236]\d|
-                5[7-9]|
-                7[016-9]|
-                9[0-8]
-              )\d|
-              4(?:
-                [06]\d|
-                7[0-4]
-              )|
-              8(?:
-                [01]\d|
-                [27][0-4]
-              )
+              1[23]|
+              [236]\d|
+              4[06]|
+              5[7-9]|
+              7[016-9]|
+              8[01]|
+              9[0-8]
             )
-          )\d{4}
+          )\d{5}
         </nationalNumberPattern>
       </mobile>
       <!-- http://www.skmm.gov.my/skmmgovmy/media/General/pdf/Special_Service_Number.pdf -->
@@ -19356,7 +20289,7 @@
       </voip>
     </territory>
 
-    <!-- Mozambique -->
+    <!-- Mozambique (MZ) -->
     <!-- The plan suggests 801 and 802 numbers are shared-cost numbers, and numbers beginning with
          a 9 are premium rate, but no online examples can be found of any of these so they are
          omitted for the time-being. -->
@@ -19409,7 +20342,7 @@
       </tollFree>
     </territory>
 
-    <!-- Namibia -->
+    <!-- Namibia (NA) -->
     <!-- http://www.itu.int/oth/T0202000093/en -->
     <territory id="NA" countryCode="264" internationalPrefix="00" nationalPrefix="0">
       <availableFormats>
@@ -19421,11 +20354,11 @@
           <leadingDigits>6</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
-        <numberFormat pattern="(\d{2})(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>8[0-5]</leadingDigits>
+        <numberFormat pattern="(\d{3})(\d{3})(\d{3})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>87</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
-        <numberFormat pattern="(\d{3})(\d{3})(\d{3})" nationalPrefixFormattingRule="$NP$FG">
+        <numberFormat pattern="(\d{2})(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>8</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
@@ -19549,19 +20482,20 @@
       </voip>
     </territory>
 
-    <!-- New Caledonia (Territoire français d'outre-mer) -->
+    <!-- New Caledonia (NC) -->
     <!-- http://www.itu.int/oth/T0202000098/en -->
     <!-- http://www.opt.nc -->
     <territory id="NC" countryCode="687" internationalPrefix="00">
       <availableFormats>
-        <!-- From http://www.1012.nc, the local yellow pages.
-             We exclude short-codes here so they are formatted as a block -->
+        <!-- 3-digit Shortcodes which would otherwise be formatted as 'XX.X' -->
+        <numberFormat pattern="(\d{3})">
+          <leadingDigits>5[6-8]</leadingDigits>
+          <format>$1</format>
+          <intlFormat>NA</intlFormat>
+        </numberFormat>
+        <!-- From http://www.1012.nc, the local yellow pages. -->
         <numberFormat pattern="(\d{2})(\d{2})(\d{2})">
-          <leadingDigits>
-            [247-9]|
-            3[0-6]|
-            5[0-4]
-          </leadingDigits>
+          <leadingDigits>[2-57-9]</leadingDigits>
           <format>$1.$2.$3</format>
         </numberFormat>
       </availableFormats>
@@ -19602,22 +20536,20 @@
       </premiumRate>
     </territory>
 
-    <!-- Niger -->
+    <!-- Niger (NE) -->
     <!-- http://www.itu.int/oth/T020200009B/en -->
     <territory id="NE" countryCode="227" internationalPrefix="00">
       <availableFormats>
+        <numberFormat pattern="(\d{2})(\d{3})(\d{3})">
+          <leadingDigits>08</leadingDigits>
+          <format>$1 $2 $3</format>
+        </numberFormat>
         <numberFormat pattern="(\d{2})(\d{2})(\d{2})(\d{2})">
           <leadingDigits>
-            09|
-            2[01]|
-            8[04589]|
-            9
+            [089]|
+            2[01]
           </leadingDigits>
           <format>$1 $2 $3 $4</format>
-        </numberFormat>
-        <numberFormat pattern="(\d{2})(\d{3})(\d{3})">
-          <leadingDigits>0</leadingDigits>
-          <format>$1 $2 $3</format>
         </numberFormat>
       </availableFormats>
       <generalDesc>
@@ -19631,7 +20563,7 @@
           2(?:
             0(?:
               20|
-              3[1-7]|
+              3[1-8]|
               4[13-5]|
               5[14]|
               6[14578]|
@@ -19655,7 +20587,7 @@
         <exampleNumber>93123456</exampleNumber>
         <nationalNumberPattern>
           (?:
-            8[04589]|
+            8[014589]|
             9\d
           )\d{6}
         </nationalNumberPattern>
@@ -19672,10 +20604,11 @@
       </premiumRate>
     </territory>
 
-    <!-- Norfolk Island -->
+    <!-- Norfolk Island (NF) -->
     <!-- Including numbers for Australian Antarctic stations. -->
     <!-- http://www.itu.int/oth/T020200009D/en -->
-    <territory id="NF" countryCode="672" internationalPrefix="00">
+    <territory id="NF" countryCode="672" internationalPrefix="00"
+               nationalPrefixForParsing="([0-258]\d{4})$" nationalPrefixTransformRule="3$1">
       <availableFormats>
         <numberFormat pattern="(\d{2})(\d{4})">
           <leadingDigits>1</leadingDigits>
@@ -19714,7 +20647,7 @@
       </mobile>
     </territory>
 
-    <!-- Nigeria -->
+    <!-- Nigeria (NG) -->
     <!-- http://www.itu.int/oth/T020200009C/en -->
     <!-- https://www.ncc.gov.ng/technology/standards/numbering -->
     <territory id="NG" countryCode="234" internationalPrefix="009" nationalPrefix="0"
@@ -19725,7 +20658,7 @@
           <leadingDigits>78</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
-        <!-- Fixed line, but includes some "fixed or mobile" ranges (this might indicate bad data). -->
+        <!-- Fixed line format for 1 digit area code -->
         <numberFormat pattern="(\d)(\d{3})(\d{3,4})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>
             [12]|
@@ -19736,7 +20669,7 @@
           </leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
-        <!-- Fixed line, but includes some "fixed or mobile" ranges (this might indicate bad data). -->
+        <!-- Fixed line format for 2 digit area code -->
         <numberFormat pattern="(\d{2})(\d{3})(\d{2,3})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>
             [3-7]|
@@ -19761,10 +20694,12 @@
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
-          [78]\d{10,13}|
-          [7-9]\d{9}|
+          (?:
+            [124-7]|
+            9\d{3}
+          )\d{6}|
           [1-9]\d{7}|
-          [124-7]\d{6}
+          [78]\d{9,13}
         </nationalNumberPattern>
       </generalDesc>
       <fixedLine>
@@ -19795,99 +20730,24 @@
       <!-- Added 906 and 907 mobile prefixes based on reports. Prefix 707 is withdrawn as per few
            websites, however 707[0-3] is added based on bug report and online search. -->
       <mobile>
-        <possibleLengths national="8,10" localOnly="6,7"/>
+        <possibleLengths national="10"/>
         <exampleNumber>8021234567</exampleNumber>
         <nationalNumberPattern>
           (?:
-            1(?:
-              (?:
-                7[34]|
-                95
-              )\d|
-              8(?:
-                04|
-                [124579]\d|
-                8[0-3]
-              )
-            )|
-            287[0-7]|
-            3(?:
-              18[1-8]|
-              88[0-7]|
-              9(?:
-                6[1-5]|
-                8[5-9]
-              )
-            )|
-            4(?:
-              [28]8[0-2]|
-              6(?:
-                7[1-9]|
-                8[02-47]
-              )
-            )|
-            5(?:
-              2(?:
-                7[7-9]|
-                8\d
-              )|
-              38[1-79]|
-              48[0-7]|
-              68[4-7]
-            )|
-            6(?:
-              2(?:
-                7[7-9]|
-                8\d
-              )|
-              4(?:
-                3[7-9]|
-                [68][129]|
-                7[04-69]|
-                9[1-8]
-              )|
-              58[0-2]|
-              98[7-9]
-            )|
-            7(?:
-              0(?:
-                [1-689]\d|
-                7[0-3]
-              )\d\d|
-              38[0-7]|
-              69[1-8]|
-              78[2-4]
-            )|
+            707[0-3]|
             8(?:
-              (?:
-                0(?:
-                  1[01]|
-                  [2-9]\d
-                )|
-                1(?:
-                  [0-8]\d|
-                  9[01]
-                )
-              )\d\d|
-              28[3-9]|
-              38[0-2]|
-              4(?:
-                2[12]|
-                3[147-9]|
-                5[346]|
-                7[4-9]|
-                8[014-689]|
-                90
-              )|
-              58[1-8]|
-              78[2-9]|
-              88[5-7]
+              01|
+              19
+            )[01]
+          )\d{6}|
+          (?:
+            70[1-689]|
+            8(?:
+              0[2-9]|
+              1[0-8]
             )|
-            9(?:
-              0[235-9]\d\d|
-              8[07]
-            )\d
-          )\d{4}
+            90[1-35-9]
+          )\d{7}
         </nationalNumberPattern>
       </mobile>
       <!-- Info on these numbers from http://www.alphatechnologieslimited.com. -->
@@ -19903,7 +20763,7 @@
       </uan>
     </territory>
 
-    <!-- Nicaragua -->
+    <!-- Nicaragua (NI) -->
     <!-- http://www.itu.int/oth/T020200009A/en -->
     <territory id="NI" countryCode="505" internationalPrefix="00">
       <availableFormats>
@@ -19958,16 +20818,31 @@
       </tollFree>
     </territory>
 
-    <!-- Netherlands -->
+    <!-- Netherlands (NL) -->
     <!-- http://en.wikipedia.org/wiki/%2B31 -->
     <!-- http://wetten.overheid.nl/BWBR0010198 -->
     <territory id="NL" countryCode="31" internationalPrefix="00" nationalPrefix="0"
                mobileNumberPortableRegion="true">
       <availableFormats>
+        <!-- Shortcodes (4 digits). -->
+        <numberFormat pattern="(\d{4})">
+          <leadingDigits>
+            1[238]|
+            [34]
+          </leadingDigits>
+          <format>$1</format>
+          <intlFormat>NA</intlFormat>
+        </numberFormat>
         <!-- National only numbers (no national prefix). -->
         <numberFormat pattern="(\d{2})(\d{3,4})">
           <leadingDigits>14</leadingDigits>
           <format>$1 $2</format>
+          <intlFormat>NA</intlFormat>
+        </numberFormat>
+        <!-- Shortcodes (6 digits). -->
+        <numberFormat pattern="(\d{6})">
+          <leadingDigits>1</leadingDigits>
+          <format>$1</format>
           <intlFormat>NA</intlFormat>
         </numberFormat>
         <!-- Toll free & premium rate. -->
@@ -19975,28 +20850,27 @@
           <leadingDigits>[89]0</leadingDigits>
           <format>$1 $2</format>
         </numberFormat>
-        <numberFormat pattern="(\d{2})(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
+        <numberFormat pattern="(\d{2})(\d{7})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>66</leadingDigits>
+          <format>$1 $2</format>
+        </numberFormat>
+        <numberFormat pattern="(\d)(\d{8})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>6</leadingDigits>
+          <format>$1 $2</format>
+        </numberFormat>
+        <numberFormat pattern="(\d{3})(\d{3})(\d{3})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>
-            1[035]|
-            2[0346]|
-            3[03568]|
-            4[0356]|
-            5[0358]|
-            [7-9]
+            1[16-8]|
+            2[259]|
+            3[124]|
+            4[17-9]|
+            5[124679]
           </leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
-        <numberFormat pattern="(\d{3})(\d{3})(\d{3})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>[1-5]</leadingDigits>
+        <numberFormat pattern="(\d{2})(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>[1-57-9]</leadingDigits>
           <format>$1 $2 $3</format>
-        </numberFormat>
-        <numberFormat pattern="(\d)(\d{8})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>6[1-58]</leadingDigits>
-          <format>$1 $2</format>
-        </numberFormat>
-        <numberFormat pattern="(\d{2})(\d{7})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>6</leadingDigits>
-          <format>$1 $2</format>
         </numberFormat>
       </availableFormats>
       <generalDesc>
@@ -20006,9 +20880,9 @@
             3(?:
               [02-9]\d|
               1[0-8]
-            )|
-            [89]\d{0,3}
+            )
           )\d{6}|
+          [89]\d{6,9}|
           1\d{4,5}
         </nationalNumberPattern>
       </generalDesc>
@@ -20016,29 +20890,21 @@
         <possibleLengths national="5,6"/>
         <nationalNumberPattern>
           140(?:
-            1(?:
-              [035]|
-              [16-8]\d
-            )|
-            2(?:
-              [0346]|
-              [259]\d
-            )|
-            3(?:
-              [03568]|
-              [124]\d
-            )|
-            4(?:
-              [0356]|
-              [17-9]\d
-            )|
-            5(?:
-              [0358]|
-              [124679]\d
-            )|
-            7\d|
+            1[035]|
+            2[0346]|
+            3[03568]|
+            4[0356]|
+            5[0358]|
             8[458]
-          )
+          )|
+          140(?:
+            1[16-8]|
+            2[259]|
+            3[124]|
+            4[17-9]|
+            5[124679]|
+            7
+          )\d
         </nationalNumberPattern>
       </noInternationalDialling>
       <fixedLine>
@@ -20128,49 +20994,46 @@
         <exampleNumber>14020</exampleNumber>
         <nationalNumberPattern>
           140(?:
-            1(?:
-              [035]|
-              [16-8]\d
-            )|
-            2(?:
-              [0346]|
-              [259]\d
-            )|
-            3(?:
-              [03568]|
-              [124]\d
-            )|
-            4(?:
-              [0356]|
-              [17-9]\d
-            )|
-            5(?:
-              [0358]|
-              [124679]\d
-            )|
-            7\d|
+            1[035]|
+            2[0346]|
+            3[03568]|
+            4[0356]|
+            5[0358]|
             8[458]
           )|
-          8[478]\d{7}
+          (?:
+            140(?:
+              1[16-8]|
+              2[259]|
+              3[124]|
+              4[17-9]|
+              5[124679]|
+              7
+            )|
+            8[478]\d{6}
+          )\d
         </nationalNumberPattern>
       </uan>
     </territory>
 
-    <!-- Norway -->
-    <!-- Metadata (excluding fixed-line) should be duplicated in 'SJ'. -->
+    <!-- Norway (NO) -->
     <!-- Main region for 'SJ' -->
+    <!-- Metadata (excluding fixed-line) should be duplicated in 'SJ'. -->
     <!-- http://www.npt.no/npt/numsys/E.164.pdf -->
     <!-- https://en.wikipedia.org/wiki/Telephone_numbers_in_Norway -->
     <territory id="NO" mainCountryForCode="true" countryCode="47" leadingDigits="[02-689]|7[0-8]"
                internationalPrefix="00" mobileNumberPortableRegion="true">
       <availableFormats>
+        <numberFormat pattern="(\d{3})(\d{2})(\d{3})">
+          <leadingDigits>
+            [489]|
+            5[89]
+          </leadingDigits>
+          <format>$1 $2 $3</format>
+        </numberFormat>
         <numberFormat pattern="(\d{2})(\d{2})(\d{2})(\d{2})">
           <leadingDigits>[235-7]</leadingDigits>
           <format>$1 $2 $3 $4</format>
-        </numberFormat>
-        <numberFormat pattern="(\d{3})(\d{2})(\d{3})">
-          <leadingDigits>[489]</leadingDigits>
-          <format>$1 $2 $3</format>
         </numberFormat>
       </availableFormats>
       <generalDesc>
@@ -20241,10 +21104,10 @@
       <!-- Includes some 810 local-rate numbers, and long-distance rate numbers. -->
       <uan>
         <possibleLengths national="5,8"/>
-        <exampleNumber>01234</exampleNumber>
+        <exampleNumber>02000</exampleNumber>
         <nationalNumberPattern>
           (?:
-            0\d|
+            0[2-9]|
             81(?:
               0(?:
                 0[7-9]|
@@ -20262,7 +21125,7 @@
       </voicemail>
     </territory>
 
-    <!-- Nepal -->
+    <!-- Nepal (NP) -->
     <!-- http://www.itu.int/oth/T0202000095/en -->
     <!-- http://www.ntc.net.np/mobile/mob_postpaid_number_scheme.php -->
     <!-- http://www.nta.gov.np/en/2012-06-01-11-45-17/2012-06-04-04-26-59/numbering-plan -->
@@ -20300,19 +21163,17 @@
         <possibleLengths national="8" localOnly="6,7"/>
         <exampleNumber>14567890</exampleNumber>
         <nationalNumberPattern>
+          1[0-6]\d{6}|
           (?:
-            1[0-6]\d|
-            (?:
-              2[13-79]|
-              3[135-8]|
-              4[146-9]|
-              5[135-7]|
-              6[13-9]|
-              7[15-9]|
-              8[1-46-9]|
-              9[1-79]
-            )[2-6]
-          )\d{5}
+            2[13-79]|
+            3[135-8]|
+            4[146-9]|
+            5[135-7]|
+            6[13-9]|
+            7[15-9]|
+            8[1-46-9]|
+            9[1-79]
+          )[2-6]\d{5}
         </nationalNumberPattern>
       </fixedLine>
       <!-- Added prefix 982 per IR21 from the carrier. -->
@@ -20329,7 +21190,7 @@
       </mobile>
     </territory>
 
-    <!-- Nauru -->
+    <!-- Nauru (NR) -->
     <!-- http://www.itu.int/oth/T0202000094/en -->
     <!-- http://en.wikipedia.org/wiki/Telephone_numbers_in_Nauru -->
     <territory id="NR" countryCode="674" internationalPrefix="00">
@@ -20365,7 +21226,7 @@
       </mobile>
     </territory>
 
-    <!-- Niue -->
+    <!-- Niue (NU) -->
     <!-- http://www.itu.int/oth/T02020000EC/en -->
     <!-- http://en.wikipedia.org/wiki/Telephone_numbers_in_Niue -->
     <territory id="NU" countryCode="683" internationalPrefix="00">
@@ -20395,7 +21256,7 @@
       </mobile>
     </territory>
 
-    <!-- New Zealand -->
+    <!-- New Zealand (NZ) -->
     <!-- Includes Ross Dependency, Antarctica -->
     <!-- Does not currently support 083 "Enhanced voice services", New Zealand direct service
          numbers and 050 "Nation-Wide Service". -->
@@ -20403,6 +21264,11 @@
     <territory id="NZ" countryCode="64" preferredInternationalPrefix="00"
                internationalPrefix="0(?:0|161)" nationalPrefix="0" mobileNumberPortableRegion="true">
       <availableFormats>
+        <!-- 8-digit variable cost (premium rate/toll free). -->
+        <numberFormat pattern="(\d{3})(\d{2})(\d{3})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>[89]0</leadingDigits>
+          <format>$1 $2 $3</format>
+        </numberFormat>
         <!-- Pattern for fixed-line formats, including Ross Dependency. -->
         <numberFormat pattern="(\d)(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>
@@ -20412,14 +21278,6 @@
             9[2-9]
           </leadingDigits>
           <format>$1-$2 $3</format>
-        </numberFormat>
-        <!-- 8-digit variable cost (premium rate/toll free). -->
-        <numberFormat pattern="(\d{3})(\d{2})(\d{3})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>
-            80|
-            9
-          </leadingDigits>
-          <format>$1 $2 $3</format>
         </numberFormat>
         <!-- 0274, 0210 and toll-free/premium-rate prefixes 0508/0800/0900. -->
         <numberFormat pattern="(\d{3})(\d{3})(\d{3,4})" nationalPrefixFormattingRule="$NP$FG">
@@ -20445,7 +21303,14 @@
              Vodafone numbers can be 8 digits (without leading 0)."
              Paging numbers and some mobile numbers (Telecom/Vodafone/TelstraClear). -->
         <numberFormat pattern="(\d{2})(\d{3})(\d{3,5})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>[278]</leadingDigits>
+          <leadingDigits>
+            2(?:
+              [169]|
+              7[0-35-9]
+            )|
+            7|
+            86
+          </leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
       </availableFormats>
@@ -20463,15 +21328,13 @@
         <possibleLengths national="8" localOnly="7"/>
         <exampleNumber>32345678</exampleNumber>
         <nationalNumberPattern>
+          24099\d{3}|
           (?:
-            24099|
-            (?:
-              3[2-79]|
-              [49][2-9]|
-              6[235-9]|
-              7[2-57-9]
-            )\d{3}
-          )\d{3}
+            3[2-79]|
+            [49][2-9]|
+            6[235-9]|
+            7[2-57-9]
+          )\d{6}
         </nationalNumberPattern>
       </fixedLine>
       <!-- Includes mobile radio service numbers (e.g. TeamTalk). -->
@@ -20479,10 +21342,8 @@
         <possibleLengths national="[8-10]"/>
         <exampleNumber>211234567</exampleNumber>
         <nationalNumberPattern>
-          2(?:
-            [0-28]\d?|
-            [79]
-          )\d{7}|
+          2[0-28]\d{8}|
+          2[0-27-9]\d{7}|
           21\d{6}
         </nationalNumberPattern>
       </mobile>
@@ -20516,7 +21377,7 @@
       </personalNumber>
     </territory>
 
-    <!-- Oman -->
+    <!-- Oman (OM) -->
     <!-- http://www.itu.int/oth/T020200009F/en -->
     <territory id="OM" countryCode="968" internationalPrefix="00" mobileNumberPortableRegion="true">
       <availableFormats>
@@ -20537,9 +21398,9 @@
         <nationalNumberPattern>
           (?:
             [279]\d{3}|
-            500|
-            8007\d?
-          )\d{4}
+            500
+          )\d{4}|
+          8007\d{4,5}
         </nationalNumberPattern>
       </generalDesc>
       <fixedLine>
@@ -20551,13 +21412,11 @@
         <possibleLengths national="8"/>
         <exampleNumber>92123456</exampleNumber>
         <nationalNumberPattern>
+          90[1-9]\d{5}|
           (?:
-            7[129]\d|
-            9(?:
-              0[1-9]|
-              [1-9]\d
-            )
-          )\d{5}
+            7[1289]|
+            9[1-9]
+          )\d{6}
         </nationalNumberPattern>
       </mobile>
       <!-- Link to document about toll-free numbers on http://www.tra.gov.om, which suggests they
@@ -20570,10 +21429,8 @@
         <possibleLengths national="[7-9]"/>
         <exampleNumber>80071234</exampleNumber>
         <nationalNumberPattern>
-          (?:
-            500|
-            8007\d?
-          )\d{4}
+          500\d{4}|
+          8007\d{4,5}
         </nationalNumberPattern>
       </tollFree>
       <premiumRate>
@@ -20583,7 +21440,7 @@
       </premiumRate>
     </territory>
 
-    <!-- Panama -->
+    <!-- Panama (PA) -->
     <!-- Last read July 9, 2014. -->
     <!-- Omits the fact that mobile phones are 8 digits long. -->
     <!-- http://www.asep.gob.pa/telecom/pnn/default.asp -->
@@ -20702,7 +21559,7 @@
             21[89]|
             6(?:
               [02-9]\d|
-              1[0-5]
+              1[0-6]
             )\d|
             8(?:
               1[01]|
@@ -20738,26 +21595,23 @@
       </premiumRate>
     </territory>
 
-    <!-- Peru -->
+    <!-- Peru (PE) -->
     <!-- http://www.itu.int/oth/T02020000A6/en -->
     <!-- http://en.wikipedia.org/wiki/+51 -->
     <!-- http://www.assistbook.com/South%20America/Peru/widecodes -->
     <territory id="PE" countryCode="51" internationalPrefix="19(?:1[124]|77|90)00"
                nationalPrefix="0" preferredExtnPrefix=" Anexo " mobileNumberPortableRegion="true">
       <availableFormats>
+        <numberFormat pattern="(\d{3})(\d{5})" nationalPrefixFormattingRule="($NP$FG)">
+          <leadingDigits>80</leadingDigits>
+          <format>$1 $2</format>
+        </numberFormat>
         <numberFormat pattern="(\d)(\d{7})" nationalPrefixFormattingRule="($NP$FG)">
           <leadingDigits>1</leadingDigits>
           <format>$1 $2</format>
         </numberFormat>
         <numberFormat pattern="(\d{2})(\d{6})" nationalPrefixFormattingRule="($NP$FG)">
-          <leadingDigits>
-            [4-7]|
-            8[2-4]
-          </leadingDigits>
-          <format>$1 $2</format>
-        </numberFormat>
-        <numberFormat pattern="(\d{3})(\d{5})" nationalPrefixFormattingRule="($NP$FG)">
-          <leadingDigits>8</leadingDigits>
+          <leadingDigits>[4-8]</leadingDigits>
           <format>$1 $2</format>
         </numberFormat>
         <!-- Formatting from common usage found on the internet, supported by ITU doc. -->
@@ -20774,12 +21628,21 @@
           )\d{7}
         </nationalNumberPattern>
       </generalDesc>
+      <!-- Looks like not all 1X numbers are land-line numbers in Lima, some of them are allotted
+           as IDDs. As it effects parsing of these numbers and no valid numbers found online, not
+           supporting 8 digit 191[124], 1977 and 1990 ranges. -->
       <fixedLine>
         <possibleLengths national="8" localOnly="6,7"/>
         <exampleNumber>11234567</exampleNumber>
         <nationalNumberPattern>
+          19(?:
+            [02-68]\d|
+            1[035-9]|
+            7[0-689]|
+            9[1-9]
+          )\d{4}|
           (?:
-            1\d|
+            1[0-8]|
             4[1-4]|
             5[1-46]|
             6[1-7]|
@@ -20815,7 +21678,7 @@
       </personalNumber>
     </territory>
 
-    <!-- French Polynesia (Tahiti) (Territoire français d'outre-mer) -->
+    <!-- French Polynesia (PF) -->
     <!-- http://www.itu.int/oth/T020200004D/en -->
     <territory id="PF" countryCode="689" internationalPrefix="00">
       <availableFormats>
@@ -20852,11 +21715,11 @@
       <mobile>
         <possibleLengths national="8"/>
         <exampleNumber>87123456</exampleNumber>
-        <nationalNumberPattern>8[79]\d{6}</nationalNumberPattern>
+        <nationalNumberPattern>8[7-9]\d{6}</nationalNumberPattern>
       </mobile>
     </territory>
 
-    <!-- Papua New Guinea -->
+    <!-- Papua New Guinea (PG) -->
     <!-- http://www.itu.int/oth/T02020000A4/en -->
     <!-- http://en.wikipedia.org/wiki/%2B675 -->
     <!-- http://nicta.gov.pg/search?searchword=numbering%20plan -->
@@ -20893,32 +21756,28 @@
         <exampleNumber>3123456</exampleNumber>
         <nationalNumberPattern>
           (?:
-            (?:
-              3[0-2]|
-              4[257]|
-              5[34]|
-              9[78]
-            )\d|
             64[1-9]|
-            77(?:
-              [0-24]\d|
-              30
-            )|
+            7730|
             85[02-46-9]
-          )\d{4}
+          )\d{4}|
+          (?:
+            3[0-2]|
+            4[257]|
+            5[34]|
+            77[0-24]|
+            9[78]
+          )\d{5}
         </nationalNumberPattern>
       </fixedLine>
       <mobile>
         <possibleLengths national="8"/>
         <exampleNumber>70123456</exampleNumber>
         <nationalNumberPattern>
+          775\d{5}|
           (?:
-            7(?:
-              [0-689]\d|
-              75
-            )|
-            81\d
-          )\d{5}
+            7[0-689]|
+            81
+          )\d{6}
         </nationalNumberPattern>
       </mobile>
       <tollFree>
@@ -20940,7 +21799,7 @@
       </voip>
     </territory>
 
-    <!-- Philippines -->
+    <!-- Philippines (PH) -->
     <!-- http://en.wikipedia.org/wiki/%2B63 -->
     <territory id="PH" countryCode="63" internationalPrefix="00" nationalPrefix="0">
       <availableFormats>
@@ -20967,15 +21826,13 @@
               4[26]|
               76
             )|
-            5(?:
-              22|
-              44
-            )|
-            642|
-            8(?:
-              62|
-              8[245]
-            )
+            544|
+            88[245]|
+            (?:
+              52|
+              64|
+              86
+            )2
           </leadingDigits>
           <leadingDigits>
             3(?:
@@ -21012,50 +21869,38 @@
           </leadingDigits>
           <format>$1 $2</format>
         </numberFormat>
-        <numberFormat pattern="(\d{2})(\d{3})(\d{4})" nationalPrefixFormattingRule="($NP$FG)">
-          <leadingDigits>
-            3[2-68]|
-            4[2-9]|
-            [5-7]|
-            8[2-8]
-          </leadingDigits>
-          <leadingDigits>
-            3(?:
-              [23568]|
-              4(?:
-                [0-57-9]|
-                6[02-8]
-              )
-            )|
-            4(?:
-              2(?:
-                [0-689]|
-                7[0-8]
-              )|
-              [3-8]|
-              9(?:
-                [0-246-9]|
-                3[1-9]|
-                5[0-57-9]
-              )
-            )|
-            [5-7]|
-            8(?:
-              [2-7]|
-              8(?:
-                [0-24-9]|
-                3[0-35-9]
-              )
-            )
-          </leadingDigits>
-          <format>$1 $2 $3</format>
-        </numberFormat>
         <numberFormat pattern="(\d{5})(\d{4})" nationalPrefixFormattingRule="($NP$FG)">
           <leadingDigits>
-            [34]|
-            88
+            346|
+            4(?:
+              27|
+              9[35]
+            )|
+            883
+          </leadingDigits>
+          <leadingDigits>
+            3469|
+            4(?:
+              279|
+              9(?:
+                30|
+                56
+              )
+            )|
+            8834
           </leadingDigits>
           <format>$1 $2</format>
+        </numberFormat>
+        <numberFormat pattern="(\d)(\d{4})(\d{4})" nationalPrefixFormattingRule="($NP$FG)">
+          <leadingDigits>2</leadingDigits>
+          <format>$1 $2 $3</format>
+        </numberFormat>
+        <numberFormat pattern="(\d{2})(\d{3})(\d{4})" nationalPrefixFormattingRule="($NP$FG)">
+          <leadingDigits>
+            [3-7]|
+            8[2-8]
+          </leadingDigits>
+          <format>$1 $2 $3</format>
         </numberFormat>
         <numberFormat pattern="(\d{3})(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>[89]</leadingDigits>
@@ -21073,27 +21918,26 @@
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
+          1800\d{7,9}|
           (?:
-            1800\d{2,4}|
             2|
             [89]\d{4}
           )\d{5}|
-          [3-8]\d{8}|
+          [2-8]\d{8}|
           [28]\d{7}
         </nationalNumberPattern>
       </generalDesc>
       <!-- Evidence on number length is hard to come by. We have found diallable numbers in Manila
            that have only 5 digits after the area code; plus it seems the 8822 area code is
-           followed by 6 digits, and 8842 by only 4. -->
+           followed by 6 digits, and 8842 by only 4. Subscriber number of area code 02 are migrated
+           from 7 digit to 8 digit since 6th October 2019. -->
       <fixedLine>
         <possibleLengths national="6,[8-10]" localOnly="4,5,7"/>
         <exampleNumber>21234567</exampleNumber>
         <nationalNumberPattern>
           (?:
-            2\d(?:
-              \d{2}
-            )?|
             (?:
+              2[3-8]|
               3[2-68]|
               4[2-9]|
               5[2-6]|
@@ -21105,6 +21949,9 @@
               42
             )
           )\d{4}|
+          2\d{5}(?:
+            \d{2}
+          )?|
           8[2-8]\d{7}
         </nationalNumberPattern>
       </fixedLine>
@@ -21117,14 +21964,13 @@
             81[37]|
             9(?:
               0[5-9]|
-              1[024-9]|
+              1[0-24-9]|
               2[0-35-9]|
-              3[02-9]|
+              [35]\d|
               4[235-9]|
-              5[056]|
-              6[5-7]|
-              7[3-79]|
-              89|
+              6[0-25-8]|
+              7[1-9]|
+              8[19]|
               9[4-9]
             )
           )\d{7}
@@ -21138,7 +21984,7 @@
       </tollFree>
     </territory>
 
-    <!-- Pakistan -->
+    <!-- Pakistan (PK) -->
     <!-- http://www.itu.int/oth/T02020000A1/en -->
     <!-- http://en.wikipedia.org/wiki/%2B92 -->
     <territory id="PK" countryCode="92" internationalPrefix="00" nationalPrefix="0"
@@ -21198,6 +22044,10 @@
             )
           </leadingDigits>
           <leadingDigits>
+            9(?:
+              2[3-8]|
+              98
+            )|
             (?:
               2(?:
                 3[2358]|
@@ -21213,23 +22063,15 @@
                 3[23578]|
                 4[3478]|
                 5[2356]
-              )
-            )[2-9]|
-            9(?:
-              2(?:
-                2[2-9]|
-                [3-8]
               )|
-              (?:
+              9(?:
+                22|
                 3[27-9]|
                 4[2-6]|
-                6[3569]
-              )[2-9]|
-              9(?:
-                [25-7][2-9]|
-                8
+                6[3569]|
+                9[25-7]
               )
-            )
+            )[2-9]
           </leadingDigits>
           <format>$1 $2</format>
         </numberFormat>
@@ -21268,20 +22110,18 @@
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
-          (?:
-            122|
-            [24-8]\d{4,5}|
-            9(?:
-              [013-9]\d{2,4}|
+          122\d{6}|
+          [24-8]\d{10,11}|
+          9(?:
+            [013-9]\d{8,10}|
+            2(?:
+              [01]\d\d|
               2(?:
-                [01]\d\d|
-                2(?:
-                  [025-8]\d|
-                  1[01]
-                )
-              )\d
-            )
-          )\d{6}|
+                [025-8]\d|
+                1[01]
+              )
+            )\d{7}
+          )|
           (?:
             [2-8]\d{3}|
             92(?:
@@ -21301,58 +22141,46 @@
         <possibleLengths national="9,10" localOnly="[5-8]"/>
         <exampleNumber>2123456789</exampleNumber>
         <nationalNumberPattern>
-          2(?:
+          (?:
             (?:
-              1[2-9]\d|
-              [25][2-9]
-            )\d{6}|
-            (?:
+              21|
+              42
+            )[2-9]|
+            58[126]
+          )\d{7}|
+          (?:
+            2[25]|
+            4[0146-9]|
+            5[1-35-7]|
+            6[1-8]|
+            7[14]|
+            8[16]|
+            91
+          )[2-9]\d{6}|
+          (?:
+            2(?:
               3[2358]|
               4[2-4]|
               9[2-8]
-            )[2-9]\d{5,6}
-          )|
-          4(?:
-            (?:
-              [0146-9][2-9]|
-              2[2-9]\d
-            )\d{6}|
-            5[3479][2-9]\d{5,6}
-          )|
-          5(?:
-            (?:
-              [1-35-7][2-9]|
-              8[126]\d
-            )\d{6}|
-            4[2-467][2-9]\d{5,6}
-          )|
-          6(?:
-            0[468][2-9]\d{5,6}|
-            [1-8][2-9]\d{6}
-          )|
-          7(?:
-            [14][2-9]\d{6}|
-            2[236][2-9]\d{5,6}
-          )|
-          8(?:
-            [16][2-9]\d{6}|
-            (?:
+            )|
+            45[3479]|
+            54[2-467]|
+            60[468]|
+            72[236]|
+            8(?:
               2[2-689]|
               3[23578]|
               4[3478]|
               5[2356]
-            )[2-9]\d{5,6}
-          )|
-          9(?:
-            1[2-9]\d{6}|
-            (?:
+            )|
+            9(?:
               2[2-8]|
               3[27-9]|
               4[2-6]|
               6[3569]|
               9[25-8]
-            )[2-9]\d{5,6}
-          )
+            )
+          )[2-9]\d{5,6}
         </nationalNumberPattern>
       </fixedLine>
       <!-- Adding 325 and 320 as SMSs have been successfully sent to these numbers and numbers
@@ -21440,7 +22268,7 @@
       </uan>
     </territory>
 
-    <!-- Poland -->
+    <!-- Poland (PL) -->
     <!-- Source is in Polish. -->
     <!-- http://en.wikipedia.org/wiki/%2B48 -->
     <!-- http://www.itu.int/oth/T02020000A8/en -->
@@ -21496,36 +22324,35 @@
           <leadingDigits>64</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
+        <!-- Mobile, pager and a few fixed-line numbers.
+             (70 numbers are formatted as per mobile numbers, based on information from some Polish people). -->
+        <numberFormat pattern="(\d{3})(\d{3})(\d{3})">
+          <leadingDigits>
+            39|
+            45|
+            5[0137]|
+            6[0469]|
+            7[02389]|
+            8[08]
+          </leadingDigits>
+          <format>$1 $2 $3</format>
+        </numberFormat>
         <!-- 9-digit fixed-line numbers. -->
         <numberFormat pattern="(\d{2})(\d{3})(\d{2})(\d{2})">
           <leadingDigits>
             1[2-8]|
-            2|
-            3[2-4]|
-            4[1-468]|
-            5[24-689]|
-            6[1-3578]|
-            7[14-7]|
-            8[1-79]|
+            [2-8]|
             9[145]
           </leadingDigits>
           <format>$1 $2 $3 $4</format>
         </numberFormat>
-        <!-- Mobile, pager and a few fixed-line numbers.
-             (70 numbers are formatted as per mobile numbers, based on information from some Polish people). -->
-        <numberFormat pattern="(\d{3})(\d{3})(\d{3})">
-          <leadingDigits>[3-8]</leadingDigits>
-          <format>$1 $2 $3</format>
-        </numberFormat>
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
-          [1-9]\d{6}(?:
+          [1-57-9]\d{6}(?:
             \d{2}
           )?|
-          6\d{5}(?:
-            \d{2}
-          )?
+          6\d{5,8}
         </nationalNumberPattern>
       </generalDesc>
       <!-- The plan says all geographical numbers are 9 digits; but we found customer service
@@ -21548,18 +22375,15 @@
             7[14-7]|
             8[1-79]|
             9[145]
-          )\d{7}|
-          (?:
-            1[2-8]|
-            2[2-69]|
-            3[2-4]|
-            4[1-468]|
-            5[24-689]|
-            6[1-3578]|
-            7[14-7]|
-            8[1-79]|
-            9[145]
-          )19\d{3}
+          )(?:
+            [02-9]\d{6}|
+            1(?:
+              [0-8]\d{5}|
+              9\d{3}(?:
+                \d{2}
+              )?
+            )
+          )
         </nationalNumberPattern>
       </fixedLine>
       <mobile>
@@ -21607,7 +22431,7 @@
       </uan>
     </territory>
 
-    <!-- Saint Pierre and Miquelon (Collectivité territoriale de la République française) -->
+    <!-- St. Pierre & Miquelon (PM) -->
     <!-- http://www.itu.int/oth/T02020000B2/en -->
     <territory id="PM" countryCode="508" internationalPrefix="00" nationalPrefix="0">
       <availableFormats>
@@ -21648,7 +22472,7 @@
       </mobile>
     </territory>
 
-    <!-- Puerto Rico -->
+    <!-- Puerto Rico (PR) -->
     <!-- Calling code and formatting shared with 'US' -->
     <!-- http://www.itu.int/oth/T02020000AA/en -->
     <territory id="PR" countryCode="1" leadingDigits="787|939" internationalPrefix="011"
@@ -21719,7 +22543,7 @@
       </personalNumber>
     </territory>
 
-    <!-- Palestinian Authority -->
+    <!-- Palestine (PS) -->
     <!-- Palestinian phone numbers can be reached through the Israeli country code (972) in addition
          to the Palestinian country code (970) and so Palestinian landlines and mobile lines are a
          subset of the Israeli formats. -->
@@ -21743,13 +22567,11 @@
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
+          [2489]2\d{6}|
           (?:
-            (?:
-              1\d|
-              5
-            )\d\d|
-            [2489]2
-          )\d{6}
+            1\d|
+            5
+          )\d{8}
         </nationalNumberPattern>
       </generalDesc>
       <fixedLine>
@@ -21781,7 +22603,7 @@
       </sharedCost>
     </territory>
 
-    <!-- Portugal -->
+    <!-- Portugal (PT) -->
     <!-- http://www.anacom.pt/render.jsp?categoryId=279098 -->
     <territory id="PT" countryCode="351" internationalPrefix="00" mobileNumberPortableRegion="true">
       <availableFormats>
@@ -21824,9 +22646,13 @@
         <possibleLengths national="9"/>
         <exampleNumber>912345678</exampleNumber>
         <nationalNumberPattern>
-          9(?:
-            [1-36]\d\d|
-            480
+          6[356]9230\d{3}|
+          (?:
+            6[036]93|
+            9(?:
+              [1-36]\d\d|
+              480
+            )
           )\d{5}
         </nationalNumberPattern>
       </mobile>
@@ -21892,7 +22718,7 @@
       </voicemail>
     </territory>
 
-    <!-- Palau -->
+    <!-- Palau (PW) -->
     <!-- http://www.itu.int/oth/T02020000A2/en -->
     <territory id="PW" countryCode="680" internationalPrefix="01[12]">
       <availableFormats>
@@ -21961,7 +22787,7 @@
       </mobile>
     </territory>
 
-    <!-- Paraguay -->
+    <!-- Paraguay (PY) -->
     <!-- http://en.wikipedia.org/wiki/Telephone_numbers_in_Paraguay -->
     <!-- http://www.itu.int/oth/T02020000A5/en -->
     <!-- http://www.copaco.com.py/portal/index.php/component/content/article/8-empresa/74-codigos-de-area.html -->
@@ -22008,30 +22834,27 @@
           </leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
-        <numberFormat pattern="(\d{3})(\d{3})(\d{3})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>
-            [2-7]|
-            85
-          </leadingDigits>
+        <!-- Format seen in examples found online. -->
+        <numberFormat pattern="(\d{2})(\d{3})(\d{4})">
+          <leadingDigits>87</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
         <numberFormat pattern="(\d{3})(\d{6})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>9</leadingDigits>
           <format>$1 $2</format>
         </numberFormat>
-        <!-- Format seen in examples found online. -->
-        <numberFormat pattern="(\d{2})(\d{3})(\d{4})">
-          <leadingDigits>8</leadingDigits>
+        <numberFormat pattern="(\d{3})(\d{3})(\d{3})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>[2-8]</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
+          59\d{4,6}|
           (?:
             [2-46-9]\d|
             5[0-8]
-          )\d{7}|
-          [2-9]\d{5,7}
+          )\d{4,7}
         </nationalNumberPattern>
       </generalDesc>
       <fixedLine>
@@ -22039,54 +22862,46 @@
         <exampleNumber>212345678</exampleNumber>
         <nationalNumberPattern>
           (?:
+            [26]1|
+            3[289]|
+            4[1246-8]|
+            7[1-3]|
+            8[1-36]
+          )\d{5,7}|
+          (?:
             2(?:
-              1\d|
               2[4-68]|
               7[15]|
               9[1-5]
+            )|
+            3(?:
+              18|
+              3[167]|
+              4[2357]|
+              51
+            )|
+            4(?:
+              3[12]|
+              5[13]|
+              9[1-47]
             )|
             5(?:
               [1-4]\d|
               5[02-4]
             )|
             6(?:
-              1\d|
               3[1-3]|
               44|
               7[1-46-8]
-            )
-          )\d{5,6}|
-          3(?:
-            (?:
-              18|
-              3[167]|
-              4[2357]|
-              51
-            )\d{5,6}|
-            [289]\d{5,7}
-          )|
-          4(?:
-            [1246-8]\d{5,7}|
-            (?:
-              3[12]|
-              5[13]|
-              9[1-47]
-            )\d{5,6}
-          )|
-          7(?:
-            [1-3]\d{5,7}|
-            (?:
+            )|
+            7(?:
               4[0-4]|
               6[1-578]|
               75|
               8[0-8]
-            )\d{5,6}
-          )|
-          8(?:
-            [1-36]\d{5,7}|
-            58\d{5,6}
-          )|
-          [26]1\d{5}
+            )|
+            858
+          )\d{5,6}
         </nationalNumberPattern>
       </fixedLine>
       <mobile>
@@ -22113,7 +22928,7 @@
       </uan>
     </territory>
 
-    <!-- Qatar -->
+    <!-- Qatar (QA) -->
     <!-- No premiumRate information can be found. -->
     <!-- http://www.itu.int/oth/T02020000AB/en -->
     <!-- http://wtng.info/wtng-qq.html -->
@@ -22127,17 +22942,15 @@
           <format>$1 $2</format>
         </numberFormat>
         <numberFormat pattern="(\d{4})(\d{4})">
-          <leadingDigits>[3-7]</leadingDigits>
+          <leadingDigits>[2-7]</leadingDigits>
           <format>$1 $2</format>
         </numberFormat>
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
+          [2-7]\d{7}|
           (?:
-            (?:
-              2|
-              [3-7]\d
-            )\d\d|
+            2\d\d|
             800
           )\d{4}
         </nationalNumberPattern>
@@ -22151,7 +22964,12 @@
       <mobile>
         <possibleLengths national="8"/>
         <exampleNumber>33123456</exampleNumber>
-        <nationalNumberPattern>[35-7]\d{7}</nationalNumberPattern>
+        <nationalNumberPattern>
+          (?:
+            28|
+            [35-7]\d
+          )\d{6}
+        </nationalNumberPattern>
       </mobile>
       <pager>
         <possibleLengths national="7"/>
@@ -22170,20 +22988,21 @@
       </tollFree>
     </territory>
 
-    <!-- Réunion (French Departments and Territories in the Indian Ocean) -->
+    <!-- Réunion (RE) -->
     <!-- Main region for 'YT' -->
     <!-- http://www.itu.int/oth/T020200004B/en -->
     <!-- http://www.arcep.fr/index.php?id=2137&bloc=0596&CMD=RESULTS_NUMEROTATION -->
-    <territory id="RE" mainCountryForCode="true" countryCode="262" leadingDigits="262|69|8"
+    <territory id="RE" mainCountryForCode="true" countryCode="262" leadingDigits="26[23]|69|[89]"
                internationalPrefix="00" nationalPrefix="0">
       <availableFormats>
         <numberFormat pattern="(\d{3})(\d{2})(\d{2})(\d{2})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>[268]</leadingDigits>
+          <leadingDigits>[2689]</leadingDigits>
           <format>$1 $2 $3 $4</format>
         </numberFormat>
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
+          9769\d{5}|
           (?:
             26|
             [68]\d
@@ -22194,26 +23013,34 @@
       <fixedLine>
         <possibleLengths national="9"/>
         <exampleNumber>262161234</exampleNumber>
-        <nationalNumberPattern>262\d{6}</nationalNumberPattern>
+        <nationalNumberPattern>
+          26(?:
+            2\d\d|
+            30[01]
+          )\d{4}
+        </nationalNumberPattern>
       </fixedLine>
       <mobile>
         <possibleLengths national="9"/>
         <exampleNumber>692123456</exampleNumber>
         <nationalNumberPattern>
-          69(?:
-            2\d\d|
-            3(?:
-              0[0-46]|
-              1[013]|
-              2[0-2]|
-              3[0-39]|
-              4\d|
-              5[05]|
-              6[0-26]|
-              7[0-27]|
-              8[0-38]|
-              9[0-479]
-            )
+          (?:
+            69(?:
+              2\d\d|
+              3(?:
+                0[0-46]|
+                1[013]|
+                2[0-2]|
+                3[0-39]|
+                4\d|
+                5[05]|
+                6[0-26]|
+                7[0-27]|
+                8[03-8]|
+                9[0-479]
+              )
+            )|
+            9769\d
           )\d{4}
         </nationalNumberPattern>
       </mobile>
@@ -22242,7 +23069,7 @@
       </sharedCost>
     </territory>
 
-    <!-- Romania -->
+    <!-- Romania (RO) -->
     <!-- Extension prefix found online, confirmed by a Romanian. -->
     <!-- http://www.itu.int/oth/T02020000AC/en -->
     <!-- http://en.wikipedia.org/wiki/Telephone_numbers_in_Romania -->
@@ -22250,16 +23077,16 @@
     <territory id="RO" countryCode="40" internationalPrefix="00" nationalPrefix="0"
                preferredExtnPrefix=" int " mobileNumberPortableRegion="true">
       <availableFormats>
+        <numberFormat pattern="(\d{3})(\d{3})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>2[3-6]</leadingDigits>
+          <leadingDigits>2[3-6]\d9</leadingDigits>
+          <format>$1 $2</format>
+        </numberFormat>
         <numberFormat pattern="(\d{2})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>
             219|
             31
           </leadingDigits>
-          <format>$1 $2</format>
-        </numberFormat>
-        <numberFormat pattern="(\d{3})(\d{3})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>2[3-6]</leadingDigits>
-          <leadingDigits>2[3-6]\d9</leadingDigits>
           <format>$1 $2</format>
         </numberFormat>
         <numberFormat pattern="(\d{2})(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
@@ -22311,17 +23138,13 @@
         <possibleLengths national="9"/>
         <exampleNumber>712034567</exampleNumber>
         <nationalNumberPattern>
+          7120\d{5}|
           7(?:
-            (?:
-              [02-7]\d|
-              8[03-8]|
-              99
-            )\d|
-            1(?:
-              [01]\d|
-              20
-            )
-          )\d{5}
+            [02-7]\d|
+            1[01]|
+            8[03-8]|
+            9[09]
+          )\d{6}
         </nationalNumberPattern>
       </mobile>
       <tollFree>
@@ -22351,7 +23174,7 @@
       </uan>
     </territory>
 
-    <!-- Serbia -->
+    <!-- Serbia (RS) -->
     <!-- http://www.itu.int/oth/T02020000B9/en -->
     <!-- http://registar.ratel.rs/en/reg202 -->
     <territory id="RS" countryCode="381" internationalPrefix="00" nationalPrefix="0"
@@ -22376,18 +23199,18 @@
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
-          [127]\d{6,11}|
-          3(?:
-            [0-79]\d{5,10}|
-            8(?:
-              [02-9]\d{4,9}|
-              1\d{4,5}
-            )
-          )|
+          38[02-9]\d{6,9}|
           6\d{7,9}|
-          800\d{3,9}|
           90\d{4,8}|
-          7\d{5}
+          38\d{5,6}|
+          (?:
+            7\d\d|
+            800
+          )\d{3,9}|
+          (?:
+            [12]\d|
+            3[0-79]
+          )\d{5,10}
         </nationalNumberPattern>
       </generalDesc>
       <!-- Most subscriber numbers may not start with 0 or 1. Exceptionally, the prefix 11 1[5-7]
@@ -22397,25 +23220,20 @@
         <exampleNumber>10234567</exampleNumber>
         <nationalNumberPattern>
           (?:
-            1(?:
-              [02-9][2-9]|
-              1[1-9]
-            )\d|
-            2(?:
-              [0-24-7][2-9]\d|
-              [389](?:
-                0[2-9]|
-                [2-9]\d
-              )
-            )|
-            3(?:
-              [0-8][2-9]\d|
-              9(?:
-                0[2-9]|
-                [2-9]\d
-              )
+            11[1-9]\d|
+            (?:
+              2[389]|
+              39
+            )(?:
+              0[2-9]|
+              [2-9]\d
             )
-          )\d{3,8}
+          )\d{3,8}|
+          (?:
+            1[02-9]|
+            2[0-24-7]|
+            3[0-8]
+          )[2-9]\d{4,9}
         </nationalNumberPattern>
       </fixedLine>
       <mobile>
@@ -22450,7 +23268,7 @@
       </uan>
     </territory>
 
-    <!-- Russian Federation -->
+    <!-- Russia (RU) -->
     <!-- Main region for 'KZ' -->
     <!-- http://www.itu.int/oth/T02020000AD/en -->
     <!-- http://en.wikipedia.org/wiki/%2B7 -->
@@ -22461,8 +23279,117 @@
                preferredInternationalPrefix="8~10" internationalPrefix="810" nationalPrefix="8">
       <availableFormats>
         <numberFormat pattern="(\d{3})(\d{2})(\d{2})">
+          <leadingDigits>[0-79]</leadingDigits>
           <format>$1-$2-$3</format>
           <intlFormat>NA</intlFormat>
+        </numberFormat>
+        <!-- Kazakhstan formatting only. -->
+        <numberFormat pattern="(\d{4})(\d{2})(\d{2})(\d{2})"
+                      nationalPrefixFormattingRule="$NP ($FG)"
+                      nationalPrefixOptionalWhenFormatting="true">
+          <leadingDigits>
+            7(?:
+              1[0-8]|
+              2[1-9]
+            )
+          </leadingDigits>
+          <leadingDigits>
+            7(?:
+              1(?:
+                [0-6]2|
+                7|
+                8[27]
+              )|
+              2(?:
+                1[23]|
+                [2-9]2
+              )
+            )
+          </leadingDigits>
+          <leadingDigits>
+            7(?:
+              1(?:
+                [0-6]2|
+                7|
+                8[27]
+              )|
+              2(?:
+                13[03-69]|
+                62[013-9]
+              )
+            )|
+            72[1-57-9]2
+          </leadingDigits>
+          <format>$1 $2 $3 $4</format>
+        </numberFormat>
+        <!-- Kazakhstan formatting only. -->
+        <numberFormat pattern="(\d{5})(\d)(\d{2})(\d{2})" nationalPrefixFormattingRule="$NP ($FG)"
+                      nationalPrefixOptionalWhenFormatting="true">
+          <leadingDigits>
+            7(?:
+              1[0-68]|
+              2[1-9]
+            )
+          </leadingDigits>
+          <leadingDigits>
+            7(?:
+              1(?:
+                [06][3-6]|
+                [18]|
+                2[35]|
+                [3-5][3-5]
+              )|
+              2(?:
+                [13][3-5]|
+                [24-689]|
+                7[457]
+              )
+            )
+          </leadingDigits>
+          <leadingDigits>
+            7(?:
+              1(?:
+                0(?:
+                  [356]|
+                  4[023]
+                )|
+                [18]|
+                2(?:
+                  3[013-9]|
+                  5
+                )|
+                3[45]|
+                43[013-79]|
+                5(?:
+                  3[1-8]|
+                  4[1-7]|
+                  5
+                )|
+                6(?:
+                  3[0-35-9]|
+                  [4-6]
+                )
+              )|
+              2(?:
+                1(?:
+                  3[178]|
+                  [45]
+                )|
+                [24-689]|
+                3[35]|
+                7[457]
+              )
+            )|
+            7(?:
+              14|
+              23
+            )4[0-8]|
+            71(?:
+              33|
+              45
+            )[1-79]
+          </leadingDigits>
+          <format>$1 $2 $3 $4</format>
         </numberFormat>
         <!-- Kazakhstan formatting only. -->
         <numberFormat pattern="(\d{3})(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP ($FG)"
@@ -22544,7 +23471,7 @@
       </personalNumber>
     </territory>
 
-    <!-- Rwanda -->
+    <!-- Rwanda (RW) -->
     <!-- According to ITU, there is no national prefix. However, this is still used. As of June 3rd
          2011, this was confirmed by a Rwandan local. It is also shown in this format on pages such
          as http://www.tigo.co.rw "Choose Your Number" service. -->
@@ -22605,12 +23532,18 @@
       </premiumRate>
     </territory>
 
-    <!-- Saudi Arabia -->
+    <!-- Saudi Arabia (SA) -->
     <!-- http://en.wikipedia.org/wiki/Telephone_numbers_in_Saudi_Arabia -->
     <!-- http://www.itu.int/oth/T02020000B7/en -->
     <territory id="SA" countryCode="966" internationalPrefix="00" nationalPrefix="0"
                mobileNumberPortableRegion="true">
       <availableFormats>
+        <!-- It seems that the trunk prefix is not used for these numbers, based on wikipedia and on
+             the fact that no numbers of this form found online have a trunk prefix added. -->
+        <numberFormat pattern="(\d{4})(\d{5})">
+          <leadingDigits>9</leadingDigits>
+          <format>$1 $2</format>
+        </numberFormat>
         <numberFormat pattern="(\d{2})(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>1</leadingDigits>
           <format>$1 $2 $3</format>
@@ -22618,12 +23551,6 @@
         <numberFormat pattern="(\d{2})(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>5</leadingDigits>
           <format>$1 $2 $3</format>
-        </numberFormat>
-        <!-- It seems that the trunk prefix is not used for these numbers, based on wikipedia and on
-             the fact that no numbers of this form found online have a trunk prefix added. -->
-        <numberFormat pattern="(\d{4})(\d{5})">
-          <leadingDigits>9</leadingDigits>
-          <format>$1 $2</format>
         </numberFormat>
         <numberFormat pattern="(\d{3})(\d{3})(\d{3,4})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>81</leadingDigits>
@@ -22636,13 +23563,11 @@
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
+          92\d{7}|
           (?:
-            (?:
-              [15]|
-              8\d
-            )\d|
-            92
-          )\d{7}
+            [15]|
+            8\d
+          )\d{8}
         </nationalNumberPattern>
       </generalDesc>
       <fixedLine>
@@ -22696,7 +23621,7 @@
       </uan>
     </territory>
 
-    <!-- Solomon Islands -->
+    <!-- Solomon Islands (SB) -->
     <!-- http://www.itu.int/oth/T02020000BF/en -->
     <!-- A single group is used to format 5-digit numbers. This formatting pattern follows
          the guidelines in the ITU document. -->
@@ -22704,16 +23629,10 @@
       <availableFormats>
         <numberFormat pattern="(\d{2})(\d{5})">
           <leadingDigits>
-            7[1-9]|
+            7|
             8[4-9]|
             9(?:
-              1[2-9]|
-              2[013-9]|
-              3[0-2]|
-              [46]|
-              5[0-46-9]|
-              7[0-689]|
-              8[0-79]|
+              [1-8]|
               9[0-8]
             )
           </leadingDigits>
@@ -22747,25 +23666,23 @@
         <possibleLengths national="5,7"/>
         <exampleNumber>7421234</exampleNumber>
         <nationalNumberPattern>
+          48\d{3}|
           (?:
-            48|
             (?:
-              (?:
-                7[1-9]|
-                8[4-9]
-              )\d|
-              9(?:
-                1[2-9]|
-                2[013-9]|
-                3[0-2]|
-                [46]\d|
-                5[0-46-9]|
-                7[0-689]|
-                8[0-79]|
-                9[0-8]
-              )
-            )\d
-          )\d{3}
+              7[1-9]|
+              8[4-9]
+            )\d|
+            9(?:
+              1[2-9]|
+              2[013-9]|
+              3[0-2]|
+              [46]\d|
+              5[0-46-9]|
+              7[0-689]|
+              8[0-79]|
+              9[0-8]
+            )
+          )\d{4}
         </nationalNumberPattern>
       </mobile>
       <tollFree>
@@ -22780,11 +23697,11 @@
       </voip>
     </territory>
 
-    <!-- Seychelles -->
+    <!-- Seychelles (SC) -->
     <!-- http://www.itu.int/oth/T02020000BA/en -->
     <!-- http://en.wikipedia.org/wiki/Telephone_numbers_in_Seychelles -->
     <territory id="SC" countryCode="248" preferredInternationalPrefix="00"
-               internationalPrefix="0(?:[02]|10?)">
+               internationalPrefix="010|0[0-2]">
       <availableFormats>
         <numberFormat pattern="(\d)(\d{3})(\d{3})">
           <leadingDigits>[246]</leadingDigits>
@@ -22793,16 +23710,11 @@
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
+          8000\d{3}|
           (?:
-            (?:
-              (?:
-                [24]\d|
-                64
-              )\d|
-              971
-            )\d|
-            8000
-          )\d{3}
+            [249]\d|
+            64
+          )\d{5}
         </nationalNumberPattern>
       </generalDesc>
       <!-- We are putting Fixed Services numbers here for now, as we cannot find any evidence that
@@ -22824,21 +23736,24 @@
         <exampleNumber>8000000</exampleNumber>
         <nationalNumberPattern>8000\d{3}</nationalNumberPattern>
       </tollFree>
-      <!-- Includes prefix 971 which is assigned to Audiotext Services. -->
+      <!-- Includes prefix 971,95[0-9] which is assigned to Audiotext ,International Audiotext
+           Services. -->
       <voip>
         <possibleLengths national="7"/>
         <exampleNumber>6412345</exampleNumber>
         <nationalNumberPattern>
+          971\d{4}|
           (?:
-            64\d|
-            971
-          )\d{4}
+            64|
+            95
+          )\d{5}
         </nationalNumberPattern>
       </voip>
     </territory>
 
-    <!-- Sudan -->
+    <!-- Sudan (SD) -->
     <!-- http://www.itu.int/oth/T02020000C4/en -->
+    <!-- https://en.wikipedia.org/wiki/Telephone_numbers_in_Sudan -->
     <territory id="SD" countryCode="249" internationalPrefix="00" nationalPrefix="0">
       <availableFormats>
         <numberFormat pattern="(\d{2})(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
@@ -22852,12 +23767,14 @@
       <!-- Retaining previous prefix as 18 since it seems still to be used. ITU doc says 12 is a
            fixed-line range but we are supporting 1[0-2] under mobile as Sudatel mentions that
            these mobile ranges are assigned to them. -->
+      <!-- The third digit here is an area code as per Wikipedia. Added 154 range based on valid
+           numbers found online. -->
       <fixedLine>
         <possibleLengths national="9"/>
-        <exampleNumber>151231234</exampleNumber>
+        <exampleNumber>153123456</exampleNumber>
         <nationalNumberPattern>
           1(?:
-            5\d|
+            5[3-7]|
             8[35-7]
           )\d{6}
         </nationalNumberPattern>
@@ -22874,7 +23791,7 @@
       </mobile>
     </territory>
 
-    <!-- Sweden -->
+    <!-- Sweden (SE) -->
     <!-- https://www.pts.se/en/english-b/telephony/national-numbering-and-addressing-plans/ -->
     <!-- Formatting patterns are from the numbering plan and from the Swedish yellow pages
          http://gulasidorna.eniro.se -->
@@ -22884,18 +23801,6 @@
         <!-- Short toll-free numbers. -->
         <numberFormat pattern="(\d{2})(\d{2,3})(\d{2})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>20</leadingDigits>
-          <format>$1-$2 $3</format>
-          <intlFormat>$1 $2 $3</intlFormat>
-        </numberFormat>
-        <!-- Short fixed line numbers (2 digit area code) -->
-        <numberFormat pattern="(\d{2})(\d{3})(\d{2})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>
-            [12][136]|
-            3[356]|
-            4[0246]|
-            6[03]|
-            90[1-9]
-          </leadingDigits>
           <format>$1-$2 $3</format>
           <intlFormat>$1 $2 $3</intlFormat>
         </numberFormat>
@@ -22910,6 +23815,18 @@
           </leadingDigits>
           <format>$1-$2</format>
           <intlFormat>$1 $2</intlFormat>
+        </numberFormat>
+        <!-- Short fixed line numbers (2 digit area code) -->
+        <numberFormat pattern="(\d{2})(\d{3})(\d{2})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>
+            [12][136]|
+            3[356]|
+            4[0246]|
+            6[03]|
+            90[1-9]
+          </leadingDigits>
+          <format>$1-$2 $3</format>
+          <intlFormat>$1 $2 $3</intlFormat>
         </numberFormat>
         <!-- Fixed line numbers in Stockholm (1 digit area code) -->
         <numberFormat pattern="(\d)(\d{2,3})(\d{2})(\d{2})" nationalPrefixFormattingRule="$NP$FG">
@@ -22942,6 +23859,18 @@
           <format>$1-$2 $3</format>
           <intlFormat>$1 $2 $3</intlFormat>
         </numberFormat>
+        <!-- 8-9 digit premium rate numbers. -->
+        <numberFormat pattern="(\d{3})(\d{2,3})(\d{3})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>
+            9(?:
+              00|
+              39|
+              44
+            )
+          </leadingDigits>
+          <format>$1-$2 $3</format>
+          <intlFormat>$1 $2 $3</intlFormat>
+        </numberFormat>
         <!-- Fixed line numbers (2 digit area code) and "long" toll free numbers. -->
         <numberFormat pattern="(\d{2})(\d{2,3})(\d{2})(\d{2})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>
@@ -22956,17 +23885,11 @@
           <format>$1-$2 $3 $4</format>
           <intlFormat>$1 $2 $3 $4</intlFormat>
         </numberFormat>
-        <!-- 8-9 digit premium rate numbers. -->
-        <numberFormat pattern="(\d{3})(\d{2,3})(\d{3})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>
-            9(?:
-              0|
-              39|
-              44
-            )
-          </leadingDigits>
-          <format>$1-$2 $3</format>
-          <intlFormat>$1 $2 $3</intlFormat>
+        <!-- Mobile numbers and other 9 digit numbers starting with 7 (pager, shared cost etc.) -->
+        <numberFormat pattern="(\d{2})(\d{3})(\d{2})(\d{2})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>7</leadingDigits>
+          <format>$1-$2 $3 $4</format>
+          <intlFormat>$1 $2 $3 $4</intlFormat>
         </numberFormat>
         <!-- Fixed line numbers in Stockholm (1 digit area code) -->
         <numberFormat pattern="(\d)(\d{3})(\d{3})(\d{2})" nationalPrefixFormattingRule="$NP$FG">
@@ -22992,12 +23915,6 @@
               4[0-3]
             )
           </leadingDigits>
-          <format>$1-$2 $3 $4</format>
-          <intlFormat>$1 $2 $3 $4</intlFormat>
-        </numberFormat>
-        <!-- Mobile numbers and other 9 digit numbers starting with 7 (pager, shared cost etc.) -->
-        <numberFormat pattern="(\d{2})(\d{3})(\d{2})(\d{2})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>7</leadingDigits>
           <format>$1-$2 $3 $4</format>
           <intlFormat>$1 $2 $3 $4</intlFormat>
         </numberFormat>
@@ -23031,19 +23948,24 @@
         <possibleLengths national="[7-9]"/>
         <exampleNumber>8123456</exampleNumber>
         <nationalNumberPattern>
-          1(?:
-            0[1-8]\d{6}|
-            (?:
-              [13689]\d|
+          10[1-8]\d{6}|
+          90[1-9]\d{4,6}|
+          (?:
+            [12][136]|
+            3[356]|
+            4[0246]|
+            6[03]|
+            8\d
+          )\d{5,7}|
+          (?:
+            1(?:
               2[0-35]|
               4[0-4]|
               5[0-25-9]|
-              7[13-6]
-            )\d{5,6}
-          )|
-          (?:
+              7[13-6]|
+              [89]\d
+            )|
             2(?:
-              [136]\d|
               2[0-7]|
               4[0136-8]|
               5[0138]|
@@ -23053,12 +23975,20 @@
             )|
             3(?:
               0[0-4]|
-              [1356]\d|
+              1\d|
               2[0-25]|
               4[056]|
               7[0-2]|
               8[0-3]|
               9[023]
+            )|
+            4(?:
+              1[013-8]|
+              3[0135]|
+              5[14-79]|
+              7[0-246-9]|
+              8[0156]|
+              9[0-689]
             )|
             5(?:
               0[0-6]|
@@ -23070,22 +24000,8 @@
               7[013]|
               8[0-79]|
               9[01]
-            )
-          )\d{5,6}|
-          4(?:
-            [0246]\d{5,7}|
-            (?:
-              1[013-8]|
-              3[0135]|
-              5[14-79]|
-              7[0-246-9]|
-              8[0156]|
-              9[0-689]
-            )\d{5,6}
-          )|
-          6(?:
-            [03]\d{5,7}|
-            (?:
+            )|
+            6(?:
               1[1-3]|
               2[0-4]|
               4[02-57]|
@@ -23094,12 +24010,8 @@
               7[0-2]|
               8[0247]|
               9[0-356]
-            )\d{5,6}
-          )|
-          8\d{6,8}|
-          9(?:
-            0[1-9]\d{4,6}|
-            (?:
+            )|
+            9(?:
               1[0-68]|
               2\d|
               3[02-5]|
@@ -23107,12 +24019,8 @@
               5[0-4]|
               [68][01]|
               7[0135-8]
-            )\d{5,6}
-          )|
-          (?:
-            [12][136]|
-            3[356]
-          )\d{5}
+            )
+          )\d{5,6}
         </nationalNumberPattern>
       </fixedLine>
       <mobile>
@@ -23164,16 +24072,34 @@
       </voicemail>
     </territory>
 
-    <!-- Singapore -->
+    <!-- Singapore (SG) -->
     <!-- http://www.ida.gov.sg/Policies-and-Regulations/Industry-and-Licensees/Numbering/National-Numbering-Plan-and-Allocation-Process.aspx -->
     <!-- https://en.wikipedia.org/wiki/Telephone_numbers_in_Singapore -->
     <territory id="SG" countryCode="65" internationalPrefix="0[0-3]\d"
                mobileNumberPortableRegion="true">
       <availableFormats>
+        <numberFormat pattern="(\d{4,5})">
+          <leadingDigits>
+            1[013-9]|
+            77
+          </leadingDigits>
+          <leadingDigits>
+            1(?:
+              [013-8]|
+              9(?:
+                0[1-9]|
+                [1-9]
+              )
+            )|
+            77
+          </leadingDigits>
+          <format>$1</format>
+          <intlFormat>NA</intlFormat>
+        </numberFormat>
         <numberFormat pattern="(\d{4})(\d{4})">
           <leadingDigits>
             [369]|
-            8[1-8]
+            8[1-9]
           </leadingDigits>
           <format>$1 $2</format>
         </numberFormat>
@@ -23181,40 +24107,54 @@
           <leadingDigits>8</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
-        <numberFormat pattern="(\d{4})(\d{3})(\d{4})">
-          <leadingDigits>1[89]</leadingDigits>
+        <numberFormat pattern="(\d{4})(\d{4})(\d{3})">
+          <leadingDigits>7</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
-        <numberFormat pattern="(\d{4})(\d{4})(\d{3})">
-          <leadingDigits>70</leadingDigits>
+        <numberFormat pattern="(\d{4})(\d{3})(\d{4})">
+          <leadingDigits>1</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
           (?:
-            1\d{3}|
-            [369]|
-            7000|
-            8(?:
-              \d{2}
-            )?
-          )\d{7}
+            (?:
+              1\d|
+              8
+            )\d\d|
+            7000
+          )\d{7}|
+          [3689]\d{7}
         </nationalNumberPattern>
       </generalDesc>
       <fixedLine>
         <possibleLengths national="8"/>
         <exampleNumber>61234567</exampleNumber>
-        <nationalNumberPattern>6[1-9]\d{6}</nationalNumberPattern>
+        <nationalNumberPattern>
+          662[0-24-9]\d{4}|
+          6(?:
+            [1-578]\d|
+            6[013-57-9]|
+            9[0-35-9]
+          )\d{5}
+        </nationalNumberPattern>
       </fixedLine>
       <mobile>
         <possibleLengths national="8"/>
         <exampleNumber>81234567</exampleNumber>
         <nationalNumberPattern>
           (?:
-            8[1-8]|
-            9[0-8]
-          )\d{6}
+            8(?:
+              [1-8]\d\d|
+              9(?:
+                [01]\d|
+                2[4-8]|
+                3[0-4]
+              )
+            )|
+            9[0-8]\d\d
+          )\d{4}
         </nationalNumberPattern>
       </mobile>
       <tollFree>
@@ -23235,7 +24175,12 @@
       <voip>
         <possibleLengths national="8"/>
         <exampleNumber>31234567</exampleNumber>
-        <nationalNumberPattern>3[12]\d{6}</nationalNumberPattern>
+        <nationalNumberPattern>
+          (?:
+            3[12]\d\d|
+            6666
+          )\d{4}
+        </nationalNumberPattern>
       </voip>
       <!-- Although not detailed in the plan beyond mentioning their existence, it seems 7000
            numbers are used for companies. Most of the online examples are in fact alpha-numbers. -->
@@ -23246,7 +24191,7 @@
       </uan>
     </territory>
 
-    <!-- Saint Helena -->
+    <!-- St. Helena (SH) -->
     <!-- Main region for 'TA' -->
     <!-- http://www.itu.int/oth/T02020000AF/en -->
     <territory id="SH" mainCountryForCode="true" countryCode="290" leadingDigits="[256]"
@@ -23291,7 +24236,7 @@
       </voip>
     </territory>
 
-    <!-- Slovenia -->
+    <!-- Slovenia (SI) -->
     <!-- http://www.itu.int/oth/T02020000BE/en -->
     <!-- http://www.akos-rs.si/numbering-space -->
     <territory id="SI" countryCode="386" preferredInternationalPrefix="00"
@@ -23305,31 +24250,32 @@
           </leadingDigits>
           <format>$1 $2</format>
         </numberFormat>
-        <numberFormat pattern="(\d)(\d{3})(\d{2})(\d{2})" nationalPrefixFormattingRule="($NP$FG)">
+        <numberFormat pattern="(\d{3})(\d{5})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>
-            [12]|
-            [357][2-8]|
-            4[24-8]
+            59|
+            8
           </leadingDigits>
-          <format>$1 $2 $3 $4</format>
+          <format>$1 $2</format>
         </numberFormat>
         <numberFormat pattern="(\d{2})(\d{3})(\d{3})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>
-            [3467]|
-            51
+            [37][01]|
+            4[0139]|
+            51|
+            6
           </leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
-        <numberFormat pattern="(\d{3})(\d{5})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>[58]</leadingDigits>
-          <format>$1 $2</format>
+        <numberFormat pattern="(\d)(\d{3})(\d{2})(\d{2})" nationalPrefixFormattingRule="($NP$FG)">
+          <leadingDigits>[1-57]</leadingDigits>
+          <format>$1 $2 $3 $4</format>
         </numberFormat>
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
-          [1-8]\d{7}|
-          90\d{4,6}|
-          8\d{4,6}
+          [1-7]\d{7}|
+          8\d{4,7}|
+          90\d{4,6}
         </nationalNumberPattern>
       </generalDesc>
       <!-- Prefix 32 added after a user report. -->
@@ -23346,30 +24292,23 @@
       <!-- 43 range is mentioned as geographic number in 18.VII.2018 ITU doc where as previous
            ITU doc (15.III.2017) says it is MVNO. Supporting it under mobile as we found the
            numbers does not belong to same area. We include 049 here - it is VoIP in the plan,
-           but is actually used to provide mobile coverage to Kosovo. -->
+           but is actually used to provide mobile coverage to Kosovo. Supporting all 69X numbers
+           based on Wikipedia and some sub ranges being present in IR 21 doc. -->
       <mobile>
         <possibleLengths national="8"/>
         <exampleNumber>31234567</exampleNumber>
         <nationalNumberPattern>
+          65(?:
+            1\d|
+            55|
+            [67]0
+          )\d{4}|
           (?:
-            (?:
-              [37][01]|
-              4[0139]|
-              51
-            )\d\d|
-            6(?:
-              [48]\d\d|
-              5(?:
-                1\d|
-                55|
-                [67]0
-              )|
-              9(?:
-                10|
-                [69]\d
-              )
-            )
-          )\d{4}
+            [37][01]|
+            4[0139]|
+            51|
+            6[489]
+          )\d{6}
         </nationalNumberPattern>
       </mobile>
       <tollFree>
@@ -23409,20 +24348,18 @@
       </voip>
     </territory>
 
-    <!-- Svalbard -->
+    <!-- Svalbard & Jan Mayen (SJ) -->
     <!-- Calling code and formatting shared with 'NO' -->
     <!-- http://www.npt.no/pt_internet/numsys/E.164.pdf -->
     <!-- https://en.wikipedia.org/wiki/Telephone_numbers_in_Svalbard -->
     <territory id="SJ" countryCode="47" leadingDigits="79" internationalPrefix="00">
       <generalDesc>
         <nationalNumberPattern>
+          0\d{4}|
           (?:
-            0|
-            (?:
-              [4589]\d|
-              79
-            )\d\d
-          )\d{4}
+            [4589]\d|
+            79
+          )\d{6}
         </nationalNumberPattern>
       </generalDesc>
       <fixedLine>
@@ -23475,10 +24412,10 @@
       <!-- Includes some 810 local-rate numbers, and long-distance rate numbers. -->
       <uan>
         <possibleLengths national="5,8"/>
-        <exampleNumber>01234</exampleNumber>
+        <exampleNumber>02000</exampleNumber>
         <nationalNumberPattern>
           (?:
-            0\d|
+            0[2-9]|
             81(?:
               0(?:
                 0[7-9]|
@@ -23496,7 +24433,7 @@
       </voicemail>
     </territory>
 
-    <!-- Slovakia -->
+    <!-- Slovakia (SK) -->
     <!-- http://www.itu.int/oth/T02020000BD/en -->
     <!-- http://www.teleoff.gov.sk/data/files/25211.pdf -->
     <territory id="SK" countryCode="421" internationalPrefix="00" nationalPrefix="0"
@@ -23521,13 +24458,13 @@
           <leadingDigits>2</leadingDigits>
           <format>$1/$2 $3 $4</format>
         </numberFormat>
-        <numberFormat pattern="(\d{2})(\d{3})(\d{2})(\d{2})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>[3-5]</leadingDigits>
-          <format>$1/$2 $3 $4</format>
-        </numberFormat>
         <numberFormat pattern="(\d{3})(\d{3})(\d{3})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>[689]</leadingDigits>
           <format>$1 $2 $3</format>
+        </numberFormat>
+        <numberFormat pattern="(\d{2})(\d{3})(\d{2})(\d{2})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>[3-5]</leadingDigits>
+          <format>$1/$2 $3 $4</format>
         </numberFormat>
       </availableFormats>
       <generalDesc>
@@ -23540,22 +24477,18 @@
       <noInternationalDialling>
         <possibleLengths national="7,9"/>
         <nationalNumberPattern>
+          9090\d{3}|
           (?:
-            (?:
-              602|
-              8(?:
-                00|
-                [5-9]\d
-              )
-            )\d{3}|
+            602|
+            8(?:
+              00|
+              [5-9]\d
+            )|
             9(?:
-              0(?:
-                0\d{3}|
-                90
-              )|
-              [78]\d{4}
+              00|
+              [78]\d
             )
-          )\d{3}
+          )\d{6}
         </nationalNumberPattern>
       </noInternationalDialling>
       <!-- Added range 16 as per pattern [areacode] + 16 + SN(\d{2,4}) -->
@@ -23584,16 +24517,12 @@
         <possibleLengths national="9"/>
         <exampleNumber>912123456</exampleNumber>
         <nationalNumberPattern>
+          909[1-9]\d{5}|
           9(?:
-            0(?:
-              [1-8]\d|
-              9[1-9]
-            )|
-            (?:
-              1[0-24-9]|
-              [45]\d
-            )\d
-          )\d{5}
+            0[1-8]|
+            1[0-24-9]|
+            [45]\d
+          )\d{6}
         </nationalNumberPattern>
       </mobile>
       <pager>
@@ -23639,21 +24568,20 @@
       </uan>
     </territory>
 
-    <!-- Sierra Leone -->
+    <!-- Sierra Leone (SL) -->
     <!-- http://www.itu.int/oth/T02020000BB/en -->
     <territory id="SL" countryCode="232" internationalPrefix="00" nationalPrefix="0">
       <availableFormats>
         <!-- Following formatting of online yellow pages http://www.leonedirect.com -->
         <numberFormat pattern="(\d{2})(\d{6})" nationalPrefixFormattingRule="($NP$FG)">
-          <leadingDigits>[2-9]</leadingDigits>
+          <leadingDigits>[237-9]</leadingDigits>
           <format>$1 $2</format>
         </numberFormat>
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
           (?:
-            [2-578]\d|
-            66|
+            [2378]\d|
             99
           )\d{6}
         </nationalNumberPattern>
@@ -23661,18 +24589,15 @@
       <fixedLine>
         <possibleLengths national="8" localOnly="6"/>
         <exampleNumber>22221234</exampleNumber>
-        <nationalNumberPattern>[235]2[2-4][2-9]\d{4}</nationalNumberPattern>
+        <nationalNumberPattern>22\d{6}</nationalNumberPattern>
       </fixedLine>
       <mobile>
         <possibleLengths national="8"/>
         <exampleNumber>25123456</exampleNumber>
         <nationalNumberPattern>
           (?:
-            2[15]|
-            3[013-5]|
-            4[04]|
-            5[05]|
-            66|
+            25|
+            3[0134]|
             7[5-9]|
             8[08]|
             99
@@ -23681,7 +24606,7 @@
       </mobile>
     </territory>
 
-    <!-- San Marino -->
+    <!-- San Marino (SM) -->
     <!-- San Marino fixed-line numbers have an area code of "0549". However, this seems to be
          optional when dialling from outside the country; the phone number can be reached both with
          and without this area code. The nationalPrefixForParsing and nationalPrefixTransformRule
@@ -23693,6 +24618,11 @@
     <territory id="SM" countryCode="378" internationalPrefix="00"
                nationalPrefixForParsing="([89]\d{5})$" nationalPrefixTransformRule="0549$1">
       <availableFormats>
+        <numberFormat pattern="(\d{6})">
+          <leadingDigits>[89]</leadingDigits>
+          <format>$1</format>
+          <intlFormat>NA</intlFormat>
+        </numberFormat>
         <!-- Non-geographic numbers (without 0549 prefix). -->
         <numberFormat pattern="(\d{2})(\d{2})(\d{2})(\d{2})">
           <leadingDigits>[5-7]</leadingDigits>
@@ -23741,19 +24671,19 @@
       </voip>
     </territory>
 
-    <!-- Senegal -->
+    <!-- Senegal (SN) -->
     <!-- http://www.itu.int/oth/T02020000B8/en -->
     <!-- http://www.artpsenegal.net/index.php?option=com_content&view=article&id=50 -->
     <territory id="SN" countryCode="221" internationalPrefix="00">
       <availableFormats>
+        <numberFormat pattern="(\d{3})(\d{2})(\d{2})(\d{2})">
+          <leadingDigits>8</leadingDigits>
+          <format>$1 $2 $3 $4</format>
+        </numberFormat>
         <!-- Using yellow pages and online telecom company formatting, rather than that implied in
              the national numbering plan. -->
         <numberFormat pattern="(\d{2})(\d{3})(\d{2})(\d{2})">
           <leadingDigits>[379]</leadingDigits>
-          <format>$1 $2 $3 $4</format>
-        </numberFormat>
-        <numberFormat pattern="(\d{3})(\d{2})(\d{2})(\d{2})">
-          <leadingDigits>8</leadingDigits>
           <format>$1 $2 $3 $4</format>
         </numberFormat>
       </availableFormats>
@@ -23815,18 +24745,16 @@
         <possibleLengths national="9"/>
         <exampleNumber>933301234</exampleNumber>
         <nationalNumberPattern>
-          (?:
-            3(?:
-              392|
-              9[01]\d
-            )\d|
-            93330
-          )\d{4}
+          93330\d{4}|
+          3(?:
+            392|
+            9[01]\d
+          )\d{5}
         </nationalNumberPattern>
       </voip>
     </territory>
 
-    <!-- Somalia -->
+    <!-- Somalia (SO) -->
     <!-- This document seems to cover only a small set of prefixes in Somalia. Somalia has limited
          information available, and the numerous telecom carriers were previously working under an
          unregulated environment. The extra prefixes were added from the contact phone numbers of
@@ -23848,10 +24776,11 @@
         <!-- These follow formats online, such as http://www.hortel.net/contact_us.html -->
         <numberFormat pattern="(\d)(\d{6})">
           <leadingDigits>
-            [15]|
+            1|
             2[0-79]|
             3[0-46-8]|
-            4[0-7]
+            4[0-7]|
+            59
           </leadingDigits>
           <format>$1 $2</format>
         </numberFormat>
@@ -23872,7 +24801,13 @@
           <format>$1 $2 $3</format>
         </numberFormat>
         <numberFormat pattern="(\d{2})(\d{5,7})">
-          <leadingDigits>[12679]</leadingDigits>
+          <leadingDigits>
+            1|
+            28|
+            6[1-35-9]|
+            799|
+            9[2-9]
+          </leadingDigits>
           <format>$1 $2</format>
         </numberFormat>
       </availableFormats>
@@ -23917,49 +24852,42 @@
         <possibleLengths national="[7-9]"/>
         <exampleNumber>71123456</exampleNumber>
         <nationalNumberPattern>
+          28\d{5}|
           (?:
+            6[1-9]|
+            79
+          )\d{6,7}|
+          (?:
+            15|
+            24|
             (?:
-              15|
-              (?:
-                3[59]|
-                4[89]|
-                6[1-9]|
-                79|
-                8[08]
-              )\d|
-              9(?:
-                0[67]|
-                [2-9]
-              )
+              3[59]|
+              4[89]|
+              8[08]
             )\d|
-            2(?:
-              4\d|
-              8
+            60|
+            7[1-8]|
+            9(?:
+              0[67]|
+              [2-9]
             )
-          )\d{5}|
-          (?:
-            6\d|
-            7[1-9]
           )\d{6}
         </nationalNumberPattern>
       </mobile>
     </territory>
 
-    <!-- Suriname -->
+    <!-- Suriname (SR) -->
     <!-- http://www.itu.int/oth/T02020000C5/en -->
     <territory id="SR" countryCode="597" internationalPrefix="00">
       <availableFormats>
+        <numberFormat pattern="(\d{2})(\d{2})(\d{2})">
+          <leadingDigits>56</leadingDigits>
+          <format>$1-$2-$3</format>
+        </numberFormat>
         <!-- Following conventions used in the Suriname Yellow Pages. -->
         <numberFormat pattern="(\d{3})(\d{3})">
-          <leadingDigits>
-            [2-4]|
-            5[2-58]
-          </leadingDigits>
+          <leadingDigits>[2-5]</leadingDigits>
           <format>$1-$2</format>
-        </numberFormat>
-        <numberFormat pattern="(\d{2})(\d{2})(\d{2})">
-          <leadingDigits>5</leadingDigits>
-          <format>$1-$2-$3</format>
         </numberFormat>
         <numberFormat pattern="(\d{3})(\d{4})">
           <leadingDigits>[6-8]</leadingDigits>
@@ -24008,7 +24936,7 @@
       </voip>
     </territory>
 
-    <!-- South Sudan -->
+    <!-- South Sudan (SS) -->
     <!-- http://www.itu.int/oth/T02020000F9/en -->
     <!-- http://en.wikipedia.org/wiki/+211 -->
     <territory id="SS" countryCode="211" internationalPrefix="00" nationalPrefix="0">
@@ -24038,7 +24966,7 @@
       </mobile>
     </territory>
 
-    <!-- Sao Tome and Principe -->
+    <!-- São Tomé & Príncipe (ST) -->
     <!-- http://www.itu.int/oth/T02020000B6/en -->
     <territory id="ST" countryCode="239" internationalPrefix="00">
       <availableFormats>
@@ -24065,18 +24993,16 @@
         <possibleLengths national="7"/>
         <exampleNumber>9812345</exampleNumber>
         <nationalNumberPattern>
+          900[5-9]\d{3}|
           9(?:
-            0(?:
-              0[5-9]|
-              [1-9]\d
-            )|
-            [89]\d\d
-          )\d{3}
+            0[1-9]|
+            [89]\d
+          )\d{4}
         </nationalNumberPattern>
       </mobile>
     </territory>
 
-    <!-- El Salvador -->
+    <!-- El Salvador (SV) -->
     <!-- http://www.itu.int/oth/T020200003F/en -->
     <!-- http://www.siget.gob.sv/BusquedaPublica.aspx?pagina=3&tipo=27&titulo=t8&sector=2&ordenar=&dir=DESC -->
     <territory id="SV" countryCode="503" internationalPrefix="00">
@@ -24135,21 +25061,20 @@
       </premiumRate>
     </territory>
 
-    <!-- Sint Maarten -->
+    <!-- Sint Maarten (SX) -->
     <!-- Calling code and formatting shared with 'US' -->
     <!-- http://www.nanpa.com/pdf/PL_429.pdf -->
     <!-- http://www.itu.int/oth/T02020000F7/en -->
     <territory id="SX" countryCode="1" leadingDigits="721" internationalPrefix="011"
-               nationalPrefix="1">
+               nationalPrefix="1" nationalPrefixForParsing="1|(5\d{6})$"
+               nationalPrefixTransformRule="721$1">
       <generalDesc>
         <nationalNumberPattern>
+          7215\d{6}|
           (?:
-            (?:
-              [58]\d\d|
-              900
-            )\d|
-            7215
-          )\d{6}
+            [58]\d\d|
+            900
+          )\d{7}
         </nationalNumberPattern>
       </generalDesc>
       <fixedLine>
@@ -24215,18 +25140,19 @@
       </personalNumber>
     </territory>
 
-    <!-- Syrian Arab Republic -->
+    <!-- Syria (SY) -->
     <!-- No tollFree or premiumRate information can be found. -->
     <!-- http://www.itu.int/oth/T02020000C9/en -->
     <!-- http://en.wikipedia.org/wiki/%2B963 -->
-    <territory id="SY" countryCode="963" internationalPrefix="00" nationalPrefix="0"
-               nationalPrefixOptionalWhenFormatting="true">
+    <territory id="SY" countryCode="963" internationalPrefix="00" nationalPrefix="0">
       <availableFormats>
-        <numberFormat pattern="(\d{2})(\d{3})(\d{3,4})" nationalPrefixFormattingRule="$NP$FG">
+        <numberFormat pattern="(\d{2})(\d{3})(\d{3,4})" nationalPrefixFormattingRule="$NP$FG"
+                      nationalPrefixOptionalWhenFormatting="true">
           <leadingDigits>[1-5]</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
-        <numberFormat pattern="(\d{3})(\d{3})(\d{3})" nationalPrefixFormattingRule="$NP$FG">
+        <numberFormat pattern="(\d{3})(\d{3})(\d{3})" nationalPrefixFormattingRule="$NP$FG"
+                      nationalPrefixOptionalWhenFormatting="true">
           <leadingDigits>9</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
@@ -24243,20 +25169,20 @@
         <possibleLengths national="8,9" localOnly="6,7"/>
         <exampleNumber>112345678</exampleNumber>
         <nationalNumberPattern>
+          [12]1\d{6,7}|
           (?:
-            1[14]\d|
-            2(?:
-              1\d?|
-              [235]
+            1(?:
+              [2356]|
+              4\d
             )|
+            2[235]|
             3(?:
               [13]\d|
               4
             )|
             4[13]|
             5[1-3]
-          )\d{6}|
-          1[1-356]\d{6}
+          )\d{6}
         </nationalNumberPattern>
       </fixedLine>
       <!-- Numbers have been found online for the prefixes 922, 95[138], and 96[05]. -->
@@ -24273,7 +25199,7 @@
       </mobile>
     </territory>
 
-    <!-- Swaziland -->
+    <!-- Eswatini (SZ) -->
     <!-- http://www.itu.int/oth/T02020000C6/en -->
     <territory id="SZ" countryCode="268" internationalPrefix="00">
       <availableFormats>
@@ -24288,13 +25214,11 @@
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
+          0800\d{4}|
           (?:
-            0800|
-            (?:
-              [237]\d|
-              900
-            )\d\d
-          )\d{4}
+            [237]\d|
+            900
+          )\d{6}
         </nationalNumberPattern>
       </generalDesc>
       <noInternationalDialling>
@@ -24328,7 +25252,7 @@
       </voip>
     </territory>
 
-    <!-- Tristan da Cunha -->
+    <!-- Tristan da Cunha (TA) -->
     <!-- Calling code and formatting shared with 'SH' -->
     <!-- http://www.itu.int/oth/T02020000AF/en -->
     <territory id="TA" countryCode="290" leadingDigits="8" internationalPrefix="00">
@@ -24342,11 +25266,12 @@
       </fixedLine>
     </territory>
 
-    <!-- Turks and Caicos Islands -->
+    <!-- Turks & Caicos Islands (TC) -->
     <!-- Calling code and formatting shared with 'US' -->
     <!-- http://www.itu.int/oth/T02020000D8/en -->
     <territory id="TC" countryCode="1" leadingDigits="649" internationalPrefix="011"
-               nationalPrefix="1">
+               nationalPrefix="1" nationalPrefixForParsing="1|([2-479]\d{6})$"
+               nationalPrefixTransformRule="649$1">
       <generalDesc>
         <nationalNumberPattern>
           (?:
@@ -24430,7 +25355,7 @@
       </voip>
     </territory>
 
-    <!-- Chad -->
+    <!-- Chad (TD) -->
     <!-- The international prefix includes 16 as the international manual exchange. -->
     <!-- http://www.itu.int/oth/T0202000029/en -->
     <territory id="TD" countryCode="235" preferredInternationalPrefix="00"
@@ -24478,7 +25403,7 @@
       </mobile>
     </territory>
 
-    <!-- Togo -->
+    <!-- Togo (TG) -->
     <!-- http://www.itu.int/oth/T02020000D1/en -->
     <territory id="TG" countryCode="228" internationalPrefix="00">
       <availableFormats>
@@ -24517,7 +25442,7 @@
       </mobile>
     </territory>
 
-    <!-- Thailand -->
+    <!-- Thailand (TH) -->
     <!-- Subscribers can use respective carrier's IDD when calling abroad. We have not configured
          any preferredInternationalPrefix as there is no official evidence for it. -->
     <!-- http://www.itu.int/oth/T02020000CD/en -->
@@ -24546,8 +25471,8 @@
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
+          1\d{8,9}|
           (?:
-            1\d\d?|
             [2-57]|
             [689]\d
           )\d{7}
@@ -24603,54 +25528,37 @@
       </voip>
     </territory>
 
-    <!-- Tajikistan -->
+    <!-- Tajikistan (TJ) -->
     <!-- No tollFree or premiumRate information can be found. -->
     <!-- http://www.itu.int/oth/T02020000CA/en -->
     <territory id="TJ" countryCode="992" preferredInternationalPrefix="8~10"
-               internationalPrefix="810" nationalPrefix="8"
-               nationalPrefixOptionalWhenFormatting="true">
+               internationalPrefix="810" nationalPrefix="8">
       <availableFormats>
-        <numberFormat pattern="(\d{4})(\d)(\d{4})">
+        <numberFormat pattern="(\d{6})(\d)(\d{2})" nationalPrefixOptionalWhenFormatting="true">
+          <leadingDigits>331</leadingDigits>
+          <leadingDigits>3317</leadingDigits>
+          <format>$1 $2 $3</format>
+        </numberFormat>
+        <numberFormat pattern="(\d{3})(\d{2})(\d{4})" nationalPrefixOptionalWhenFormatting="true">
           <leadingDigits>
-            3(?:
-              [1245]|
-              3[12]
-            )
-          </leadingDigits>
-          <leadingDigits>
-            3(?:
-              [1245]|
-              3(?:
-                1[0-689]|
-                2
-              )
-            )
+            [34]7|
+            91[78]
           </leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
-        <numberFormat pattern="(\d{6})(\d)(\d{2})">
-          <leadingDigits>33</leadingDigits>
+        <numberFormat pattern="(\d{4})(\d)(\d{4})" nationalPrefixOptionalWhenFormatting="true">
+          <leadingDigits>3</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
-        <numberFormat pattern="(\d{2})(\d{3})(\d{4})">
-          <leadingDigits>
-            4[148]|
-            [578]|
-            9(?:
-              [0235-9]|
-              1[0-69]
-            )
-          </leadingDigits>
-          <format>$1 $2 $3</format>
-        </numberFormat>
-        <numberFormat pattern="(\d{3})(\d{2})(\d{4})">
-          <leadingDigits>[349]</leadingDigits>
+        <numberFormat pattern="(\d{2})(\d{3})(\d{4})" nationalPrefixOptionalWhenFormatting="true">
+          <leadingDigits>[0457-9]</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
           (?:
+            00|
             [3-59]\d|
             77|
             88
@@ -24679,25 +25587,25 @@
         </nationalNumberPattern>
       </fixedLine>
       <!-- Adding 90 prefix as SMS messages could be successfully delivered to these mobile
-           numbers and 55 for Megafon from bug reports. -->
+           numbers and 55 for Megafon from bug reports. 00 mobile range is assigned to
+           Megafon as per their confirmation. -->
       <mobile>
         <possibleLengths national="9"/>
         <exampleNumber>917123456</exampleNumber>
         <nationalNumberPattern>
+          41[18]\d{6}|
           (?:
-            41[18]|
-            (?:
-              5[05]|
-              77|
-              88|
-              9[0-35-9]
-            )\d
-          )\d{6}
+            00|
+            5[05]|
+            77|
+            88|
+            9\d
+          )\d{7}
         </nationalNumberPattern>
       </mobile>
     </territory>
 
-    <!-- Tokelau -->
+    <!-- Tokelau (TK) -->
     <!-- http://www.itu.int/oth/T02020000D2/en -->
     <territory id="TK" countryCode="690" internationalPrefix="00">
       <generalDesc>
@@ -24724,7 +25632,7 @@
       </mobile>
     </territory>
 
-    <!-- Timor-Leste (East Timor) -->
+    <!-- Timor-Leste (TL) -->
     <!-- http://www.itu.int/oth/T02020000D0/en -->
     <territory id="TL" countryCode="670" internationalPrefix="00">
       <availableFormats>
@@ -24744,9 +25652,9 @@
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
+          7\d{7}|
           (?:
-            [2-4]\d|
-            7\d\d?|
+            [2-47]\d|
             [89]0
           )\d{5}
         </nationalNumberPattern>
@@ -24788,7 +25696,7 @@
       </personalNumber>
     </territory>
 
-    <!-- Turkmenistan -->
+    <!-- Turkmenistan (TM) -->
     <!-- No tollFree or premiumRate information can be found. -->
     <!-- http://www.itu.int/oth/T02020000D7/en -->
     <!-- http://en.wikipedia.org/wiki/Telephone_numbers_in_Turkmenistan -->
@@ -24803,13 +25711,13 @@
           <leadingDigits>12</leadingDigits>
           <format>$1 $2-$3-$4</format>
         </numberFormat>
-        <numberFormat pattern="(\d{2})(\d{6})" nationalPrefixFormattingRule="$NP $FG">
-          <leadingDigits>6</leadingDigits>
-          <format>$1 $2</format>
-        </numberFormat>
         <numberFormat pattern="(\d{3})(\d)(\d{2})(\d{2})" nationalPrefixFormattingRule="($NP $FG)">
           <leadingDigits>[1-5]</leadingDigits>
           <format>$1 $2-$3-$4</format>
+        </numberFormat>
+        <numberFormat pattern="(\d{2})(\d{6})" nationalPrefixFormattingRule="$NP $FG">
+          <leadingDigits>6</leadingDigits>
+          <format>$1 $2</format>
         </numberFormat>
       </availableFormats>
       <generalDesc>
@@ -24860,7 +25768,7 @@
       </mobile>
     </territory>
 
-    <!-- Tunisia -->
+    <!-- Tunisia (TN) -->
     <!-- http://www.itu.int/oth/T02020000D5/en -->
     <!-- http://www.tunisietelecom.tn/tt/wcm/connect/?MOD=PDMProxy&TYPE=personalization&ID=NONE&KEY=NONE&LIBRARY=%2FcontentRoot%2Ficm%3Alibraries%5B16%5D&FOLDER=%2F&DOC_NAME=%2FcontentRoot%2Ficm%3Alibraries%5B16%5D%2FOTTI+2011.pdf -->
     <!-- http://www.tunisietelecom.tn/tt/internet/fr/pme/fixe/numeros_acceuil -->
@@ -24881,13 +25789,11 @@
         <possibleLengths national="8"/>
         <exampleNumber>30010123</exampleNumber>
         <nationalNumberPattern>
+          81200\d{3}|
           (?:
-            (?:
-              3[0-2]|
-              7\d
-            )\d{3}|
-            81200
-          )\d{3}
+            3[0-2]|
+            7\d
+          )\d{6}
         </nationalNumberPattern>
       </fixedLine>
       <!-- All Restricted Mobility numbers mentioned in ITU doc are supported as mobile based on
@@ -24896,24 +25802,21 @@
         <possibleLengths national="8"/>
         <exampleNumber>20123456</exampleNumber>
         <nationalNumberPattern>
+          3(?:
+            001|
+            [12]40
+          )\d{4}|
           (?:
             (?:
               [259]\d|
               4[0-6]
-            )\d\d|
+            )\d|
             3(?:
-              001|
-              1(?:
-                [1-35]\d|
-                40
-              )|
-              240|
-              (?:
-                6[0-4]|
-                91
-              )\d
+              1[1-35]|
+              6[0-4]|
+              91
             )
-          )\d{4}
+          )\d{5}
         </nationalNumberPattern>
       </mobile>
       <!-- ITU lists 80 xx xx xx, but the document published by Tunisie Telecom has more specific
@@ -24939,43 +25842,38 @@
       </sharedCost>
     </territory>
 
-    <!-- Tonga -->
+    <!-- Tonga (TO) -->
     <!-- http://www.itu.int/oth/T02020000D3/en -->
     <!-- http://www.wtng.info/wtng-676-to.html -->
     <territory id="TO" countryCode="676" internationalPrefix="00">
       <availableFormats>
         <numberFormat pattern="(\d{2})(\d{3})">
           <leadingDigits>
-            [2-6]|
-            7[014]|
+            [2-4]|
+            50|
+            6[09]|
+            7[0-24-69]|
             8[05]
           </leadingDigits>
           <format>$1-$2</format>
         </numberFormat>
-        <numberFormat pattern="(\d{3})(\d{4})">
-          <leadingDigits>
-            7[578]|
-            8
-          </leadingDigits>
-          <format>$1 $2</format>
-        </numberFormat>
         <numberFormat pattern="(\d{4})(\d{3})">
           <leadingDigits>0</leadingDigits>
+          <format>$1 $2</format>
+        </numberFormat>
+        <!-- Format for mobile and premium rate numbers. -->
+        <numberFormat pattern="(\d{3})(\d{4})">
+          <leadingDigits>[5-8]</leadingDigits>
           <format>$1 $2</format>
         </numberFormat>
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
           (?:
-            (?:
-              080|
-              [56]
-            )0|
-            [2-4]\d|
-            [78]\d(?:
-              \d{2}
-            )?
-          )\d{3}
+            0800|
+            [5-8]\d{3}
+          )\d{3}|
+          [2-8]\d{4}
         </nationalNumberPattern>
       </generalDesc>
       <fixedLine>
@@ -24984,10 +25882,11 @@
         <nationalNumberPattern>
           (?:
             2\d|
-            3[1-8]|
-            4[1-4]|
-            [56]0|
-            7[0149]|
+            3[0-8]|
+            4[0-4]|
+            50|
+            6[09]|
+            7[0-24-69]|
             8[05]
           )\d{3}
         </nationalNumberPattern>
@@ -24999,9 +25898,17 @@
         <exampleNumber>7715123</exampleNumber>
         <nationalNumberPattern>
           (?:
-            7[578]|
-            8[46-9]
-          )\d{5}
+            6(?:
+              3[02]|
+              85|
+              90
+            )|
+            7(?:
+              [2-46]0|
+              [578]\d
+            )|
+            8[46-9]\d
+          )\d{4}
         </nationalNumberPattern>
       </mobile>
       <tollFree>
@@ -25009,40 +25916,69 @@
         <exampleNumber>0800222</exampleNumber>
         <nationalNumberPattern>0800\d{3}</nationalNumberPattern>
       </tollFree>
+      <premiumRate>
+        <possibleLengths national="7"/>
+        <exampleNumber>5501234</exampleNumber>
+        <nationalNumberPattern>55[04]\d{4}</nationalNumberPattern>
+      </premiumRate>
     </territory>
 
-    <!-- Turkey -->
+    <!-- Turkey (TR) -->
     <!-- http://en.wikipedia.org/wiki/%2B90 -->
     <!-- http://www.itu.int/oth/T02020000D6/en -->
     <!-- https://eng.btk.gov.tr/en-US/Pages/National-Numbering-Plan -->
     <!-- https://www.btk.gov.tr/tr-TR/Sayfalar/Isletmecilere-Tahsisli-Numaralar -->
     <territory id="TR" countryCode="90" internationalPrefix="00" nationalPrefix="0"
-               nationalPrefixOptionalWhenFormatting="true" mobileNumberPortableRegion="true">
+               mobileNumberPortableRegion="true">
       <availableFormats>
         <!-- 7-digit UAN. -->
-        <numberFormat pattern="(\d{3})(\d)(\d{3})">
+        <numberFormat pattern="(\d{3})(\d)(\d{3})" nationalPrefixOptionalWhenFormatting="true">
           <leadingDigits>444</leadingDigits>
           <format>$1 $2 $3</format>
           <intlFormat>NA</intlFormat>
         </numberFormat>
-        <!-- In online references we see both these formats for mobile and fixed-line numbers:
-             (\d{3})(\d{3})(\d{2})(\d{2}) and (\d{3})(\d{3})(\d{4}). However the former seems to be
-             more common. -->
-        <numberFormat pattern="(\d{3})(\d{3})(\d{2})(\d{2})" nationalPrefixFormattingRule="($NP$FG)">
-          <leadingDigits>[2-4]</leadingDigits>
-          <format>$1 $2 $3 $4</format>
-        </numberFormat>
         <!-- Fixed line, UAN, pager. -->
-        <numberFormat pattern="(\d{3})(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
+        <numberFormat pattern="(\d{3})(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG"
+                      nationalPrefixOptionalWhenFormatting="true">
           <leadingDigits>
             512|
-            [89]
+            8[0589]|
+            90
           </leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
         <!-- Mobile and "personal" numbers. -->
-        <numberFormat pattern="(\d{3})(\d{3})(\d{2})(\d{2})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>5</leadingDigits>
+        <numberFormat pattern="(\d{3})(\d{3})(\d{2})(\d{2})" nationalPrefixFormattingRule="$NP$FG"
+                      nationalPrefixOptionalWhenFormatting="true">
+          <leadingDigits>
+            5(?:
+              [0-59]|
+              61
+            )
+          </leadingDigits>
+          <leadingDigits>
+            5(?:
+              [0-59]|
+              616
+            )
+          </leadingDigits>
+          <leadingDigits>
+            5(?:
+              [0-59]|
+              6161
+            )
+          </leadingDigits>
+          <format>$1 $2 $3 $4</format>
+        </numberFormat>
+        <!-- In online references we see both these formats for mobile and fixed-line numbers:
+             (\d{3})(\d{3})(\d{2})(\d{2}) and (\d{3})(\d{3})(\d{4}). However the former seems to be
+             more common. -->
+        <numberFormat pattern="(\d{3})(\d{3})(\d{2})(\d{2})" nationalPrefixFormattingRule="($NP$FG)"
+                      nationalPrefixOptionalWhenFormatting="true">
+          <leadingDigits>
+            [24][1-8]|
+            3[1-9]
+          </leadingDigits>
           <format>$1 $2 $3 $4</format>
         </numberFormat>
       </availableFormats>
@@ -25094,17 +26030,15 @@
         <possibleLengths national="10"/>
         <exampleNumber>5012345678</exampleNumber>
         <nationalNumberPattern>
+          56161\d{5}|
           5(?:
-            (?:
-              0[15-7]|
-              1[06]|
-              24|
-              [34]\d|
-              5[1-59]|
-              9[46]
-            )\d\d|
-            6161
-          )\d{5}
+            0[15-7]|
+            1[06]|
+            24|
+            [34]\d|
+            5[1-59]|
+            9[46]
+          )\d{7}
         </nationalNumberPattern>
       </mobile>
       <!-- 512 range is mentioned as call services number in eng.btk.gov.tr's doc. As we not sure
@@ -25156,11 +26090,12 @@
       </uan>
     </territory>
 
-    <!-- Trinidad and Tobago -->
+    <!-- Trinidad & Tobago (TT) -->
     <!-- Calling code and formatting shared with 'US' -->
     <!-- http://www.itu.int/oth/T02020000D4/en -->
     <territory id="TT" countryCode="1" leadingDigits="868" internationalPrefix="011"
-               nationalPrefix="1">
+               nationalPrefix="1" nationalPrefixForParsing="1|([2-46-8]\d{6})$"
+               nationalPrefixTransformRule="868$1">
       <generalDesc>
         <nationalNumberPattern>
           (?:
@@ -25178,7 +26113,9 @@
           868(?:
             2(?:
               01|
-              [23]\d
+              1[89]|
+              [23]\d|
+              4[0-2]
             )|
             6(?:
               0[7-9]|
@@ -25261,7 +26198,7 @@
       </voicemail>
     </territory>
 
-    <!-- Tuvalu -->
+    <!-- Tuvalu (TV) -->
     <!-- http://www.itu.int/oth/T02020000D9/en -->
     <!-- http://en.wikipedia.org/wiki/Telephone_numbers_in_Tuvalu -->
     <territory id="TV" countryCode="688" internationalPrefix="00">
@@ -25294,7 +26231,7 @@
       </mobile>
     </territory>
 
-    <!-- Taiwan, China -->
+    <!-- Taiwan (TW) -->
     <!-- Extension symbols found on the internet so far have been #, X and Ext - so # has been
          chosen as the preferred extension prefix. -->
     <!-- http://www.itu.int/oth/T02020000EB/en -->
@@ -25307,38 +26244,49 @@
           <leadingDigits>202</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
+        <!-- Fixed line and UAN. -->
+        <numberFormat pattern="(\d{2})(\d{3})(\d{3,4})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>[258]0</leadingDigits>
+          <format>$1 $2 $3</format>
+        </numberFormat>
         <!-- Fixed line. -->
         <numberFormat pattern="(\d)(\d{3,4})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>
-            [25][2-8]|
-            [346]|
-            7[1-9]|
-            8[27-9]
+            [23568]|
+            4(?:
+              0[02-48]|
+              [1-47-9]
+            )|
+            7[1-9]
+          </leadingDigits>
+          <leadingDigits>
+            [23568]|
+            4(?:
+              0[2-48]|
+              [1-47-9]
+            )|
+            (?:
+              400|
+              7
+            )[1-9]
           </leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
-        <!-- Fixed line and UAN. -->
-        <numberFormat pattern="(\d{2})(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>[258]</leadingDigits>
-          <format>$1 $2 $3</format>
-        </numberFormat>
-        <!-- Mobile and "personal" numbers. -->
+        <!-- Mobile and personal numbers. -->
         <numberFormat pattern="(\d{3})(\d{3})(\d{3})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>9</leadingDigits>
+          <leadingDigits>[49]</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
         <!-- VOIP. -->
-        <numberFormat pattern="(\d{2})(\d{4})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
+        <numberFormat pattern="(\d{2})(\d{4})(\d{4,5})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>7</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
-          (?:
-            [24589]|
-            7\d
-          )\d{8}|
+          [2-689]\d{8}|
+          7\d{9,10}|
           [2-8]\d{7}|
           2\d{6}
         </nationalNumberPattern>
@@ -25347,43 +26295,125 @@
            is possible they aren't fixed-line, but adding them here since we don't have better
            information for now. Prefix 90 is mentioned as reserved in http://www.ncc.gov.tw/
            and wikipedea states it as M2M, but we still support in Mobile as we were able to
-           find working online number. -->
+           find working online number. Prefix 64 is added on the basis of user report. -->
       <fixedLine>
         <possibleLengths national="8,9"/>
         <exampleNumber>221234567</exampleNumber>
         <nationalNumberPattern>
           (?:
+            2[2-8]\d|
+            370|
+            55[01]|
+            7[1-9]
+          )\d{6}|
+          4(?:
             (?:
-              2[2-8]\d|
-              3[2-9]|
-              4(?:
-                [239]\d|
-                [78]
+              0(?:
+                0[1-9]|
+                [2-48]\d
               )|
-              5[2-8]|
-              6[235-79]|
-              7[1-9]
-            )\d\d|
-            8(?:
+              1[023]\d
+            )\d{4,5}|
+            (?:
+              [239]\d\d|
+              4(?:
+                0[56]|
+                12|
+                49
+              )
+            )\d{5}
+          )|
+          6(?:
+            [01]\d{7}|
+            4(?:
+              0[56]|
+              12|
+              24|
+              4[09]
+            )\d{4,5}
+          )|
+          8(?:
+            (?:
               2(?:
                 3\d|
+                4[0-269]|
+                [578]0|
                 66
               )|
-              [7-9]\d\d
-            )
-          )\d{4}|
-          24\d{6}
+              36[24-9]|
+              90\d\d
+            )\d{4}|
+            4(?:
+              0[56]|
+              12|
+              24|
+              4[09]
+            )\d{4,5}
+          )|
+          (?:
+            2(?:
+              2(?:
+                0\d\d|
+                4(?:
+                  0[68]|
+                  [249]0|
+                  3[0-467]|
+                  5[0-25-9]|
+                  6[0235689]
+                )
+              )|
+              (?:
+                3(?:
+                  [09]\d|
+                  1[0-4]
+                )|
+                (?:
+                  4\d|
+                  5[0-49]|
+                  6[0-29]|
+                  7[0-5]
+                )\d
+              )\d
+            )|
+            (?:
+              (?:
+                3[2-9]|
+                5[2-8]|
+                6[0-35-79]|
+                8[7-9]
+              )\d\d|
+              4(?:
+                2(?:
+                  [089]\d|
+                  7[1-9]
+                )|
+                (?:
+                  3[0-4]|
+                  [78]\d|
+                  9[01]
+                )\d
+              )
+            )\d
+          )\d{3}
         </nationalNumberPattern>
       </fixedLine>
       <mobile>
         <possibleLengths national="9"/>
         <exampleNumber>912345678</exampleNumber>
-        <nationalNumberPattern>9[0-8]\d{7}</nationalNumberPattern>
+        <nationalNumberPattern>
+          (?:
+            40001[0-2]|
+            9[0-8]\d{4}
+          )\d{3}
+        </nationalNumberPattern>
       </mobile>
       <tollFree>
-        <possibleLengths national="9"/>
+        <possibleLengths national="8,9"/>
         <exampleNumber>800123456</exampleNumber>
-        <nationalNumberPattern>80[0-79]\d{6}</nationalNumberPattern>
+        <nationalNumberPattern>
+          80[0-79]\d{6}|
+          800\d{5}
+        </nationalNumberPattern>
       </tollFree>
       <premiumRate>
         <possibleLengths national="7,9"/>
@@ -25402,9 +26432,16 @@
       </personalNumber>
       <!-- http://www.chief.com.tw/telecom_eng/front/bin/ptlist.phtml?Category=107 -->
       <voip>
-        <possibleLengths national="10"/>
+        <possibleLengths national="10,11"/>
         <exampleNumber>7012345678</exampleNumber>
-        <nationalNumberPattern>70\d{8}</nationalNumberPattern>
+        <nationalNumberPattern>
+          7010(?:
+            [0-2679]\d|
+            3[0-7]|
+            8[0-5]
+          )\d{5}|
+          70\d{8}
+        </nationalNumberPattern>
       </voip>
       <uan>
         <possibleLengths national="9"/>
@@ -25413,21 +26450,21 @@
       </uan>
     </territory>
 
-    <!-- Tanzania -->
+    <!-- Tanzania (TZ) -->
     <!-- http://www.itu.int/oth/T02020000CB/en -->
     <territory id="TZ" countryCode="255" internationalPrefix="00[056]" nationalPrefix="0">
       <availableFormats>
+        <!-- Formatting for special numbers from http://www.tcra.go.tz -->
+        <numberFormat pattern="(\d{3})(\d{2})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>[89]</leadingDigits>
+          <format>$1 $2 $3</format>
+        </numberFormat>
         <numberFormat pattern="(\d{2})(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>[24]</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
         <numberFormat pattern="(\d{3})(\d{3})(\d{3})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>[67]</leadingDigits>
-          <format>$1 $2 $3</format>
-        </numberFormat>
-        <!-- Formatting for special numbers from http://www.tcra.go.tz -->
-        <numberFormat pattern="(\d{3})(\d{2})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>[89]</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
       </availableFormats>
@@ -25494,7 +26531,7 @@
       </voip>
     </territory>
 
-    <!-- Ukraine -->
+    <!-- Ukraine (UA) -->
     <!-- http://www.itu.int/oth/T02020000DB/en -->
     <!-- http://en.wikipedia.org/wiki/%2B380 -->
     <!-- No definitive list has been found of what constitutes the area code for formatting.
@@ -25504,95 +26541,99 @@
     <territory id="UA" countryCode="380" preferredInternationalPrefix="0~0" internationalPrefix="00"
                nationalPrefix="0">
       <availableFormats>
-        <!-- Fixed line and premium rate. -->
+        <!-- Fixed line -->
         <numberFormat pattern="(\d{3})(\d{3})(\d{3})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>
+            6[12][29]|
             (?:
               3[1-8]|
-              4[136-8]
+              4[136-8]|
+              5[12457]|
+              6[49]
             )2|
-            5(?:
-              [12457]2|
-              6[24]
-            )|
-            6(?:
-              [12][29]|
-              [49]2|
-              5[24]
-            )|
-            [89]0
+            (?:
+              56|
+              65
+            )[24]
           </leadingDigits>
           <leadingDigits>
-            3(?:
-              [1-46-8]2[013-9]|
-              52
-            )|
-            4(?:
-              [1378]2|
-              62[013-9]
-            )|
+            6[12][29]|
+            (?:
+              35|
+              4[1378]|
+              5[12457]|
+              6[49]
+            )2|
+            (?:
+              56|
+              65
+            )[24]|
+            (?:
+              3[1-46-8]|
+              46
+            )2[013-9]
+          </leadingDigits>
+          <format>$1 $2 $3</format>
+        </numberFormat>
+        <!-- General format (fixed line, mobile, voip etc.) -->
+        <numberFormat pattern="(\d{2})(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>
+            4[45][0-5]|
             5(?:
-              [12457]2|
-              6[24]
+              0|
+              6[37]
             )|
             6(?:
-              [12][29]|
-              [49]2|
-              5[24]
+              [12][018]|
+              [36-8]
             )|
-            [89]0
+            7|
+            89|
+            9[1-9]|
+            (?:
+              48|
+              57
+            )[0137-9]
+          </leadingDigits>
+          <leadingDigits>
+            4[45][0-5]|
+            5(?:
+              0|
+              6(?:
+                3[14-7]|
+                7
+              )
+            )|
+            6(?:
+              [12][018]|
+              [36-8]
+            )|
+            7|
+            89|
+            9[1-9]|
+            (?:
+              48|
+              57
+            )[0137-9]
           </leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
         <!-- Fixed line (4-digit area code). -->
         <numberFormat pattern="(\d{4})(\d{5})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>
-            3[1-8]|
-            4(?:
-              [1367]|
-              [45][6-9]|
-              8[4-6]
-            )|
-            5(?:
-              [1-5]|
-              6[0135689]|
-              7[4-6]
-            )|
-            6(?:
-              [12][3-7]|
-              [459]
-            )
-          </leadingDigits>
-          <leadingDigits>
-            3[1-8]|
-            4(?:
-              [1367]|
-              [45][6-9]|
-              8[4-6]
-            )|
-            5(?:
-              [1-5]|
-              6(?:
-                [015689]|
-                3[02389]
-              )|
-              7[4-6]
-            )|
-            6(?:
-              [12][3-7]|
-              [459]
-            )
-          </leadingDigits>
+          <leadingDigits>[3-6]</leadingDigits>
           <format>$1 $2</format>
         </numberFormat>
-        <!-- General format (fixed line, mobile, voip etc.) -->
-        <numberFormat pattern="(\d{2})(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>[3-9]</leadingDigits>
+        <!-- Premium Rate and Toll Free -->
+        <numberFormat pattern="(\d{3})(\d{3})(\d{3,4})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>[89]</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
       </availableFormats>
       <generalDesc>
-        <nationalNumberPattern>[3-9]\d{8}</nationalNumberPattern>
+        <nationalNumberPattern>
+          [89]\d{9}|
+          [3-9]\d{8}
+        </nationalNumberPattern>
       </generalDesc>
       <!-- Official numbering plan https://regulation.gov.ua/documents/id89506 (Dated: 23.11.2006)
            mentions that xx[018] (xx represents valid area code) fixed-line numbers as invalid and
@@ -25611,16 +26652,12 @@
           )\d{7}
         </nationalNumberPattern>
       </fixedLine>
-      <!-- Added 71 prefix based on user report and 72 based on online numbers. 39X mobile range
-           is mentioned in ITU doc dated 10.VIII.2006 but not in new one (dated 6.II.2017) and no
-           numbers found online. Considering the impact and lack of authoritative evidence we
-           choose not to mark 39X range as invalid. -->
+      <!-- Added 71 prefix based on user report and 72 based on online numbers.  -->
       <mobile>
         <possibleLengths national="9"/>
-        <exampleNumber>391234567</exampleNumber>
+        <exampleNumber>501234567</exampleNumber>
         <nationalNumberPattern>
           (?:
-            39|
             50|
             6[36-8]|
             7[1-3]|
@@ -25629,16 +26666,16 @@
         </nationalNumberPattern>
       </mobile>
       <tollFree>
-        <possibleLengths national="9"/>
+        <possibleLengths national="9,10"/>
         <exampleNumber>800123456</exampleNumber>
-        <nationalNumberPattern>800\d{6}</nationalNumberPattern>
+        <nationalNumberPattern>800[1-8]\d{5,6}</nationalNumberPattern>
       </tollFree>
       <!-- 4th digit added based on
            http://www.mts.ua/ru/support/services/200-tarify-na-nomera-0-800-0-900-0-703/ -->
       <premiumRate>
-        <possibleLengths national="9"/>
+        <possibleLengths national="9,10"/>
         <exampleNumber>900212345</exampleNumber>
-        <nationalNumberPattern>900[2-49]\d{5}</nationalNumberPattern>
+        <nationalNumberPattern>900[239]\d{5,6}</nationalNumberPattern>
       </premiumRate>
       <!-- 89[1-579] ranges are mentioned as "Non-geographic number – mobile services assigned" in
            the ITU doc. All the 89X phone numbers found online are listed as conference calls and
@@ -25652,22 +26689,10 @@
       </voip>
     </territory>
 
-    <!-- Uganda -->
+    <!-- Uganda (UG) -->
     <!-- http://www.itu.int/oth/T02020000F1/en -->
-    <!-- http://www.ucc.co.ug/licensing/ugandaNumberingPlan.pdf -->
     <territory id="UG" countryCode="256" internationalPrefix="00[057]" nationalPrefix="0">
       <availableFormats>
-        <!-- 2-digit area codes -->
-        <numberFormat pattern="(\d{2})(\d{7})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>
-            3|
-            4(?:
-              [0-5]|
-              6[0-36-9]
-            )
-          </leadingDigits>
-          <format>$1 $2</format>
-        </numberFormat>
         <!-- 4-digit area codes -->
         <numberFormat pattern="(\d{4})(\d{5})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>202</leadingDigits>
@@ -25676,19 +26701,28 @@
         </numberFormat>
         <!-- Fixed and mobile format. -->
         <numberFormat pattern="(\d{3})(\d{6})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>[247-9]</leadingDigits>
+          <leadingDigits>
+            [27-9]|
+            4(?:
+              6[45]|
+              [7-9]
+            )
+          </leadingDigits>
+          <format>$1 $2</format>
+        </numberFormat>
+        <!-- 2-digit area codes -->
+        <numberFormat pattern="(\d{2})(\d{7})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>[34]</leadingDigits>
           <format>$1 $2</format>
         </numberFormat>
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
+          800\d{6}|
           (?:
-            (?:
-              [29]0|
-              [347]\d
-            )\d|
-            800
-          )\d{6}
+            [29]0|
+            [347]\d
+          )\d{7}
         </nationalNumberPattern>
       </generalDesc>
       <!-- The ITU plan calls for all numbers to be exactly 9 digits. However, it's not clear if
@@ -25705,22 +26739,22 @@
               (?:
                 (?:
                   [0147]\d|
-                  5[0-4]|
-                  8[0-2]
+                  5[0-4]
                 )\d|
                 2(?:
                   40|
                   [5-9]\d
                 )|
                 3(?:
-                  0[0-4]|
-                  [2367]\d
-                )
+                  0[67]|
+                  2[0-4]
+                )|
+                810
               )\d|
               6(?:
                 00[0-2]|
-                30[0-4]|
-                [5-9]\d\d
+                [15-9]\d\d|
+                30[0-4]
               )
             )|
             [34]\d{5}
@@ -25732,17 +26766,12 @@
         <possibleLengths national="9"/>
         <exampleNumber>712345678</exampleNumber>
         <nationalNumberPattern>
+          7260\d{5}|
           7(?:
-            (?:
-              [0157-9]\d|
-              30|
-              4[0-4]
-            )\d|
-            2(?:
-              [03]\d|
-              60
-            )
-          )\d{5}
+            [0157-9]\d|
+            20|
+            4[0-4]
+          )\d{6}
         </nationalNumberPattern>
       </mobile>
       <tollFree>
@@ -25757,7 +26786,8 @@
       </premiumRate>
     </territory>
 
-    <!-- United States -->
+    <!-- United States (US) -->
+    <!-- Main region for 'AG,AI,AS,BB,BM,BS,CA,DM,DO,GD,GU,JM,KN,KY,LC,MP,MS,PR,SX,TC,TT,VC,VG,VI' -->
     <!-- Note the national prefix of US is the same as its country code, and when formatting phone
          numbers in the national format, it is not included. Therefore, we omit it here to make
          formatting consistent with the rest of the world. The same applies to all the
@@ -25765,7 +26795,6 @@
     <!-- The national prefix of "1" here is the same as the country code. It is not used by default
          when formatting, but is set here so that users who are calling formatByPattern can specify
          NationalPrefixFormattingRule if they want to. -->
-    <!-- Main region for 'AG,AI,AS,BB,BM,BS,CA,DM,DO,GD,GU,JM,KN,KY,LC,MP,MS,PR,SX,TC,TT,VC,VG,VI' -->
     <!-- http://www.nanpa.com/reports/reports_npa.html -->
     <!-- http://en.wikipedia.org/wiki/North_American_Numbering_Plan -->
     <territory id="US" mainCountryForCode="true" countryCode="1" internationalPrefix="011"
@@ -25808,7 +26837,7 @@
               1[02-9]|
               2[0135]|
               3[0-24679]|
-              4[67]|
+              4[167]|
               5[12]|
               6[014]|
               8[056]
@@ -25843,7 +26872,7 @@
               5[017]|
               6[0-279]|
               78|
-              8[0-2]
+              8[0-29]
             )|
             7(?:
               0[1-46-8]|
@@ -25900,7 +26929,7 @@
               1[02-9]|
               2[0135]|
               3[0-24679]|
-              4[67]|
+              4[167]|
               5[12]|
               6[014]|
               8[056]
@@ -25935,7 +26964,7 @@
               5[017]|
               6[0-279]|
               78|
-              8[0-2]
+              8[0-29]
             )|
             7(?:
               0[1-46-8]|
@@ -26016,7 +27045,7 @@
       </uan>
     </territory>
 
-    <!-- Uruguay -->
+    <!-- Uruguay (UY) -->
     <!-- International long-distance providers can be dialled by dialling 01 followed by a carrier
          code JK, where J = [3-9] and K is any digit. -->
     <!-- http://www.itu.int/oth/T02020000E0/en -->
@@ -26032,15 +27061,15 @@
           </leadingDigits>
           <format>$1 $2</format>
         </numberFormat>
-        <!-- Following paginasamarillas.com.uy formatting. -->
-        <numberFormat pattern="(\d{4})(\d{4})">
-          <leadingDigits>[24]</leadingDigits>
-          <format>$1 $2</format>
-        </numberFormat>
         <!-- Including the national prefix here since URSEC does when formatting these. -->
         <numberFormat pattern="(\d{2})(\d{3})(\d{3})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>9</leadingDigits>
           <format>$1 $2 $3</format>
+        </numberFormat>
+        <!-- Following paginasamarillas.com.uy formatting. -->
+        <numberFormat pattern="(\d{4})(\d{4})">
+          <leadingDigits>[24]</leadingDigits>
+          <format>$1 $2</format>
         </numberFormat>
       </availableFormats>
       <generalDesc>
@@ -26079,7 +27108,7 @@
       </premiumRate>
     </territory>
 
-    <!-- Uzbekistan -->
+    <!-- Uzbekistan (UZ) -->
     <!-- No tollFree or premiumRate information can be found. -->
     <!-- http://www.ttts.uz/eng/telephone_codes/codes_uzb_eng -->
     <!-- http://www.itu.int/oth/T02020000E1/en -->
@@ -26097,9 +27126,22 @@
       <!-- Adding 711 from numbers found online, such as the US embassy, and 6922, which seems to
            be used in Namangan. -->
       <fixedLine>
-        <possibleLengths national="9" localOnly="7"/>
+        <possibleLengths national="9"/>
         <exampleNumber>669050123</exampleNumber>
         <nationalNumberPattern>
+          78(?:
+            1(?:
+              13|
+              2[02]|
+              50
+            )|
+            2(?:
+              10|
+              2[139]|
+              98
+            )|
+            77[01]
+          )\d{4}|
           (?:
             6(?:
               1(?:
@@ -26436,29 +27478,28 @@
       </mobile>
     </territory>
 
-    <!-- Vatican City -->
+    <!-- Vatican City (VA) -->
+    <!-- Calling code and formatting shared with 'IT' -->
     <!-- Vatican City is assigned country code 379. However, Vatican City is still reached
          via the Italian numbering plan. Telephone numbers in Vatican City are integrated into
          the Italian telephone numbering plan. Telephone numbers in the Vatican City are similar
          to telephone numbers in Rome, with "698" following the "06" for Rome.
          A Vatican telephone number is in the form of 06 698x xxxx. -->
-    <!-- Calling code and formatting shared with 'IT' -->
     <!-- http://en.wikipedia.org/wiki/Telephone_numbers_in_Vatican_City -->
     <territory id="VA" countryCode="39" leadingDigits="06698" internationalPrefix="00"
                mobileNumberPortableRegion="true">
       <generalDesc>
         <nationalNumberPattern>
-          0\d{6}(?:
-            \d{4}
+          0\d{5,10}|
+          3[0-8]\d{7,10}|
+          55\d{8}|
+          8\d{5}(?:
+            \d{2,4}
           )?|
-          3[0-8]\d{9}|
           (?:
-            [0138]\d?|
-            55
-          )\d{8}|
-          [08]\d{5}(?:
-            \d{2}
-          )?
+            1\d|
+            39
+          )\d{7,8}
         </nationalNumberPattern>
       </generalDesc>
       <!-- As per Wikipedia only 10 digit 06 698 is assigned to Vatican City. However in reality we
@@ -26474,10 +27515,9 @@
            digits long. However, a user reported the existence of new 11 digit long numbers for
            TIM with the prefix 33X, so this is supported also. -->
       <mobile>
-        <possibleLengths national="[9-11]"/>
+        <possibleLengths national="9,10"/>
         <exampleNumber>3123456789</exampleNumber>
         <nationalNumberPattern>
-          33\d{9}|
           3[1-9]\d{8}|
           3[2-9]\d{7}
         </nationalNumberPattern>
@@ -26501,25 +27541,23 @@
         <exampleNumber>899123456</exampleNumber>
         <nationalNumberPattern>
           (?:
-            (?:
-              0878|
-              1(?:
-                44|
-                6[346]
-              )\d
-            )\d\d|
+            0878\d\d|
             89(?:
               2|
-              (?:
-                4[5-9]|
-                (?:
-                  5[5-9]|
-                  9
-                )\d\d
-              )\d
+              4[5-9]\d
             )
           )\d{3}|
-          89[45][0-4]\d\d
+          89[45][0-4]\d\d|
+          (?:
+            1(?:
+              44|
+              6[346]
+            )|
+            89(?:
+              5[5-9]|
+              9
+            )
+          )\d{6}
         </nationalNumberPattern>
       </premiumRate>
       <sharedCost>
@@ -26547,13 +27585,19 @@
         <exampleNumber>5512345678</exampleNumber>
         <nationalNumberPattern>55\d{8}</nationalNumberPattern>
       </voip>
+      <voicemail>
+        <possibleLengths national="11,12"/>
+        <exampleNumber>33101234501</exampleNumber>
+        <nationalNumberPattern>3[2-8]\d{9,10}</nationalNumberPattern>
+      </voicemail>
     </territory>
 
-    <!-- Saint Vincent and the Grenadines -->
+    <!-- St. Vincent & Grenadines (VC) -->
     <!-- Calling code and formatting shared with 'US' -->
     <!-- http://www.itu.int/oth/T02020000B3/en -->
     <territory id="VC" countryCode="1" leadingDigits="784" internationalPrefix="011"
-               nationalPrefix="1">
+               nationalPrefix="1" nationalPrefixForParsing="1|([2-7]\d{6})$"
+               nationalPrefixTransformRule="784$1">
       <generalDesc>
         <nationalNumberPattern>
           (?:
@@ -26648,7 +27692,7 @@
       </personalNumber>
     </territory>
 
-    <!-- Venezuela -->
+    <!-- Venezuela (VE) -->
     <!-- 1XX specifies a particular carrier to route a call to, but none of these have been
          implemented. -->
     <!-- http://www.itu.int/oth/T02020000E3/en -->
@@ -26663,13 +27707,11 @@
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
+          [89]00\d{7}|
           (?:
-            (?:
-              [24]\d|
-              50
-            )\d|
-            [89]00
-          )\d{7}
+            [24]\d|
+            50
+          )\d{8}
         </nationalNumberPattern>
       </generalDesc>
       <!-- Including region-free 500 calls here, since these are treated as local calls. Wikipedia
@@ -26713,11 +27755,12 @@
       </premiumRate>
     </territory>
 
-    <!-- Virgin Islands, British -->
+    <!-- British Virgin Islands (VG) -->
     <!-- Calling code and formatting shared with 'US' -->
     <!-- http://www.itu.int/oth/T020200001E/en -->
     <territory id="VG" countryCode="1" leadingDigits="284" internationalPrefix="011"
-               nationalPrefix="1">
+               nationalPrefix="1" nationalPrefixForParsing="1|([2-578]\d{6})$"
+               nationalPrefixTransformRule="284$1">
       <generalDesc>
         <nationalNumberPattern>
           (?:
@@ -26733,23 +27776,19 @@
         <possibleLengths national="10" localOnly="7"/>
         <exampleNumber>2842291234</exampleNumber>
         <nationalNumberPattern>
+          284496[0-5]\d{3}|
           284(?:
-            (?:
-              229|
-              774|
-              8(?:
-                52|
-                6[459]
-              )
-            )\d|
+            229|
             4(?:
-              22\d|
-              9(?:
-                [45]\d|
-                6[0-5]
-              )
+              22|
+              9[45]
+            )|
+            774|
+            8(?:
+              52|
+              6[459]
             )
-          )\d{3}
+          )\d{4}
         </nationalNumberPattern>
       </fixedLine>
       <!-- No data on central office codes can be found on the nanpa.com website. The codes 446
@@ -26758,27 +27797,21 @@
         <possibleLengths national="10" localOnly="7"/>
         <exampleNumber>2843001234</exampleNumber>
         <nationalNumberPattern>
+          284496[6-9]\d{3}|
           284(?:
-            (?:
-              3(?:
-                0[0-3]|
-                4[0-7]|
-                68|
-                9[34]
-              )|
-              54[0-57]
-            )\d|
+            3(?:
+              0[0-3]|
+              4[0-7]|
+              68|
+              9[34]
+            )|
             4(?:
-              (?:
-                4[0-6]|
-                68
-              )\d|
-              9(?:
-                6[6-9]|
-                9\d
-              )
-            )
-          )\d{3}
+              4[0-6]|
+              68|
+              99
+            )|
+            54[0-57]
+          )\d{4}
         </nationalNumberPattern>
       </mobile>
       <tollFree>
@@ -26819,20 +27852,19 @@
       </personalNumber>
     </territory>
 
-    <!-- Virgin Islands, United States -->
+    <!-- U.S. Virgin Islands (VI) -->
     <!-- Calling code and formatting shared with 'US' -->
     <!-- http://www.itu.int/oth/T02020000DF/en -->
     <territory id="VI" countryCode="1" leadingDigits="340" internationalPrefix="011"
-               nationalPrefix="1">
+               nationalPrefix="1" nationalPrefixForParsing="1|([2-9]\d{6})$"
+               nationalPrefixTransformRule="340$1">
       <generalDesc>
         <nationalNumberPattern>
+          [58]\d{9}|
           (?:
-            (?:
-              34|
-              90
-            )0|
-            [58]\d\d
-          )\d{7}
+            34|
+            90
+          )0\d{7}
         </nationalNumberPattern>
       </generalDesc>
       <!-- The ITU document seems a bit out-of-date so extra prefixes based on numbers in the
@@ -26844,9 +27876,9 @@
         <nationalNumberPattern>
           340(?:
             2(?:
-              01|
+              0[12]|
               2[06-8]|
-              44|
+              4[49]|
               77
             )|
             3(?:
@@ -26855,14 +27887,15 @@
             )|
             4(?:
               22|
-              7[34]
+              7[34]|
+              89
             )|
             5(?:
               1[34]|
               55
             )|
             6(?:
-              26|
+              2[56]|
               4[23]|
               77|
               9[023]
@@ -26883,9 +27916,9 @@
         <nationalNumberPattern>
           340(?:
             2(?:
-              01|
+              0[12]|
               2[06-8]|
-              44|
+              4[49]|
               77
             )|
             3(?:
@@ -26894,14 +27927,15 @@
             )|
             4(?:
               22|
-              7[34]
+              7[34]|
+              89
             )|
             5(?:
               1[34]|
               55
             )|
             6(?:
-              26|
+              2[56]|
               4[23]|
               77|
               9[023]
@@ -26954,51 +27988,57 @@
       </personalNumber>
     </territory>
 
-    <!-- Viet Nam (Vietnam) -->
+    <!-- Vietnam (VN) -->
     <!-- http://www.itu.int/oth/T02020000E4/en -->
     <!-- http://en.wikipedia.org/wiki/%2B84 -->
-    <territory id="VN" countryCode="84" internationalPrefix="00" nationalPrefix="0"
-               nationalPrefixOptionalWhenFormatting="true">
+    <territory id="VN" countryCode="84" internationalPrefix="00" nationalPrefix="0">
       <availableFormats>
-        <!-- UAN, but not marked as national only (there are instance of numbers in these ranges
-             formatted for international dialling online, but they could be auto-generated). -->
-        <numberFormat pattern="(\d{2})(\d{5})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>80</leadingDigits>
-          <format>$1 $2</format>
-        </numberFormat>
         <!-- National only UAN -->
-        <numberFormat pattern="(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
+        <numberFormat pattern="(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG"
+                      nationalPrefixOptionalWhenFormatting="true">
           <leadingDigits>[17]99</leadingDigits>
           <format>$1 $2</format>
           <intlFormat>NA</intlFormat>
         </numberFormat>
+        <!-- UAN, but not marked as national only (there are instance of numbers in these ranges
+             formatted for international dialling online, but they could be auto-generated). -->
+        <numberFormat pattern="(\d{2})(\d{5})" nationalPrefixFormattingRule="$NP$FG"
+                      nationalPrefixOptionalWhenFormatting="true">
+          <leadingDigits>80</leadingDigits>
+          <format>$1 $2</format>
+        </numberFormat>
         <!-- National only UAN -->
-        <numberFormat pattern="(\d{3})(\d{4,5})" nationalPrefixFormattingRule="$NP$FG">
+        <numberFormat pattern="(\d{3})(\d{4,5})" nationalPrefixFormattingRule="$NP$FG"
+                      nationalPrefixOptionalWhenFormatting="true">
           <leadingDigits>69</leadingDigits>
           <format>$1 $2</format>
           <intlFormat>NA</intlFormat>
         </numberFormat>
         <!-- Non-geographic fixed line (toll free / standard rate) -->
-        <numberFormat pattern="(\d{4})(\d{4,6})">
+        <numberFormat pattern="(\d{4})(\d{4,6})" nationalPrefixOptionalWhenFormatting="true">
           <leadingDigits>1</leadingDigits>
           <format>$1 $2</format>
         </numberFormat>
         <!-- Format for old mobile ranges and VOIP. -->
-        <numberFormat pattern="(\d{2})(\d{3})(\d{2})(\d{2})" nationalPrefixFormattingRule="$NP$FG">
+        <numberFormat pattern="(\d{2})(\d{3})(\d{2})(\d{2})" nationalPrefixFormattingRule="$NP$FG"
+                      nationalPrefixOptionalWhenFormatting="true">
           <leadingDigits>[69]</leadingDigits>
           <format>$1 $2 $3 $4</format>
         </numberFormat>
-        <numberFormat pattern="(\d{3})(\d{3})(\d{3})" nationalPrefixFormattingRule="$NP$FG">
+        <numberFormat pattern="(\d{3})(\d{3})(\d{3})" nationalPrefixFormattingRule="$NP$FG"
+                      nationalPrefixOptionalWhenFormatting="true">
           <leadingDigits>[3578]</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
         <!-- 2-digit area codes (big cities) -->
-        <numberFormat pattern="(\d{2})(\d{4})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
+        <numberFormat pattern="(\d{2})(\d{4})(\d{4})" nationalPrefixFormattingRule="$NP$FG"
+                      nationalPrefixOptionalWhenFormatting="true">
           <leadingDigits>2[48]</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
         <!-- 3-digit area codes -->
-        <numberFormat pattern="(\d{3})(\d{4})(\d{3})" nationalPrefixFormattingRule="$NP$FG">
+        <numberFormat pattern="(\d{3})(\d{4})(\d{3})" nationalPrefixFormattingRule="$NP$FG"
+                      nationalPrefixOptionalWhenFormatting="true">
           <leadingDigits>2</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
@@ -27007,24 +28047,21 @@
         <nationalNumberPattern>
           [12]\d{9}|
           [135-9]\d{8}|
-          (?:
-            [16]\d?|
-            [78]
-          )\d{6}
+          [16]\d{7}|
+          [16-8]\d{6}
         </nationalNumberPattern>
       </generalDesc>
       <noInternationalDialling>
         <possibleLengths national="7,8"/>
         <nationalNumberPattern>
-          (?:
-            [17]99|
-            69\d\d?
-          )\d{4}
+          [17]99\d{4}|
+          69\d{5,6}
         </nationalNumberPattern>
       </noInternationalDialling>
       <!-- While 24 and 28 are the new area codes for Hanoi and Ho Chi Minh respectively, currently
            only 24[2-8] and 28[2-7] are in use. Reporter mentioned prefix 866 is Mobile but was
-           unable to receive SMS so for now supporting in both Mobile and Fixed-line -->
+           unable to receive SMS so for now supporting in both Mobile and Fixed-line. Range 289 is
+           added based on user report. -->
       <fixedLine>
         <possibleLengths national="10"/>
         <exampleNumber>2101234567</exampleNumber>
@@ -27038,59 +28075,62 @@
             5[124-9]|
             6[0-39]|
             7[0-7]|
-            8[2-7]|
+            8[2-79]|
             9[0-4679]
           )\d{7}
         </nationalNumberPattern>
       </fixedLine>
       <!-- For the 8\d{8} range, we have clearer & more recent information available from IR.21
-           docs than from ITU. Thus we consider 88x, 868, 89[89] as mobile ranges. 86[59] has been
+           docs than from ITU. Thus we consider 88x, 868, 89[89] as mobile ranges. 86[259] has been
            added to Mobile as per a user report. -->
       <mobile>
         <possibleLengths national="9"/>
         <exampleNumber>912345678</exampleNumber>
         <nationalNumberPattern>
           (?:
-            (?:
-              3\d|
-              7[06-9]
-            )\d|
-            5(?:
-              2[238]|
-              [689]\d
-            )|
+            52[238]|
             8(?:
-              [1-58]\d|
-              6[5689]|
+              79|
               9[689]
             )|
-            9(?:
-              [0-8]\d|
-              9[013-9]
-            )
-          )\d{6}
+            99[013-9]
+          )\d{6}|
+          (?:
+            3\d|
+            5[689]|
+            7[06-9]|
+            8[1-68]|
+            9[0-8]
+          )\d{7}
         </nationalNumberPattern>
       </mobile>
+      <!-- As per the user and update from carrier it seems that numbers starting with 1800 are
+           renumbered to 1228. Because we don't have complete update,supporting both the ranges
+           at present.
+           Prefix 1203 is toll free number and is diallable from Orange Business Services based on
+           user report. As we do not have official document mentioning the cost of the range, we
+           have added it here for now. -->
       <tollFree>
         <possibleLengths national="[8-10]"/>
         <exampleNumber>1800123456</exampleNumber>
-        <nationalNumberPattern>1800\d{4,6}</nationalNumberPattern>
+        <nationalNumberPattern>
+          1800\d{4,6}|
+          12(?:
+            03|
+            28
+          )\d{4}
+        </nationalNumberPattern>
       </tollFree>
       <premiumRate>
         <possibleLengths national="[8-10]"/>
         <exampleNumber>1900123456</exampleNumber>
         <nationalNumberPattern>1900\d{4,6}</nationalNumberPattern>
       </premiumRate>
-      <!-- 992 is a VSAT numbering range as per ITU doc. -->
+      <!-- 672 is a VSAT numbering range as per ITU doc. -->
       <voip>
         <possibleLengths national="9"/>
-        <exampleNumber>992012345</exampleNumber>
-        <nationalNumberPattern>
-          (?:
-            67|
-            99
-          )2\d{6}
-        </nationalNumberPattern>
+        <exampleNumber>672012345</exampleNumber>
+        <nationalNumberPattern>672\d{6}</nationalNumberPattern>
       </voip>
       <!-- These include non-geographic fixed numbers, such as for government ministries. While
            listed as "private networks", they may actually be callable from within Vietnam. (They
@@ -27101,14 +28141,14 @@
         <nationalNumberPattern>
           (?:
             [17]99|
-            69\d\d?|
             80\d
-          )\d{4}
+          )\d{4}|
+          69\d{5,6}
         </nationalNumberPattern>
       </uan>
     </territory>
 
-    <!-- Vanuatu -->
+    <!-- Vanuatu (VU) -->
     <!-- http://www.itu.int/oth/T02020000E2/en -->
     <!-- Should be formatted in one block, apart from the mobile numbers. -->
     <territory id="VU" countryCode="678" internationalPrefix="00">
@@ -27121,15 +28161,13 @@
       <generalDesc>
         <nationalNumberPattern>
           (?:
-            (?:
-              [23]|
-              (?:
-                [57]\d|
-                90
-              )\d
-            )\d|
+            [23]\d|
             [48]8
-          )\d{3}
+          )\d{3}|
+          (?:
+            [57]\d|
+            90
+          )\d{5}
         </nationalNumberPattern>
       </generalDesc>
       <fixedLine>
@@ -27137,29 +28175,25 @@
         <exampleNumber>22123</exampleNumber>
         <nationalNumberPattern>
           (?:
-            (?:
-              2[02-9]|
-              88
-            )\d|
-            3(?:
-              [5-7]\d|
-              8[0-8]
-            )|
+            38[0-8]|
             48[4-9]
-          )\d\d
+          )\d\d|
+          (?:
+            2[02-9]|
+            3[4-7]|
+            88
+          )\d{3}
         </nationalNumberPattern>
       </fixedLine>
       <mobile>
         <possibleLengths national="7"/>
         <exampleNumber>5912345</exampleNumber>
         <nationalNumberPattern>
+          57[2-5]\d{4}|
           (?:
-            5(?:
-              [0-689]\d|
-              7[2-5]
-            )|
-            7[013-7]\d
-          )\d{4}
+            5[0-689]|
+            7[013-7]
+          )\d{5}
         </nationalNumberPattern>
       </mobile>
       <voip>
@@ -27181,7 +28215,7 @@
       </uan>
     </territory>
 
-    <!-- Wallis and Futuna (Territoire français d'outre-mer) -->
+    <!-- Wallis & Futuna (WF) -->
     <!-- http://www.itu.int/oth/T02020000E6/en -->
     <territory id="WF" countryCode="681" internationalPrefix="00">
       <availableFormats>
@@ -27232,7 +28266,7 @@
       </voicemail>
     </territory>
 
-    <!-- Samoa -->
+    <!-- Samoa (WS) -->
     <!-- http://www.itu.int/oth/T02020000B4/en -->
     <territory id="WS" countryCode="685" internationalPrefix="0">
       <availableFormats>
@@ -27251,12 +28285,10 @@
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
-          (?:
-            [2-6]|
-            8\d(?:
-              \d{4}
-            )?
-          )\d{4}|
+          [2-6]\d{4}|
+          8\d{5}(?:
+            \d{4}
+          )?|
           [78]\d{6}
         </nationalNumberPattern>
       </generalDesc>
@@ -27296,18 +28328,18 @@
       </tollFree>
     </territory>
 
-    <!-- Kosovo -->
+    <!-- Kosovo (XK) -->
     <!-- https://www.itu.int/oth/T02020000FD/en -->
     <!-- http://arkep-rks.org/?cid=1,50 -->
     <territory id="XK" countryCode="383" internationalPrefix="00" nationalPrefix="0">
       <availableFormats>
-        <numberFormat pattern="(\d{2})(\d{3})(\d{3})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>[2-4]</leadingDigits>
-          <format>$1 $2 $3</format>
-        </numberFormat>
         <numberFormat pattern="(\d{3})(\d{5})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>[89]</leadingDigits>
           <format>$1 $2</format>
+        </numberFormat>
+        <numberFormat pattern="(\d{2})(\d{3})(\d{3})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>[2-4]</leadingDigits>
+          <format>$1 $2 $3</format>
         </numberFormat>
         <numberFormat pattern="(\d{3})(\d{3})(\d{3})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>[23]</leadingDigits>
@@ -27316,8 +28348,8 @@
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
+          [23]\d{7,8}|
           (?:
-            [23]\d{2,3}|
             4\d\d|
             [89]00
           )\d{5}
@@ -27337,7 +28369,7 @@
       <mobile>
         <possibleLengths national="8"/>
         <exampleNumber>43201234</exampleNumber>
-        <nationalNumberPattern>4[3-79]\d{6}</nationalNumberPattern>
+        <nationalNumberPattern>4[3-9]\d{6}</nationalNumberPattern>
       </mobile>
       <tollFree>
         <possibleLengths national="8"/>
@@ -27351,7 +28383,7 @@
       </premiumRate>
     </territory>
 
-    <!-- Yemen -->
+    <!-- Yemen (YE) -->
     <!-- No tollFree or premiumRate information can be found. -->
     <!-- http://www.itu.int/oth/T02020000E7/en -->
     <territory id="YE" countryCode="967" internationalPrefix="00" nationalPrefix="0">
@@ -27400,7 +28432,7 @@
       </mobile>
     </territory>
 
-    <!-- Mayotte -->
+    <!-- Mayotte (YT) -->
     <!-- Calling code and formatting shared with 'RE' -->
     <!-- Some information at the following source, but most from collection of internet data. -->
     <!-- Verifies the fixed-line prefixes, but the mobile prefixes listed here seem out of date. -->
@@ -27411,13 +28443,11 @@
                nationalPrefix="0">
       <generalDesc>
         <nationalNumberPattern>
+          80\d{7}|
           (?:
-            (?:
-              26|
-              63
-            )9|
-            80\d
-          )\d{6}
+            26|
+            63
+          )9\d{6}
         </nationalNumberPattern>
       </generalDesc>
       <fixedLine>
@@ -27426,7 +28456,7 @@
         <nationalNumberPattern>
           269(?:
             0[67]|
-            5[01]|
+            5[0-2]|
             6\d|
             [78]0
           )\d{4}
@@ -27454,7 +28484,7 @@
       </tollFree>
     </territory>
 
-    <!-- South Africa -->
+    <!-- South Africa (ZA) -->
     <!-- http://www.itu.int/oth/T02020000C1/en -->
     <!-- http://en.wikipedia.org/wiki/Telephone_numbers_in_South_Africa -->
     <!-- https://www.icasa.org.za/Portals/0/Regulations/Regulations/NumberingPlanReg.pdf -->
@@ -27497,7 +28527,10 @@
           )\d{7}
         </nationalNumberPattern>
       </fixedLine>
-      <!-- Even though ITU mentions it as protected, the 9-digit 85 range is a valid mobile range
+      <!-- Based on confirmation from telecom partners, many sub ranges of 1X, 2X, 3X, 4X and
+           5X - which are fixed-line as per ITU - can also be used for mobile purpose. Similarly,
+           some 87X VOIP ranges are also moved here.
+           Even though ITU mentions it as protected, the 9-digit 85 range is a valid mobile range
            as per Wikipedia and user reports. Also note that we are still supporting numbers
            beginning with 8 that are fewer than 9 digits since they are in prominent places
            online, even though the ITU document says numbers must be 10 digits long (including the
@@ -27507,11 +28540,52 @@
         <exampleNumber>711234567</exampleNumber>
         <nationalNumberPattern>
           (?:
-            6\d|
-            7[0-46-9]|
-            8[1-5]
-          )\d{7}|
-          8[1-4]\d{3,6}
+            1(?:
+              3492[0-25]|
+              4495[0235]|
+              549(?:
+                20|
+                5[01]
+              )
+            )|
+            4[34]492[01]
+          )\d{3}|
+          8[1-4]\d{3,7}|
+          (?:
+            2[27]|
+            47|
+            54
+          )4950\d{3}|
+          (?:
+            1(?:
+              049[2-4]|
+              9[12]\d\d
+            )|
+            (?:
+              6\d|
+              7[0-46-9]
+            )\d{3}|
+            8(?:
+              5\d{3}|
+              7(?:
+                08[67]|
+                158|
+                28[5-9]|
+                310
+              )
+            )
+          )\d{4}|
+          (?:
+            1[6-8]|
+            28|
+            3[2-69]|
+            4[025689]|
+            5[36-8]
+          )4920\d{3}|
+          (?:
+            12|
+            [2-5]1
+          )492\d{4}
         </nationalNumberPattern>
       </mobile>
       <tollFree>
@@ -27540,7 +28614,20 @@
       <voip>
         <possibleLengths national="9"/>
         <exampleNumber>871234567</exampleNumber>
-        <nationalNumberPattern>87\d{7}</nationalNumberPattern>
+        <nationalNumberPattern>
+          87(?:
+            08[0-589]|
+            15[0-79]|
+            28[0-4]|
+            31[1-9]
+          )\d{4}|
+          87(?:
+            [02][0-79]|
+            1[0-46-9]|
+            3[02-9]|
+            [4-9]\d
+          )\d{5}
+        </nationalNumberPattern>
       </voip>
       <!-- MaxiCall numbers cost as much as national long distance, so they are classified as UAN
            numbers. -->
@@ -27551,12 +28638,13 @@
       </uan>
     </territory>
 
-    <!-- Zambia -->
+    <!-- Zambia (ZM) -->
     <!-- http://www.itu.int/oth/T02020000E8/en -->
     <!-- https://www.zicta.zm/Downloads/Numbering%20Plan.pdf (2014, possibly out of date) -->
     <territory id="ZM" countryCode="260" internationalPrefix="00" nationalPrefix="0">
       <availableFormats>
         <numberFormat pattern="(\d{3})(\d{3})">
+          <leadingDigits>[1-9]</leadingDigits>
           <format>$1 $2</format>
           <intlFormat>NA</intlFormat>
         </numberFormat>
@@ -27574,13 +28662,13 @@
       <generalDesc>
         <nationalNumberPattern>
           (?:
-            (?:
-              21|
-              76|
-              9\d
-            )\d|
-            800
-          )\d{6}
+            63|
+            80
+          )0\d{6}|
+          (?:
+            21|
+            [79]\d
+          )\d{7}
         </nationalNumberPattern>
       </generalDesc>
       <!-- Zambia has deprecated the "intra-network" dialling system as described in
@@ -27597,7 +28685,7 @@
         <exampleNumber>955123456</exampleNumber>
         <nationalNumberPattern>
           (?:
-            76|
+            7[67]|
             9[5-8]
           )\d{7}
         </nationalNumberPattern>
@@ -27607,42 +28695,48 @@
         <exampleNumber>800123456</exampleNumber>
         <nationalNumberPattern>800\d{6}</nationalNumberPattern>
       </tollFree>
+      <voip>
+        <possibleLengths national="9"/>
+        <exampleNumber>630012345</exampleNumber>
+        <nationalNumberPattern>630\d{6}</nationalNumberPattern>
+      </voip>
     </territory>
 
-    <!-- Zimbabwe -->
+    <!-- Zimbabwe (ZW) -->
     <!-- http://www.itu.int/oth/T02020000E9/en -->
     <!-- https://telone.co.zw/sites/default/files/TelOneNewAreaCodesUpdated.pdf -->
     <territory id="ZW" countryCode="263" internationalPrefix="00" nationalPrefix="0">
       <availableFormats>
-        <!-- One-digit area codes -->
-        <numberFormat pattern="(\d)(\d{3})(\d{2,4})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>[49]</leadingDigits>
-          <format>$1 $2 $3</format>
-        </numberFormat>
         <!-- Three-digit area codes (short format) -->
         <numberFormat pattern="(\d{3})(\d{3,5})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>
             2(?:
               0[45]|
               2[278]|
-              [49]8|
-              [78]
+              [49]8
             )|
             3(?:
               [09]8|
-              17|
-              3[78]|
-              [78]
+              17
             )|
-            5[15][78]|
             6(?:
               [29]8|
               37|
-              [68][78]|
               75
-            )
+            )|
+            [23][78]|
+            (?:
+              33|
+              5[15]|
+              6[68]
+            )[78]
           </leadingDigits>
           <format>$1 $2</format>
+        </numberFormat>
+        <!-- One-digit area codes -->
+        <numberFormat pattern="(\d)(\d{3})(\d{2,4})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>[49]</leadingDigits>
+          <format>$1 $2 $3</format>
         </numberFormat>
         <!-- Tollfree Numbers -->
         <numberFormat pattern="(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
@@ -27652,16 +28746,14 @@
         <!-- Format of new fixed-line ranges after renumbering. -->
         <numberFormat pattern="(\d{2})(\d{7})" nationalPrefixFormattingRule="($NP$FG)">
           <leadingDigits>
-            2(?:
-              [05-79]2|
-              4
-            )|
+            24|
+            8[13-59]|
             (?:
+              2[05-79]|
               39|
               5[45]|
               6[15-8]
-            )2|
-            8[13-59]
+            )2
           </leadingDigits>
           <leadingDigits>
             2(?:
@@ -27724,33 +28816,59 @@
         <!-- Two-digit area codes (short format) -->
         <numberFormat pattern="(\d{2})(\d{3,5})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>
-            [16]|
+            1|
             2(?:
-              [0-256]|
-              9[0-79]
+              0[0-36-9]|
+              12|
+              29|
+              [56]
             )|
             3(?:
-              [09][0-79]|
               1[0-689]|
-              [24-6]|
-              3[0-69]
+              [24-6]
             )|
-            5[0-35-9]
+            5(?:
+              [0236-9]|
+              1[2-4]
+            )|
+            6(?:
+              [013-59]|
+              7[0-46-9]
+            )|
+            (?:
+              33|
+              55|
+              6[68]
+            )[0-69]|
+            (?:
+              29|
+              3[09]|
+              62
+            )[0-79]
           </leadingDigits>
           <format>$1 $2</format>
         </numberFormat>
         <!-- Two-digit area codes (long format) -->
         <numberFormat pattern="(\d{2})(\d{3})(\d{3,4})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>
-            29|
-            3|
+            29[013-9]|
+            39|
             54
           </leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
         <!-- Four-digit area codes (short format) -->
         <numberFormat pattern="(\d{4})(\d{3,5})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>[25]</leadingDigits>
+          <leadingDigits>
+            (?:
+              25|
+              54
+            )8
+          </leadingDigits>
+          <leadingDigits>
+            258|
+            5483
+          </leadingDigits>
           <format>$1 $2</format>
         </numberFormat>
       </availableFormats>
@@ -27838,10 +28956,6 @@
                 [56]\d
               )
             )|
-            (?:
-              4\d\d|
-              9[2-9]
-            )\d\d?|
             5(?:
               0|
               1[2-478]|
@@ -27870,6 +28984,10 @@
               523
             )\d\d
           )\d{3}|
+          (?:
+            4\d\d|
+            9[2-9]
+          )\d{4,5}|
           (?:
             (?:
               2(?:
@@ -27922,21 +29040,13 @@
           )\d{3}
         </nationalNumberPattern>
       </fixedLine>
-      <!-- The ITU document list 8644 as VoIP, but an open-source reporter was in touch with the
-           issuing company (Africom) who said they were using them for SMS-capable devices, so we
-           support it as mobile. -->
       <mobile>
-        <possibleLengths national="9,10"/>
+        <possibleLengths national="9"/>
         <exampleNumber>712345678</exampleNumber>
         <nationalNumberPattern>
-          (?:
-            7(?:
-              1\d|
-              3[2-9]|
-              7[1-9]|
-              8[2-5]
-            )|
-            8644
+          7(?:
+            [17]\d|
+            [38][1-9]
           )\d{6}
         </nationalNumberPattern>
       </mobile>
@@ -27958,7 +29068,9 @@
         <nationalNumberPattern>
           86(?:
             1[12]|
+            22|
             30|
+            44|
             55|
             77|
             8[368]
@@ -28131,10 +29243,10 @@
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
-          [13]\d{6}(?:
+          1\d{6,11}|
+          3\d{6}(?:
             \d{2,5}
-          )?|
-          1\d{7}
+          )?
         </nationalNumberPattern>
       </generalDesc>
       <!-- Bebbicell Mobile numbers, MCP and Oration. We are guessing the number length for
@@ -28145,18 +29257,14 @@
         <exampleNumber>3421234</exampleNumber>
         <nationalNumberPattern>
           3(?:
-            (?:
-              (?:
-                2|
-                7\d{3}
-              )\d|
-              37
-            )\d\d|
-            4(?:
-              2|
-              7\d{3}
-            )
-          )\d{4}
+            37\d\d|
+            42
+          )\d{4}|
+          3(?:
+            2|
+            47|
+            7\d{3}
+          )\d{7}
         </nationalNumberPattern>
       </mobile>
       <!-- Telespazio S.p.A., Thuraya and Bebbicell VOIP numbers. -->
@@ -28166,25 +29274,23 @@
         <possibleLengths national="[7-12]"/>
         <exampleNumber>390123456789</exampleNumber>
         <nationalNumberPattern>
-          (?:
-            1(?:
-              3(?:
-                0[0347]|
-                [13][0139]|
-                2[035]|
-                4[013568]|
-                6[0459]|
-                7[06]|
-                8[15-8]|
-                9[0689]
-              )|
-              6\d{1,6}
-            )|
+          1(?:
             3(?:
-              45|
-              9\d{3}
-            )\d{3}
-          )\d{4}
+              0[0347]|
+              [13][0139]|
+              2[035]|
+              4[013568]|
+              6[0459]|
+              7[06]|
+              8[15-8]|
+              9[0689]
+            )\d{4}|
+            6\d{5,10}
+          )|
+          3(?:
+            45|
+            9\d{3}
+          )\d{7}
         </nationalNumberPattern>
       </voip>
       <voicemail>

--- a/resources/PhoneNumberMetadataForTesting.xml
+++ b/resources/PhoneNumberMetadataForTesting.xml
@@ -551,19 +551,14 @@
     <!-- This country is used to test ShortNumberInfo, so at least the country calling code must be
          recognised by the library, and it must be the same as that of the United Kingdom. -->
     <territory id="GG" countryCode="44" internationalPrefix="00">
-    </territory>
-
-    <!-- Hungary -->
-    <!-- This country has special logic in formatNumberForMobileDialing which must be tested. -->
-    <territory id="HU" countryCode="36" internationalPrefix="00" nationalPrefix="06">
       <generalDesc>
-        <nationalNumberPattern>30\d{7}</nationalNumberPattern>
+        <nationalNumberPattern>\d{6,10}</nationalNumberPattern>
       </generalDesc>
-      <mobile>
-        <nationalNumberPattern>30\d{7}</nationalNumberPattern>
-        <possibleLengths national="9"/>
-        <exampleNumber>301234567</exampleNumber>
-      </mobile>
+      <fixedLine>
+        <nationalNumberPattern>\d{6,10}</nationalNumberPattern>
+        <possibleLengths national="10" localOnly="6"/>
+        <exampleNumber>7033456789</exampleNumber>
+      </fixedLine>
     </territory>
 
     <!-- Italy -->


### PR DESCRIPTION
Hi,

This PR updates to the latest [version](https://github.com/google/libphonenumber/tree/master/resources) which is **8.11.1**.

There is a failing test about `gb_invalid`, I don't have enough knowledge about GB phone numbers to know the cause. Can someone help me to fix the test?

```
  1) test .is_valid_number/1 test GB invalid returns false (ExPhoneNumber.ValidationTest)
     test/ex_phone_number/validation_test.exs:206
     Expected false or nil, got true
     code: refute is_valid_number?(PhoneNumberFixture.gb_invalid())
     arguments:

         # 1
         %ExPhoneNumber.Model.PhoneNumber{
           country_code: 44,
           country_code_source: nil,
           extension: nil,
           italian_leading_zero: nil,
           national_number: 791234567,
           number_of_leading_zeros: nil,
           preferred_domestic_carrier_code: nil,
           raw_input: nil
         }

     stacktrace:
       test/ex_phone_number/validation_test.exs:207: (test)
```