### PR TITLE
Update parse to check invalid_length of stripped national number

### DIFF
--- a/lib/ex_phone_number/parsing.ex
+++ b/lib/ex_phone_number/parsing.ex
@@ -154,7 +154,7 @@ defmodule ExPhoneNumber.Parsing do
           case maybe_strip_national_prefix_and_carrier_code(normalized_national_number, metadata) do
             {true, carrier_code, potential_national_number} ->
               national_number =
-                if not is_shorter_than_possible_normal_number?(
+                if is_valid_possible_number_length?(
                      metadata,
                      potential_national_number
                    ),

--- a/lib/ex_phone_number/validation.ex
+++ b/lib/ex_phone_number/validation.ex
@@ -92,8 +92,14 @@ defmodule ExPhoneNumber.Validation do
     end
   end
 
-  def is_shorter_than_possible_normal_number?(metadata, number) do
-    test_number_length(number, metadata) == ValidationResults.too_short()
+  def is_valid_possible_number_length?(metadata, number) do
+    !Enum.member?(
+      [
+        ValidationResults.too_short(),
+        ValidationResults.invalid_length()
+      ],
+      test_number_length(number, metadata)
+    )
   end
 
   def is_valid_number?(%PhoneNumber{} = number) do

--- a/test/ex_phone_number/parsing_test.exs
+++ b/test/ex_phone_number/parsing_test.exs
@@ -24,6 +24,10 @@ defmodule ExPhoneNumber.ParsingTest do
         assert is_possible_number?("253-0000", RegionCodeFixture.us())
       end
 
+      it "should return true #5" do
+        assert is_possible_number?("+1 111 253 0000", RegionCodeFixture.us())
+      end
+
       it "should return false #1" do
         refute is_possible_number?("+1 650 253 00000", RegionCodeFixture.us())
       end


### PR DESCRIPTION
👋  I came across an obscure bug in this library when compared to Google's implementation.

`is_possible_number?` will incorrectly return false for any US number with an area code that starts with 1. 

You can confirm this by running `ExPhoneNumber.is_possible_number?(+11115551234)` and comparing to the result from Google's reference site:
https://libphonenumber.appspot.com/phonenumberparser?number=%2B11115551234&country=US

This happens due to how the numbers are parsed ex. 1-111-555-1234 is parsed as `national_number: 11-555-1234`. Once I found where it was incorrectly stripping the first digit I compared the implementation to the golang `libphonenumber` port to find the fix which makes me fairly confident that it's not just some random coincidental change that happens to fix this.

This seems to only affect the US because of combination of
- `mainCountryForCode=true`
- the first digit of the number cannot start with the same digit as the `countryCode`
- localOnly numbers that are shorter than national numbers

Unfortunately, it's not possible to unit test this behavior because `PhoneNumberMetadataForTesting.xml` simplifies the US config and doesn't seem to have a comparable one. The unit test included with this PR will fail when using `PhoneNumberMetadata` but pass with `PhoneNumberMetadataForTesting`. A reduced config that captures this behavior is:

```
   <territory id="fake" mainCountryForCode="true" countryCode="1" internationalPrefix="011"
               nationalPrefix="1">
      <generalDesc>
        <nationalNumberPattern>[2-9]\d{9}</nationalNumberPattern>
      </generalDesc>
      <fixedLine>
        <possibleLengths national="10" localOnly="7"/>
        <exampleNumber>2015550123</exampleNumber>
        <nationalNumberPattern>
         [2-9]\d{9}
        </nationalNumberPattern>
      </fixedLine>
    </territory>
```



