### PR TITLE
Metadata updates for release 8.13.7

### DIFF
--- a/resources/PhoneNumberMetadata.xml
+++ b/resources/PhoneNumberMetadata.xml
@@ -3,7 +3,7 @@
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.
      You may obtain a copy of the License at
-
+     
      http://www.apache.org/licenses/LICENSE-2.0
 
      Unless required by applicable law or agreed to in writing, software
@@ -310,7 +310,7 @@
     <!-- Calling code and formatting shared with 'US' -->
     <!-- http://www.itu.int/oth/T0202000008/en -->
     <territory id="AG" countryCode="1" leadingDigits="268" internationalPrefix="011"
-               nationalPrefix="1" nationalPrefixForParsing="1|([457]\d{6})$"
+               nationalPrefix="1" nationalPrefixForParsing="([457]\d{6})$|1"
                nationalPrefixTransformRule="268$1" mobileNumberPortableRegion="true">
       <generalDesc>
         <nationalNumberPattern>
@@ -413,7 +413,7 @@
           52[34][2-9]1[02-9]\d{4}|
           5(?:
             00|
-            2[125-7]|
+            2[125-9]|
             33|
             44|
             66|
@@ -434,7 +434,7 @@
     <!-- Calling code and formatting shared with 'US' -->
     <!-- http://www.itu.int/oth/T0202000007/en -->
     <territory id="AI" countryCode="1" leadingDigits="264" internationalPrefix="011"
-               nationalPrefix="1" nationalPrefixForParsing="1|([2457]\d{6})$"
+               nationalPrefix="1" nationalPrefixForParsing="([2457]\d{6})$|1"
                nationalPrefixTransformRule="264$1" mobileNumberPortableRegion="true">
       <generalDesc>
         <nationalNumberPattern>
@@ -538,7 +538,7 @@
           52[34][2-9]1[02-9]\d{4}|
           5(?:
             00|
-            2[125-7]|
+            2[125-9]|
             33|
             44|
             66|
@@ -935,7 +935,7 @@
           <intlFormat>NA</intlFormat>
         </numberFormat>
         <numberFormat pattern="(\d{3})(\d{4})">
-          <leadingDigits>[2-8]</leadingDigits>
+          <leadingDigits>[2-9]</leadingDigits>
           <format>$1-$2</format>
           <intlFormat>NA</intlFormat>
         </numberFormat>
@@ -1437,16 +1437,6 @@
         <exampleNumber>1123456789</exampleNumber>
         <nationalNumberPattern>
           3888[013-9]\d{5}|
-          (?:
-            29(?:
-              54|
-              66
-            )|
-            3(?:
-              777|
-              865
-            )
-          )[2-8]\d{5}|
           3(?:
             7(?:
               1[15]|
@@ -1459,6 +1449,19 @@
               9[12]
             )
           )[46]\d{5}|
+          (?:
+            29(?:
+              54|
+              66
+            )|
+            3(?:
+              7(?:
+                55|
+                77
+              )|
+              865
+            )
+          )[2-8]\d{5}|
           (?:
             2(?:
               2(?:
@@ -1483,7 +1486,10 @@
           (?:
             2(?:
               284|
-              302|
+              3(?:
+                02|
+                23
+              )|
               657|
               920
             )|
@@ -1493,7 +1499,6 @@
                 92
               )|
               541|
-              755|
               878
             )
           )[2-7]\d{5}|
@@ -1503,7 +1508,7 @@
                 26|
                 62
               )2|
-              32[03]|
+              320|
               477|
               9(?:
                 42|
@@ -1557,7 +1562,7 @@
                 84
               )|
               5(?:
-                1[2-8]|
+                1[2-9]|
                 [38][4-6]
               )|
               6(?:
@@ -1566,8 +1571,9 @@
               )|
               7[069][45]|
               8(?:
-                [03][45]|
+                0[45]|
                 [17][2-6]|
+                3[4-6]|
                 [58][3-6]
               )
             )
@@ -1702,29 +1708,34 @@
         <possibleLengths national="10,11" localOnly="[6-8]"/>
         <exampleNumber>91123456789</exampleNumber>
         <nationalNumberPattern>
-          93888[013-9]\d{5}|
+          93(?:
+            7(?:
+              1[15]|
+              81
+            )[46]|
+            8(?:
+              (?:
+                21|
+                4[16]|
+                69|
+                9[12]
+              )[46]|
+              88[013-9]
+            )
+          )\d{5}|
           9(?:
             29(?:
               54|
               66
             )|
             3(?:
-              777|
+              7(?:
+                55|
+                77
+              )|
               865
             )
           )[2-8]\d{5}|
-          93(?:
-            7(?:
-              1[15]|
-              81
-            )|
-            8(?:
-              21|
-              4[16]|
-              69|
-              9[12]
-            )
-          )[46]\d{5}|
           9(?:
             2(?:
               2(?:
@@ -1749,7 +1760,10 @@
           9(?:
             2(?:
               284|
-              302|
+              3(?:
+                02|
+                23
+              )|
               657|
               920
             )|
@@ -1759,7 +1773,6 @@
                 92
               )|
               541|
-              755|
               878
             )
           )[2-7]\d{5}|
@@ -1769,7 +1782,7 @@
                 26|
                 62
               )2|
-              32[03]|
+              320|
               477|
               9(?:
                 42|
@@ -1822,7 +1835,7 @@
                   84
                 )|
                 5(?:
-                  1[2-8]|
+                  1[2-9]|
                   [38][4-6]
                 )|
                 6(?:
@@ -1831,8 +1844,9 @@
                 )|
                 7[069][45]|
                 8(?:
-                  [03][45]|
+                  0[45]|
                   [17][2-6]|
+                  3[4-6]|
                   [58][3-6]
                 )
               )
@@ -1984,7 +1998,7 @@
     <!-- Calling code and formatting shared with 'US' -->
     <!-- http://www.itu.int/oth/T0202000004/en -->
     <territory id="AS" countryCode="1" leadingDigits="684" internationalPrefix="011"
-               nationalPrefix="1" nationalPrefixForParsing="1|([267]\d{6})$"
+               nationalPrefix="1" nationalPrefixForParsing="([267]\d{6})$|1"
                nationalPrefixTransformRule="684$1">
       <generalDesc>
         <nationalNumberPattern>
@@ -2019,7 +2033,7 @@
             2(?:
               48|
               5[2468]|
-              72
+              7[26]
             )|
             7(?:
               3[13]|
@@ -2083,7 +2097,7 @@
           52[34][2-9]1[02-9]\d{4}|
           5(?:
             00|
-            2[125-7]|
+            2[125-9]|
             33|
             44|
             66|
@@ -2099,6 +2113,12 @@
     <territory id="AT" countryCode="43" internationalPrefix="00" nationalPrefix="0"
                mobileNumberPortableRegion="true">
       <availableFormats>
+        <!-- Shortcode format -->
+        <numberFormat pattern="(\d{4})">
+          <leadingDigits>14</leadingDigits>
+          <format>$1</format>
+          <intlFormat>NA</intlFormat>
+        </numberFormat>
         <!-- Vienna (Wien) fixed line format (1-digit area code). -->
         <numberFormat pattern="(\d)(\d{3,12})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>
@@ -2122,7 +2142,7 @@
         </numberFormat>
         <!-- Shortcode format -->
         <numberFormat pattern="(\d{6})">
-          <leadingDigits>1</leadingDigits>
+          <leadingDigits>[18]</leadingDigits>
           <format>$1</format>
           <intlFormat>NA</intlFormat>
         </numberFormat>
@@ -2327,7 +2347,7 @@
     <territory id="AU" mainCountryForCode="true" countryCode="61"
                preferredInternationalPrefix="0011"
                internationalPrefix="001[14-689]|14(?:1[14]|34|4[17]|[56]6|7[47]|88)0011"
-               nationalPrefix="0" nationalPrefixForParsing="0|(183[12])"
+               nationalPrefix="0" nationalPrefixForParsing="(183[12])|0"
                mobileNumberPortableRegion="true">
       <availableFormats>
         <!-- Pager (5-6 digits) -->
@@ -2506,15 +2526,16 @@
         <exampleNumber>412345678</exampleNumber>
         <nationalNumberPattern>
           4(?:
-            83[0-38]|
+            79[01]|
+            83[0-389]|
             93[0-6]
           )\d{5}|
           4(?:
             [0-3]\d|
             4[047-9]|
             5[0-25-9]|
-            6[06-9]|
-            7[02-9]|
+            6[016-9]|
+            7[02-8]|
             8[0-24-9]|
             9[0-27-9]
           )\d{6}
@@ -2974,7 +2995,7 @@
     <!-- Calling code and formatting shared with 'US' -->
     <!-- http://www.itu.int/oth/T0202000013/en -->
     <territory id="BB" countryCode="1" leadingDigits="246" internationalPrefix="011"
-               nationalPrefix="1" nationalPrefixForParsing="1|([2-9]\d{6})$"
+               nationalPrefix="1" nationalPrefixForParsing="([2-9]\d{6})$|1"
                nationalPrefixTransformRule="246$1" mobileNumberPortableRegion="true">
       <generalDesc>
         <nationalNumberPattern>
@@ -3109,7 +3130,7 @@
           52[34][2-9]1[02-9]\d{4}|
           5(?:
             00|
-            2[125-7]|
+            2[125-9]|
             33|
             44|
             66|
@@ -3634,14 +3655,14 @@
               2[0-57]|
               3[04-7]|
               44|
-              69|
+              6[569]|
               7[0579]
             )|
             90(?:
               0[0-8]|
               1[36]|
               2[0-3568]|
-              3[013-689]|
+              3[0-689]|
               [47][2-68]|
               5[1-68]|
               6[0-378]|
@@ -3664,12 +3685,12 @@
         <nationalNumberPattern>
           78(?:
             0[57]|
-            1[0458]|
+            1[014-8]|
             2[25]|
             3[15-8]|
             48|
             [56]0|
-            7[078]|
+            7[06-8]|
             9\d
           )\d{4}
         </nationalNumberPattern>
@@ -3721,7 +3742,7 @@
         <exampleNumber>70123456</exampleNumber>
         <nationalNumberPattern>
           (?:
-            0[125-7]|
+            0[1-35-7]|
             5[1-8]|
             [67]\d
           )\d{6}
@@ -3801,6 +3822,7 @@
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
+          00800\d{7}|
           [2-7]\d{6,7}|
           [89]\d{6,8}|
           2\d{5}
@@ -3844,9 +3866,14 @@
         </nationalNumberPattern>
       </mobile>
       <tollFree>
-        <possibleLengths national="8"/>
+        <possibleLengths national="8,12"/>
         <exampleNumber>80012345</exampleNumber>
-        <nationalNumberPattern>800\d{5}</nationalNumberPattern>
+        <nationalNumberPattern>
+          (?:
+            00800\d\d|
+            800
+          )\d{5}
+        </nationalNumberPattern>
       </tollFree>
       <premiumRate>
         <possibleLengths national="8"/>
@@ -4008,8 +4035,7 @@
         <nationalNumberPattern>
           (?:
             29|
-            6[1257-9]|
-            7[125-9]
+            [67][125-9]
           )\d{6}
         </nationalNumberPattern>
       </mobile>
@@ -4026,12 +4052,7 @@
         </numberFormat>
       </availableFormats>
       <generalDesc>
-        <nationalNumberPattern>
-          (?:
-            [25689]\d|
-            40
-          )\d{6}
-        </nationalNumberPattern>
+        <nationalNumberPattern>[24-689]\d{7}</nationalNumberPattern>
       </generalDesc>
       <!-- These come from the national numbering plan, but have been widened to include other
            prefixes found in the yellow pages - specifically 21 0. -->
@@ -4043,7 +4064,8 @@
             02|
             1[037]|
             2[45]|
-            3[68]
+            3[68]|
+            4\d
           )\d{5}
         </nationalNumberPattern>
       </fixedLine>
@@ -4056,9 +4078,8 @@
         <exampleNumber>90011234</exampleNumber>
         <nationalNumberPattern>
           (?:
-            40|
-            5[1-8]|
-            6\d|
+            4[0-2]|
+            [56]\d|
             9[013-9]
           )\d{6}
         </nationalNumberPattern>
@@ -4148,7 +4169,7 @@
     <!-- Calling code and formatting shared with 'US' -->
     <!-- http://www.itu.int/oth/T0202000018/en -->
     <territory id="BM" countryCode="1" leadingDigits="441" internationalPrefix="011"
-               nationalPrefix="1" nationalPrefixForParsing="1|([2-8]\d{6})$"
+               nationalPrefix="1" nationalPrefixForParsing="([2-9]\d{6})$|1"
                nationalPrefixTransformRule="441$1" mobileNumberPortableRegion="true">
       <generalDesc>
         <nationalNumberPattern>
@@ -4179,7 +4200,8 @@
         <nationalNumberPattern>
           441(?:
             [2378]\d|
-            5[0-39]
+            5[0-39]|
+            92
           )\d{5}
         </nationalNumberPattern>
       </mobile>
@@ -4237,7 +4259,7 @@
           52[34][2-9]1[02-9]\d{4}|
           5(?:
             00|
-            2[125-7]|
+            2[125-9]|
             33|
             44|
             66|
@@ -4574,7 +4596,7 @@
             [1-46-9]\d\d|
             5(?:
               [0-46-9]\d|
-              5[0-24679]
+              5[0-46-9]
             )
           )\d{8}|
           [1-9]\d{9}|
@@ -4583,10 +4605,17 @@
         </nationalNumberPattern>
       </generalDesc>
       <noInternationalDialling>
-        <possibleLengths national="8"/>
+        <possibleLengths national="[8-10]"/>
         <nationalNumberPattern>
-          4020\d{4}|
-          [34]00\d{5}
+          30(?:
+            0\d{5,7}|
+            3\d{7}
+          )|
+          40(?:
+            0\d|
+            20
+          )\d{4}|
+          800\d{6,7}
         </nationalNumberPattern>
       </noInternationalDialling>
       <!-- 52 is not added as an area code even though ITU mentions it, since it is not yet
@@ -4661,7 +4690,7 @@
     <!-- Calling code and formatting shared with 'US' -->
     <!-- http://www.itu.int/oth/T0202000010/en -->
     <territory id="BS" countryCode="1" leadingDigits="242" internationalPrefix="011"
-               nationalPrefix="1" nationalPrefixForParsing="1|([3-8]\d{6})$"
+               nationalPrefix="1" nationalPrefixForParsing="([3-8]\d{6})$|1"
                nationalPrefixTransformRule="242$1" mobileNumberPortableRegion="true">
       <generalDesc>
         <nationalNumberPattern>
@@ -4689,7 +4718,7 @@
             461|
             502|
             6(?:
-              0[1-4]|
+              0[1-5]|
               12|
               2[013]|
               [45]0|
@@ -4800,7 +4829,7 @@
           52[34][2-9]1[02-9]\d{4}|
           5(?:
             00|
-            2[125-7]|
+            2[125-9]|
             33|
             44|
             66|
@@ -4971,7 +5000,7 @@
             321|
             7(?:
               [1-7]\d|
-              8[01]
+              8[0-4]
             )
           )\d{5}
         </nationalNumberPattern>
@@ -4999,9 +5028,9 @@
           79(?:
             1(?:
               [01]\d|
-              20
+              2[0-7]
             )|
-            2[0-25-7]\d
+            2[0-7]\d
           )\d{3}
         </nationalNumberPattern>
       </voip>
@@ -5302,7 +5331,9 @@
             3(?:
               06|
               43|
-              6[578]
+              54|
+              6[578]|
+              82
             )|
             4(?:
               03|
@@ -5321,13 +5352,15 @@
             )|
             6(?:
               04|
-              13|
+              [18]3|
               39|
               47|
               72
             )|
             7(?:
               0[59]|
+              42|
+              53|
               78|
               8[02]
             )|
@@ -5356,7 +5389,9 @@
             3(?:
               06|
               43|
-              6[578]
+              54|
+              6[578]|
+              82
             )|
             4(?:
               03|
@@ -5375,13 +5410,15 @@
             )|
             6(?:
               04|
-              13|
+              [18]3|
               39|
               47|
               72
             )|
             7(?:
               0[59]|
+              42|
+              53|
               78|
               8[02]
             )|
@@ -5450,7 +5487,7 @@
           (?:
             5(?:
               00|
-              2[125-7]|
+              2[125-9]|
               33|
               44|
               66|
@@ -5484,7 +5521,7 @@
     <!-- https://www.thenumberingsystem.com.au/#/number-register/search -->
     <territory id="CC" countryCode="61" preferredInternationalPrefix="0011"
                internationalPrefix="001[14-689]|14(?:1[14]|34|4[17]|[56]6|7[47]|88)0011"
-               nationalPrefix="0" nationalPrefixForParsing="0|([59]\d{7})$"
+               nationalPrefix="0" nationalPrefixForParsing="([59]\d{7})$|0"
                nationalPrefixTransformRule="8$1">
       <generalDesc>
         <nationalNumberPattern>
@@ -5548,15 +5585,16 @@
         <exampleNumber>412345678</exampleNumber>
         <nationalNumberPattern>
           4(?:
-            83[0-38]|
+            79[01]|
+            83[0-389]|
             93[0-6]
           )\d{5}|
           4(?:
             [0-3]\d|
             4[047-9]|
             5[0-25-9]|
-            6[06-9]|
-            7[02-9]|
+            6[016-9]|
+            7[02-8]|
             8[0-24-9]|
             9[0-27-9]
           )\d{6}
@@ -5687,7 +5725,7 @@
       <mobile>
         <possibleLengths national="8"/>
         <exampleNumber>70012345</exampleNumber>
-        <nationalNumberPattern>7[02457]\d{6}</nationalNumberPattern>
+        <nationalNumberPattern>7[024-7]\d{6}</nationalNumberPattern>
       </mobile>
       <premiumRate>
         <possibleLengths national="8"/>
@@ -5872,7 +5910,8 @@
               2(?:
                 0[23]|
                 1[2357]|
-                [23][45]|
+                2[245]|
+                3[45]|
                 4[3-5]
               )|
               3(?:
@@ -5892,16 +5931,7 @@
       <mobile>
         <possibleLengths national="10"/>
         <exampleNumber>0123456789</exampleNumber>
-        <nationalNumberPattern>
-          0704[0-7]\d{5}|
-          0(?:
-            [15]\d\d|
-            7(?:
-              0[0-37-9]|
-              [4-9][7-9]
-            )
-          )\d{6}
-        </nationalNumberPattern>
+        <nationalNumberPattern>0[157]\d{8}</nationalNumberPattern>
       </mobile>
     </territory>
 
@@ -6061,14 +6091,15 @@
               3(?:
                 2\d\d|
                 3(?:
-                  [034]\d|
+                  [0346]\d|
                   1[0-35-9]|
                   2[1-9]|
-                  5[0-2]
+                  5[0-24-9]|
+                  7[0-3]
                 )|
                 600
               )|
-              6469
+              646[59]
             )|
             80[1-9]\d\d|
             9(?:
@@ -6129,14 +6160,15 @@
               3(?:
                 2\d\d|
                 3(?:
-                  [034]\d|
+                  [0346]\d|
                   1[0-35-9]|
                   2[1-9]|
-                  5[0-2]
+                  5[0-24-9]|
+                  7[0-3]
                 )|
                 600
               )|
-              6469
+              646[59]
             )|
             80[1-9]\d\d|
             9(?:
@@ -6270,10 +6302,13 @@
     <!-- https://en.wikipedia.org/wiki/Telephone_numbers_in_China -->
     <territory id="CN" countryCode="86" preferredInternationalPrefix="00"
                internationalPrefix="00|1(?:[12]\d|79)\d\d00" nationalPrefix="0"
-               nationalPrefixForParsing="0|(1(?:[12]\d|79)\d\d)">
+               nationalPrefixForParsing="(1(?:[12]\d|79)\d\d)|0">
       <availableFormats>
         <numberFormat pattern="(\d{5,6})">
-          <leadingDigits>96</leadingDigits>
+          <leadingDigits>
+            10|
+            96
+          </leadingDigits>
           <format>$1</format>
           <intlFormat>NA</intlFormat>
         </numberFormat>
@@ -6296,10 +6331,11 @@
             )
           </leadingDigits>
           <leadingDigits>
-            (?:
+            10(?:
               10|
-              2[0-57-9]
-            )(?:
+              9[56]
+            )|
+            2[0-57-9](?:
               100|
               9[56]
             )
@@ -6321,20 +6357,25 @@
             )
           </leadingDigits>
           <leadingDigits>
-            1[1-9]|
-            26|
-            [3-9]|
-            (?:
-              10|
-              2[0-57-9]
-            )(?:
-              [02-8]|
-              1(?:
-                0[1-9]|
-                [1-9]
+            1(?:
+              0(?:
+                [0-8]|
+                9[0-47-9]
               )|
-              9[0-47-9]
-            )
+              [1-9]
+            )|
+            2(?:
+              [0-57-9](?:
+                [02-8]|
+                1(?:
+                  0[1-9]|
+                  [1-9]
+                )|
+                9[0-47-9]
+              )|
+              6
+            )|
+            [3-9]
           </leadingDigits>
           <format>$1 $2</format>
           <intlFormat>NA</intlFormat>
@@ -6579,21 +6620,36 @@
         <numberFormat pattern="(\d{4})(\d{4})">
           <leadingDigits>[1-9]</leadingDigits>
           <leadingDigits>
-            1[1-9]|
-            26|
-            [3-9]|
-            (?:
-              10|
-              2[0-57-9]
-            )(?:
-              [0-8]|
-              9[0-47-9]
-            )
+            1(?:
+              0(?:
+                [02-8]|
+                1[1-9]|
+                9[0-47-9]
+              )|
+              [1-9]
+            )|
+            2(?:
+              [0-57-9](?:
+                [0-8]|
+                9[0-47-9]
+              )|
+              6
+            )|
+            [3-9]
           </leadingDigits>
           <leadingDigits>
+            1(?:
+              0(?:
+                [02-8]|
+                1[1-9]|
+                9[0-47-9]
+              )|
+              [1-9]
+            )|
             26|
             3(?:
               [0268]|
+              4[0-8]|
               9[079]
             )|
             4(?:
@@ -6608,10 +6664,12 @@
               2[0-24-689]|
               4[0-2457-9]|
               6[057-9]|
+              8[1-9]|
               90
             )|
             6(?:
               [0-24578]|
+              3[06-9]|
               6[14-79]|
               9[03-9]
             )|
@@ -6627,7 +6685,10 @@
               [046]|
               1[01459]|
               2[0-489]|
-              50|
+              5(?:
+                0|
+                [23][0-8]
+              )|
               8[0-2459]|
               9[09]
             )|
@@ -6635,26 +6696,14 @@
               0[0457]|
               1[08]|
               [268]|
-              4[024-9]
+              4[024-9]|
+              5[06-9]
             )|
-            (?:
-              34|
-              85[23]
-            )[0-8]|
-            (?:
-              1|
-              58
-            )[1-9]|
-            (?:
-              63|
-              95
-            )[06-9]|
             (?:
               33|
               85[23]9
             )[0-46-9]|
             (?:
-              10|
               2[0-57-9]|
               3(?:
                 [157]\d|
@@ -6711,7 +6760,14 @@
             )
           </leadingDigits>
           <leadingDigits>
-            26|
+            1(?:
+              0[02-8]|
+              [1-9]
+            )|
+            2(?:
+              [0-57-9][0-8]|
+              6
+            )|
             3(?:
               [0268]|
               3[0-46-9]|
@@ -6769,17 +6825,14 @@
               5[06-9]
             )|
             (?:
-              1|
+              10|
+              2[0-57-9]
+            )9[0-47-9]|
+            (?:
+              101|
               58|
               85[23]10
             )[1-9]|
-            (?:
-              10|
-              2[0-57-9]
-            )(?:
-              [0-8]|
-              9[0-47-9]
-            )|
             (?:
               3(?:
                 [157]\d|
@@ -7175,10 +7228,9 @@
           1(?:
             [38]\d|
             4[57]|
-            5[0-35-9]|
+            [59][0-35-9]|
             6[25-7]|
-            7[0-35-8]|
-            9[0135-9]
+            7[0-35-8]
           )\d{8}
         </nationalNumberPattern>
       </mobile>
@@ -7213,10 +7265,13 @@
         <possibleLengths national="[7-11]" localOnly="5,6"/>
         <exampleNumber>4001234567</exampleNumber>
         <nationalNumberPattern>
+          10(?:
+            10\d{4}|
+            96\d{3,4}
+          )|
           400\d{7}|
           950\d{7,8}|
           (?:
-            10|
             2[0-57-9]|
             3(?:
               [157]\d|
@@ -7276,23 +7331,19 @@
     <!-- http://www.itu.int/oth/T020200002C/en -->
     <!-- http://en.wikipedia.org/wiki/Telephone_numbers_in_Colombia -->
     <territory id="CO" countryCode="57" internationalPrefix="00(?:4(?:[14]4|56)|[579])"
-               nationalPrefix="0" nationalPrefixForParsing="0([3579]|4(?:[14]4|56))?"
+               nationalPrefix="0" nationalPrefixForParsing="0(4(?:[14]4|56)|[579])?"
                mobileNumberPortableRegion="true">
       <availableFormats>
-        <numberFormat pattern="(\d)(\d{7})" nationalPrefixFormattingRule="($FG)"
+        <numberFormat pattern="(\d{3})(\d{7})" nationalPrefixFormattingRule="($FG)"
                       carrierCodeFormattingRule="$NP$CC $FG">
-          <leadingDigits>
-            [146][2-9]|
-            [2578]
-          </leadingDigits>
-          <format>$1 $2</format>
-        </numberFormat>
-        <numberFormat pattern="(\d{3})(\d{7})" nationalPrefixFormattingRule="($FG)">
           <leadingDigits>6</leadingDigits>
           <format>$1 $2</format>
         </numberFormat>
         <numberFormat pattern="(\d{3})(\d{7})" carrierCodeFormattingRule="$NP$CC $FG">
-          <leadingDigits>[39]</leadingDigits>
+          <leadingDigits>
+            3[0-357]|
+            91
+          </leadingDigits>
           <format>$1 $2</format>
         </numberFormat>
         <numberFormat pattern="(\d)(\d{3})(\d{7})" nationalPrefixFormattingRule="$NP$FG">
@@ -7304,21 +7355,28 @@
       <generalDesc>
         <nationalNumberPattern>
           (?:
-            (?:
-              1\d|
-              [36]
-            )\d{3}|
+            60\d\d|
             9101
           )\d{6}|
-          [124-8]\d{7}
+          (?:
+            1\d|
+            3
+          )\d{9}
         </nationalNumberPattern>
       </generalDesc>
       <fixedLine>
-        <possibleLengths national="8,10" localOnly="7"/>
-        <exampleNumber>12345678</exampleNumber>
+        <possibleLengths national="10" localOnly="7"/>
+        <exampleNumber>6012345678</exampleNumber>
         <nationalNumberPattern>
-          60[124-8][2-9]\d{6}|
-          [124-8][2-9]\d{6}
+          601055(?:
+            [0-4]\d|
+            50
+          )\d\d|
+          6010(?:
+            [0-4]\d|
+            5[0-4]
+          )\d{4}|
+          60[124-8][2-9]\d{6}
         </nationalNumberPattern>
       </fixedLine>
       <!-- Added prefix 323 based on user report and online evidences. -->
@@ -7684,7 +7742,7 @@
     <!-- https://www.thenumberingsystem.com.au/#/number-register/search -->
     <territory id="CX" countryCode="61" preferredInternationalPrefix="0011"
                internationalPrefix="001[14-689]|14(?:1[14]|34|4[17]|[56]6|7[47]|88)0011"
-               nationalPrefix="0" nationalPrefixForParsing="0|([59]\d{7})$"
+               nationalPrefix="0" nationalPrefixForParsing="([59]\d{7})$|0"
                nationalPrefixTransformRule="8$1">
       <generalDesc>
         <nationalNumberPattern>
@@ -7756,15 +7814,16 @@
         <exampleNumber>412345678</exampleNumber>
         <nationalNumberPattern>
           4(?:
-            83[0-38]|
+            79[01]|
+            83[0-389]|
             93[0-6]
           )\d{5}|
           4(?:
             [0-3]\d|
             4[047-9]|
             5[0-25-9]|
-            6[06-9]|
-            7[02-9]|
+            6[016-9]|
+            7[02-8]|
             8[0-24-9]|
             9[0-27-9]
           )\d{6}
@@ -7843,7 +7902,12 @@
       <mobile>
         <possibleLengths national="8"/>
         <exampleNumber>96123456</exampleNumber>
-        <nationalNumberPattern>9[4-79]\d{6}</nationalNumberPattern>
+        <nationalNumberPattern>
+          9(?:
+            10|
+            [4-79]\d
+          )\d{5}
+        </nationalNumberPattern>
       </mobile>
       <tollFree>
         <possibleLengths national="8"/>
@@ -8260,8 +8324,7 @@
             9\d
           )\d{1,3}|
           49(?:
-            1\d|
-            2[02-9]|
+            2[024-9]|
             3[2-689]|
             7[1-7]
           )\d{1,8}|
@@ -8271,8 +8334,9 @@
             4[0-8]
           )\d{3,13}|
           49(?:
-            [05]\d|
-            [23]1|
+            [015]\d|
+            2[13]|
+            31|
             [46][1-8]
           )\d{1,9}
         </nationalNumberPattern>
@@ -8282,7 +8346,7 @@
            subscriber numbers. However, a contact of the German numbering authority
            confirmed that subscriber numbers can never be shorter than 2-digit and total
            length can not be less than 6 digits. Prefix 4921 of length 13-digit is added
-           based on user report. -->
+           based on user report. Prefix 322 of length 9-digits is added based on user report. -->
       <!-- Maximum lengths of German numbers are generally undefined, since any subscriber
            number can connect to a private exchange (PABX), which can consume additionally
            dialled digits (e.g. for calling individual rooms in a hotel directly). This means that in
@@ -8295,7 +8359,8 @@
         <exampleNumber>30123456</exampleNumber>
         <nationalNumberPattern>
           32\d{9,11}|
-          49[2-6]\d{10}|
+          49[1-6]\d{10}|
+          322\d{6}|
           49[0-7]\d{3,9}|
           (?:
             [34]0|
@@ -8570,7 +8635,7 @@
     <!-- Calling code and formatting shared with 'US' -->
     <!-- http://www.itu.int/oth/T020200003B/en -->
     <territory id="DM" countryCode="1" leadingDigits="767" internationalPrefix="011"
-               nationalPrefix="1" nationalPrefixForParsing="1|([2-7]\d{6})$"
+               nationalPrefix="1" nationalPrefixForParsing="([2-7]\d{6})$|1"
                nationalPrefixTransformRule="767$1" mobileNumberPortableRegion="true">
       <generalDesc>
         <nationalNumberPattern>
@@ -8668,7 +8733,7 @@
           52[34][2-9]1[02-9]\d{4}|
           5(?:
             00|
-            2[125-7]|
+            2[125-9]|
             33|
             44|
             66|
@@ -8814,7 +8879,7 @@
           52[34][2-9]1[02-9]\d{4}|
           5(?:
             00|
-            2[125-7]|
+            2[125-9]|
             33|
             44|
             66|
@@ -9093,7 +9158,7 @@
                     1\d
                   )|
                   (?:
-                    23|
+                    2[0-59]|
                     [3-79]\d
                   )\d
                 )\d
@@ -9269,7 +9334,9 @@
             )|
             7(?:
               [017]\d|
-              6[0-367]
+              2[0-2]|
+              6[0-8]|
+              8[0-3]
             )
           )\d{6}
         </nationalNumberPattern>
@@ -9460,7 +9527,7 @@
     <territory id="ET" countryCode="251" internationalPrefix="00" nationalPrefix="0">
       <availableFormats>
         <numberFormat pattern="(\d{2})(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>[1-59]</leadingDigits>
+          <leadingDigits>[1-579]</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
       </availableFormats>
@@ -9468,7 +9535,7 @@
         <nationalNumberPattern>
           (?:
             11|
-            [2-59]\d
+            [2-579]\d
           )\d{7}
         </nationalNumberPattern>
       </generalDesc>
@@ -9514,11 +9581,11 @@
                 5[0-4]
               )|
               6(?:
-                1[78]|
+                1[578]|
                 2[69]|
                 39|
                 4[5-7]|
-                5[1-5]|
+                5[0-5]|
                 6[0-59]|
                 8[015-8]
               )
@@ -9607,7 +9674,19 @@
       <mobile>
         <possibleLengths national="9"/>
         <exampleNumber>911234567</exampleNumber>
-        <nationalNumberPattern>9\d{8}</nationalNumberPattern>
+        <nationalNumberPattern>
+          7001\d{5}|
+          (?:
+            7(?:
+              0[1-9]|
+              1[01]|
+              77|
+              86|
+              99
+            )|
+            9\d\d
+          )\d{6}
+        </nationalNumberPattern>
       </mobile>
     </territory>
 
@@ -9962,7 +10041,7 @@
           (?:
             [27][1-9]|
             5\d|
-            91
+            9[16]
           )\d{4}
         </nationalNumberPattern>
       </mobile>
@@ -10054,10 +10133,7 @@
               3[0-8]|
               9[589]
             )|
-            7(?:
-              00|
-              [3-9]\d
-            )
+            7[3-9]\d
           )\d{6}
         </nationalNumberPattern>
       </mobile>
@@ -10341,16 +10417,18 @@
                 4(?:
                   [0-5]\d\d|
                   69[7-9]|
-                  70[01359]
+                  70[0-579]
                 )|
                 (?:
-                  5[0-26-9]|
-                  [78][0-49]
-                )\d\d|
-                6(?:
-                  [0-4]\d\d|
-                  50[0-79]
-                )
+                  (?:
+                    5[0-26-9]|
+                    [78][0-49]
+                  )\d|
+                  6(?:
+                    [0-4]\d|
+                    50
+                  )
+                )\d
               )|
               2(?:
                 (?:
@@ -10367,7 +10445,7 @@
                   [0-7]\d\d|
                   8(?:
                     [02]\d|
-                    1[0-27-9]
+                    1[0-246-9]
                   )
                 )
               )|
@@ -10641,7 +10719,7 @@
             652
           )\d{5}|
           76(?:
-            0[0-2]|
+            0[0-28]|
             2[356]|
             34|
             4[01347]|
@@ -10715,7 +10793,7 @@
     <!-- Calling code and formatting shared with 'US' -->
     <!-- http://www.itu.int/oth/T0202000057/en -->
     <territory id="GD" countryCode="1" leadingDigits="473" internationalPrefix="011"
-               nationalPrefix="1" nationalPrefixForParsing="1|([2-9]\d{6})$"
+               nationalPrefix="1" nationalPrefixForParsing="([2-9]\d{6})$|1"
                nationalPrefixTransformRule="473$1" mobileNumberPortableRegion="true">
       <generalDesc>
         <nationalNumberPattern>
@@ -10830,7 +10908,7 @@
           52[34][2-9]1[02-9]\d{4}|
           5(?:
             00|
-            2[125-7]|
+            2[125-9]|
             33|
             44|
             66|
@@ -10911,26 +10989,34 @@
         <nationalNumberPattern>
           5(?:
             (?:
-              0555|
-              1177
-            )[5-9]|
-            757(?:
-              7[7-9]|
-              8[01]
-            )
-          )\d{3}|
+              (?:
+                0555|
+                1(?:
+                  [17]77|
+                  555
+                )
+              )[5-9]|
+              757(?:
+                7[7-9]|
+                8[01]
+              )
+            )\d|
+            22252[0-4]
+          )\d\d|
           5(?:
             00(?:
               0\d|
-              50
+              5[05]
             )|
             11(?:
               00|
-              1\d|
-              2[0-4]|
+              [124]\d|
               3[01]
             )|
-            5200|
+            (?:
+              520|
+              909
+            )0|
             75(?:
               00|
               [57]5
@@ -10947,15 +11033,6 @@
               )
             )
           )\d{4}|
-          5(?:
-            0070|
-            11(?:
-              33|
-              51
-            )|
-            [25]222|
-            3333
-          )[0-4]\d{3}|
           (?:
             5(?:
               [14]4|
@@ -10965,7 +11042,34 @@
               9[1-35-9]
             )|
             790
-          )\d{6}
+          )\d{6}|
+          5(?:
+            0(?:
+              070|
+              505
+            )|
+            1(?:
+              0[01]0|
+              1(?:
+                07|
+                33|
+                51
+              )
+            )|
+            2(?:
+              0[02]0|
+              2[25]2
+            )|
+            3(?:
+              0[03]0|
+              3[35]3
+            )|
+            (?:
+              40[04]|
+              900
+            )0|
+            5222
+          )[0-4]\d{3}
         </nationalNumberPattern>
       </mobile>
       <!-- Information from http://www.yell.ge, examples such as Wissol Petroleum Georgia
@@ -11018,13 +11122,12 @@
         <exampleNumber>594101234</exampleNumber>
         <nationalNumberPattern>
           594(?:
-            [023]\d|
-            1[01]|
+            [0239]\d|
+            1[0-2]|
             4[03-9]|
             5[6-9]|
             6[0-3]|
-            80|
-            9[0-8]
+            80
           )\d{4}
         </nationalNumberPattern>
       </fixedLine>
@@ -11036,7 +11139,7 @@
         <nationalNumberPattern>
           694(?:
             [0-249]\d|
-            3[0-48]
+            3[0-8]
           )\d{4}
         </nationalNumberPattern>
       </mobile>
@@ -11061,7 +11164,7 @@
     <!-- http://static.ofcom.org.uk/static/numbering/ -->
     <!-- http://en.wikipedia.org/wiki/Telephone_numbers_in_the_United_Kingdom -->
     <territory id="GG" countryCode="44" internationalPrefix="00" nationalPrefix="0"
-               nationalPrefixForParsing="0|([25-9]\d{5})$" nationalPrefixTransformRule="1481$1">
+               nationalPrefixForParsing="([25-9]\d{5})$|0" nationalPrefixTransformRule="1481$1">
       <generalDesc>
         <nationalNumberPattern>
           (?:
@@ -11103,7 +11206,7 @@
             652
           )\d{5}|
           76(?:
-            0[0-2]|
+            0[0-28]|
             2[356]|
             34|
             4[01347]|
@@ -11253,12 +11356,11 @@
         <nationalNumberPattern>
           (?:
             2(?:
-              [0346-8]\d|
+              [0346-9]\d|
               5[67]
             )|
             5(?:
-              [0457]\d|
-              6[01]|
+              [03-7]\d|
               9[1-9]
             )
           )\d{6}
@@ -11295,20 +11397,25 @@
         <possibleLengths national="8"/>
         <exampleNumber>20012345</exampleNumber>
         <nationalNumberPattern>
-          21(?:
-            6[24-7]\d|
-            90[0-2]
-          )\d{3}|
+          2190[0-2]\d{3}|
           2(?:
-            00|
-            2[25]
-          )\d{5}
+            0(?:
+              0\d|
+              20
+            )|
+            16[24-9]|
+            2[2-5]\d
+          )\d{4}
         </nationalNumberPattern>
       </fixedLine>
       <mobile>
         <possibleLengths national="8"/>
         <exampleNumber>57123456</exampleNumber>
         <nationalNumberPattern>
+          525(?:
+            0\d|
+            1[0-4]
+          )\d{3}|
           (?:
             5[146-8]\d|
             606
@@ -11524,7 +11631,7 @@
             2[0-68]|
             3[1289]|
             5[3-579]|
-            6[0189]|
+            6[0-489]|
             7[08]|
             8[0-689]|
             9\d
@@ -11830,7 +11937,7 @@
     <!-- Calling code and formatting shared with 'US' -->
     <!-- http://www.nationalnanpa.com/nas/public/assigned_code_query_step1.do?method=resetCodeQueryModel -->
     <territory id="GU" countryCode="1" leadingDigits="671" internationalPrefix="011"
-               nationalPrefix="1" nationalPrefixForParsing="1|([3-9]\d{6})$"
+               nationalPrefix="1" nationalPrefixForParsing="([3-9]\d{6})$|1"
                nationalPrefixTransformRule="671$1">
       <generalDesc>
         <nationalNumberPattern>
@@ -11859,7 +11966,7 @@
               00|
               56|
               7[1-9]|
-              8[0236-9]
+              8[02-46-9]
             )|
             5(?:
               55|
@@ -11910,7 +12017,7 @@
               00|
               56|
               7[1-9]|
-              8[0236-9]
+              8[02-46-9]
             )|
             5(?:
               55|
@@ -11998,7 +12105,7 @@
           52[34][2-9]1[02-9]\d{4}|
           5(?:
             00|
-            2[125-7]|
+            2[125-9]|
             33|
             44|
             66|
@@ -12103,7 +12210,7 @@
         <nationalNumberPattern>
           (?:
             6\d\d|
-            70[015-7]
+            70[0-35-7]
           )\d{4}
         </nationalNumberPattern>
       </mobile>
@@ -12180,8 +12287,8 @@
                 7[0-24-69]
               )\d|
               8(?:
-                4[0-8]|
-                5[0-5]|
+                [45][0-8]|
+                6[01]|
                 9\d
               )
             )|
@@ -12200,12 +12307,15 @@
         <exampleNumber>51234567</exampleNumber>
         <nationalNumberPattern>
           (?:
-            46(?:
-              0[0-7]|
-              1[0-6]|
-              4[0-57-9]|
-              6[0-4]|
-              7[0-8]
+            4(?:
+              44[5-9]|
+              6(?:
+                0[0-7]|
+                1[0-6]|
+                4[0-57-9]|
+                6[0-4]|
+                7[0-8]
+              )
             )|
             573[0-6]|
             6(?:
@@ -12217,17 +12327,20 @@
               8[0-4]
             )|
             848[015-9]|
-            929[013-9]
+            9(?:
+              29[013-9]|
+              59[0-4]
+            )
           )\d{4}|
           (?:
             4(?:
-              40|
+              4[01]|
               6[2358]
             )|
             5(?:
               [1-59][0-46-9]|
               6[0-4689]|
-              7[0-24679]
+              7[0-246-9]
             )|
             6(?:
               0[1-9]|
@@ -12380,10 +12493,10 @@
         <nationalNumberPattern>
           2(?:
             2(?:
-              0[0-39]|
-              1[1-367]|
+              0[0-59]|
+              1[1-9]|
               [23]\d|
-              4[03-6]|
+              4[02-6]|
               5[57]|
               6[245]|
               7[0135689]|
@@ -12391,18 +12504,18 @@
               9[0-2]
             )|
             4(?:
-              0[78]|
+              0[578]|
               2[3-59]|
               3[13-9]|
               4[0-68]|
-              5[1-35]
+              5[1-3589]
             )|
             5(?:
-              0[7-9]|
-              16|
+              0[2357-9]|
+              1[1-356]|
               4[03-5]|
               5\d|
-              6[014-6]|
+              6[014-69]|
               7[04]|
               80
             )|
@@ -12410,12 +12523,13 @@
               [056]\d|
               17|
               2[067]|
-              3[04]|
+              3[047]|
               4[0-378]|
               [78][0-8]|
               9[01]
             )|
             7(?:
+              0[5-79]|
               6[46-9]|
               7[02-9]|
               8[034]|
@@ -12513,7 +12627,8 @@
           98\d{6,7}|
           975(?:
             1\d|
-            96
+            77|
+            9[67]
           )\d{4}|
           9(?:
             0[1-9]|
@@ -12558,12 +12673,17 @@
     <territory id="HT" countryCode="509" internationalPrefix="00">
       <availableFormats>
         <numberFormat pattern="(\d{2})(\d{2})(\d{4})">
-          <leadingDigits>[2-489]</leadingDigits>
+          <leadingDigits>[2-589]</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
       </availableFormats>
       <generalDesc>
-        <nationalNumberPattern>[2-489]\d{7}</nationalNumberPattern>
+        <nationalNumberPattern>
+          (?:
+            [2-489]\d|
+            55
+          )\d{6}
+        </nationalNumberPattern>
       </generalDesc>
       <!-- Digicel reported 281 and 29[149] belong to them, the more recent ITU doc 20.I.2017
            agrees and classifies them as fixedLine so we follow that here. -->
@@ -12584,7 +12704,12 @@
       <mobile>
         <possibleLengths national="8"/>
         <exampleNumber>34101234</exampleNumber>
-        <nationalNumberPattern>[34]\d{7}</nationalNumberPattern>
+        <nationalNumberPattern>
+          (?:
+            [34]\d|
+            55
+          )\d{6}
+        </nationalNumberPattern>
       </mobile>
       <!-- ITU document says numbers with prefix 8 are "value-added services and free numbers
            without making any further distinction. However, http://www.numberingplans.com/ seems
@@ -13315,7 +13440,7 @@
     <!-- http://en.wikipedia.org/wiki/Telephone_numbers_in_the_United_Kingdom -->
     <territory id="IM" countryCode="44" leadingDigits="74576|(?:16|7[56])24"
                internationalPrefix="00" nationalPrefix="0"
-               nationalPrefixForParsing="0|([25-8]\d{5})$" nationalPrefixTransformRule="1624$1">
+               nationalPrefixForParsing="([25-8]\d{5})$|0" nationalPrefixTransformRule="1624$1">
       <generalDesc>
         <nationalNumberPattern>
           1624\d{6}|
@@ -14738,7 +14863,7 @@
                 88
               )|
               9(?:
-                0[013]|
+                0[0-3]|
                 [19]\d|
                 21|
                 77|
@@ -15002,7 +15127,7 @@
               44|
               [679]
             )|
-            [38]
+            [378]
           </leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
@@ -15034,7 +15159,10 @@
             [0-8]\d{7,10}|
             9\d{7,8}
           )|
-          55\d{8}|
+          (?:
+            55|
+            70
+          )\d{8}|
           8\d{5}(?:
             \d{2,4}
           )?
@@ -15210,7 +15338,7 @@
     <!-- http://en.wikipedia.org/wiki/Telephone_numbers_in_the_United_Kingdom -->
     <!-- http://www.jcra.je/cms3/v2/public/cmsChild.asp?pageID=1024&childID=1036 -->
     <territory id="JE" countryCode="44" internationalPrefix="00" nationalPrefix="0"
-               nationalPrefixForParsing="0|([0-24-8]\d{5})$" nationalPrefixTransformRule="1534$1">
+               nationalPrefixForParsing="([0-24-8]\d{5})$|0" nationalPrefixTransformRule="1534$1">
       <generalDesc>
         <nationalNumberPattern>
           1534\d{6}|
@@ -15256,7 +15384,7 @@
             652
           )\d{5}|
           76(?:
-            0[0-2]|
+            0[0-28]|
             2[356]|
             34|
             4[01347]|
@@ -15406,12 +15534,12 @@
               52[35]|
               6(?:
                 0[1-3579]|
-                1[02357-9]|
+                1[0235-9]|
                 [23]\d|
                 40|
                 5[06]|
                 6[2-589]|
-                7[0257]|
+                7[025-9]|
                 8[04]|
                 9[4-9]
               )|
@@ -15525,7 +15653,7 @@
           52[34][2-9]1[02-9]\d{4}|
           5(?:
             00|
-            2[125-7]|
+            2[125-9]|
             33|
             44|
             66|
@@ -16649,7 +16777,8 @@
             1(?:
               0[0-6]|
               1[0-5]|
-              2[014]
+              2[014]|
+              30
             )|
             7\d\d
           )\d{6}
@@ -16784,11 +16913,12 @@
               2\d
             )|
             5[0-24-7]\d|
+            600|
             7(?:
               [07]\d|
               55
             )|
-            880|
+            88[08]|
             99[05-9]
           )\d{6}
         </nationalNumberPattern>
@@ -17045,7 +17175,7 @@
     <!-- Calling code and formatting shared with 'US' -->
     <!-- http://www.itu.int/oth/T02020000B0/en -->
     <territory id="KN" countryCode="1" leadingDigits="869" internationalPrefix="011"
-               nationalPrefix="1" nationalPrefixForParsing="1|([2-7]\d{6})$"
+               nationalPrefix="1" nationalPrefixForParsing="([2-7]\d{6})$|1"
                nationalPrefixTransformRule="869$1" mobileNumberPortableRegion="true">
       <generalDesc>
         <nationalNumberPattern>
@@ -17143,7 +17273,7 @@
           52[34][2-9]1[02-9]\d{4}|
           5(?:
             00|
-            2[125-7]|
+            2[125-9]|
             33|
             44|
             66|
@@ -17545,9 +17675,13 @@
                 5[015-9]|
                 6\d
               )\d|
-              111|
+              1(?:
+                00|
+                11|
+                66
+              )|
               222|
-              333|
+              3[36]3|
               444|
               7(?:
                 0[013-9]|
@@ -17595,7 +17729,7 @@
     <!-- Calling code and formatting shared with 'US' -->
     <!-- http://www.itu.int/oth/T0202000027/en -->
     <territory id="KY" countryCode="1" leadingDigits="345" internationalPrefix="011"
-               nationalPrefix="1" nationalPrefixForParsing="1|([2-9]\d{6})$"
+               nationalPrefix="1" nationalPrefixForParsing="([2-9]\d{6})$|1"
                nationalPrefixTransformRule="345$1" mobileNumberPortableRegion="true">
       <generalDesc>
         <nationalNumberPattern>
@@ -17738,7 +17872,7 @@
           52[34][2-9]1[02-9]\d{4}|
           5(?:
             00|
-            2[125-7]|
+            2[125-9]|
             33|
             44|
             66|
@@ -17803,7 +17937,8 @@
                 4(?:
                   [24]\d|
                   3[013-9]|
-                  5[1-9]
+                  5[1-9]|
+                  97
                 )|
                 5(?:
                   2\d|
@@ -17820,7 +17955,8 @@
                 8(?:
                   [27]\d|
                   3[1-46-9]|
-                  4[0-5]
+                  4[0-5]|
+                  59
                 )
               )|
               2(?:
@@ -17846,7 +17982,7 @@
                 )|
                 5(?:
                   [23]\d|
-                  4[0-246-8]|
+                  4[0-8]|
                   59|
                   61
                 )|
@@ -17974,8 +18110,7 @@
         <nationalNumberPattern>
           (?:
             20(?:
-              [239]\d|
-              5[24-9]|
+              [2359]\d|
               7[6-8]|
               88
             )|
@@ -18082,7 +18217,7 @@
     <!-- Calling code and formatting shared with 'US' -->
     <!-- http://www.itu.int/oth/T02020000B1/en -->
     <territory id="LC" countryCode="1" leadingDigits="758" internationalPrefix="011"
-               nationalPrefix="1" nationalPrefixForParsing="1|([2-8]\d{6})$"
+               nationalPrefix="1" nationalPrefixForParsing="([2-8]\d{6})$|1"
                nationalPrefixTransformRule="758$1" mobileNumberPortableRegion="true">
       <generalDesc>
         <nationalNumberPattern>
@@ -18193,7 +18328,7 @@
           52[34][2-9]1[02-9]\d{4}|
           5(?:
             00|
-            2[125-7]|
+            2[125-9]|
             33|
             44|
             66|
@@ -18210,7 +18345,7 @@
     <!-- http://www.llv.li/#/11193 -->
     <!-- https://www.itu.int/oth/T020200007B/en -->
     <territory id="LI" countryCode="423" internationalPrefix="00" nationalPrefix="0"
-               nationalPrefixForParsing="0|(1001)">
+               nationalPrefixForParsing="(1001)|0">
       <availableFormats>
         <!-- Number format for national mobile services, fixed-line, toll-free, UAN and premium rate services.
              Some different patterns for tollfree and shared cost numbers may be found by searching
@@ -18441,20 +18576,22 @@
           <format>$1 $2 $3</format>
         </numberFormat>
         <numberFormat pattern="(\d{2})(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>[3578]</leadingDigits>
+          <leadingDigits>[23578]</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
           (?:
-            2|
+            [25]\d|
             33|
-            5\d|
             77|
             88
           )\d{7}|
-          [4-6]\d{6}
+          (?:
+            2\d|
+            [4-6]
+          )\d{6}
         </nationalNumberPattern>
       </generalDesc>
       <fixedLine>
@@ -18474,7 +18611,10 @@
         <nationalNumberPattern>
           (?:
             (?:
-              330|
+              (?:
+                22|
+                33
+              )0|
               555|
               (?:
                 77|
@@ -18853,7 +18993,21 @@
       <mobile>
         <possibleLengths national="8"/>
         <exampleNumber>21234567</exampleNumber>
-        <nationalNumberPattern>2\d{7}</nationalNumberPattern>
+        <nationalNumberPattern>
+          23(?:
+            23[0-57-9]|
+            33[0238]
+          )\d{3}|
+          2(?:
+            [0-24-9]\d\d|
+            3(?:
+              0[07]|
+              [14-9]\d|
+              2[024-9]|
+              3[0-24-9]
+            )
+          )\d{4}
+        </nationalNumberPattern>
       </mobile>
       <tollFree>
         <possibleLengths national="8"/>
@@ -18960,15 +19114,20 @@
           </leadingDigits>
           <leadingDigits>
             5(?:
-              29[89]|
+              29[1289]|
               389
             )
           </leadingDigits>
           <leadingDigits>
+            529(?:
+              1[1-46-9]|
+              2[013-8]|
+              90
+            )|
             5(?:
-              29[89]|
+              298|
               389
-            )0
+            )[0-46-9]
           </leadingDigits>
           <format>$1-$2</format>
         </numberFormat>
@@ -19016,27 +19175,20 @@
         <possibleLengths national="9"/>
         <exampleNumber>520123456</exampleNumber>
         <nationalNumberPattern>
-          5(?:
-            29(?:
-              [189][05]|
-              2[29]|
-              3[01]
-            )|
-            389[05]
-          )\d{4}|
+          5293[01]\d{4}|
           5(?:
             2(?:
               [0-25-7]\d|
               3[1-578]|
               4[02-46-8]|
               8[0235-7]|
-              90
+              9[0-289]
             )|
             3(?:
               [0-47]\d|
               5[02-9]|
               6[02-8]|
-              8[08]|
+              8[0189]|
               9[3-9]
             )|
             (?:
@@ -19058,7 +19210,9 @@
             )|
             7(?:
               [017]\d|
-              6[0-367]
+              2[0-2]|
+              6[0-8]|
+              8[0-3]
             )
           )\d{6}
         </nationalNumberPattern>
@@ -19431,7 +19585,7 @@
     <!-- Madagascar (MG) -->
     <!-- http://www.itu.int/oth/T020200007F/en -->
     <territory id="MG" countryCode="261" internationalPrefix="00" nationalPrefix="0"
-               nationalPrefixForParsing="0|([24-9]\d{6})$" nationalPrefixTransformRule="20$1">
+               nationalPrefixForParsing="([24-9]\d{6})$|0" nationalPrefixTransformRule="20$1">
       <availableFormats>
         <numberFormat pattern="(\d{2})(\d{2})(\d{3})(\d{2})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>[23]</leadingDigits>
@@ -19465,7 +19619,7 @@
       <mobile>
         <possibleLengths national="9"/>
         <exampleNumber>321234567</exampleNumber>
-        <nationalNumberPattern>3[2-489]\d{7}</nationalNumberPattern>
+        <nationalNumberPattern>3[2-47-9]\d{7}</nationalNumberPattern>
       </mobile>
       <!-- Putting VSAT numbers here. -->
       <voip>
@@ -19514,7 +19668,7 @@
               54
             )5|
             329|
-            45[56]
+            45[356]
           )\d{4}
         </nationalNumberPattern>
       </mobile>
@@ -19581,7 +19735,7 @@
           )700\d{3}|
           (?:
             2(?:
-              [23]\d|
+              [0-3]\d|
               5[0-578]|
               6[01]|
               82
@@ -19611,21 +19765,28 @@
         <nationalNumberPattern>
           7(?:
             3555|
-            4(?:
-              60\d|
-              747
-            )|
-            94(?:
-              [01]\d|
-              2[0-4]
-            )
+            (?:
+              474|
+              9[019]7
+            )7
           )\d{3}|
           7(?:
-            [0-25-8]\d|
-            3[1-4]|
-            42|
-            9[23]
-          )\d{5}
+            [0-25-8]\d\d|
+            3(?:
+              [1-48]\d|
+              7[01578]
+            )|
+            4(?:
+              2\d|
+              60|
+              7[01578]
+            )|
+            9(?:
+              [2-4]\d|
+              5[01]|
+              7[015]
+            )
+          )\d{4}
         </nationalNumberPattern>
       </mobile>
       <tollFree>
@@ -19636,7 +19797,7 @@
       <premiumRate>
         <possibleLengths national="8"/>
         <exampleNumber>50012345</exampleNumber>
-        <nationalNumberPattern>5[02-9]\d{6}</nationalNumberPattern>
+        <nationalNumberPattern>5\d{7}</nationalNumberPattern>
       </premiumRate>
       <sharedCost>
         <possibleLengths national="8"/>
@@ -19724,7 +19885,7 @@
           (?:
             5[01]|
             [679]\d|
-            8[239]
+            8[2-49]
           )\d{6}
         </nationalNumberPattern>
       </mobile>
@@ -20067,13 +20228,16 @@
                 )|
                 (?:
                   6\d|
-                  8[89]|
                   9[4-8]
                 )\d|
                 7(?:
                   3|
                   40|
                   [5-9]\d
+                )|
+                8(?:
+                  78|
+                  [89]\d
                 )
               )\d|
               4(?:
@@ -20128,7 +20292,7 @@
         <!-- Format for 5X wireless local loop numbers (that are supported in fixed-line)
              which do not need national prefix as per online results. -->
         <numberFormat pattern="(\d{4})(\d{4})">
-          <leadingDigits>[57-9]</leadingDigits>
+          <leadingDigits>[5-9]</leadingDigits>
           <format>$1 $2</format>
         </numberFormat>
         <!-- For fixed-line two digit area code numbers. -->
@@ -20165,7 +20329,7 @@
       <generalDesc>
         <nationalNumberPattern>
           [12]\d{7,9}|
-          [57-9]\d{7}
+          [5-9]\d{7}
         </nationalNumberPattern>
       </generalDesc>
       <!-- Note the leading digit is the access code: 1 is used by Mongolia Telecom subscribers
@@ -20207,7 +20371,8 @@
           )\d{5}|
           (?:
             5[05]|
-            8[05689]|
+            6[069]|
+            8[015689]|
             9[013-9]
           )\d{6}
         </nationalNumberPattern>
@@ -20222,7 +20387,7 @@
           712[0-79]\d{4}|
           7(?:
             1[013-9]|
-            [25-8]\d
+            [25-9]\d
           )\d{5}
         </nationalNumberPattern>
       </voip>
@@ -20299,7 +20464,7 @@
     <!-- http://www.itu.int/oth/T02020000EE/en -->
     <!-- http://www.cnmiphonebook.com/ -->
     <territory id="MP" countryCode="1" leadingDigits="670" internationalPrefix="011"
-               nationalPrefix="1" nationalPrefixForParsing="1|([2-9]\d{6})$"
+               nationalPrefix="1" nationalPrefixForParsing="([2-9]\d{6})$|1"
                nationalPrefixTransformRule="670$1">
       <generalDesc>
         <nationalNumberPattern>
@@ -20430,7 +20595,7 @@
           52[34][2-9]1[02-9]\d{4}|
           5(?:
             00|
-            2[125-7]|
+            2[125-9]|
             33|
             44|
             66|
@@ -20461,14 +20626,12 @@
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
+          596\d{6}|
           (?:
             69|
-            80
-          )\d{7}|
-          (?:
-            59|
-            97
-          )6\d{6}
+            80|
+            9\d
+          )\d{7}
         </nationalNumberPattern>
       </generalDesc>
       <fixedLine>
@@ -20476,10 +20639,9 @@
         <exampleNumber>596301234</exampleNumber>
         <nationalNumberPattern>
           596(?:
-            [04-7]\d|
+            [03-7]\d|
             10|
             2[7-9]|
-            3[014-9]|
             8[09]|
             9[4-9]
           )\d{4}
@@ -20511,9 +20673,15 @@
         <possibleLengths national="9"/>
         <exampleNumber>976612345</exampleNumber>
         <nationalNumberPattern>
-          976(?:
-            6\d|
-            7[0-367]
+          9(?:
+            (?:
+              39|
+              47
+            )7[01]|
+            76(?:
+              6\d|
+              7[0-367]
+            )
           )\d{4}
         </nationalNumberPattern>
       </voip>
@@ -20567,7 +20735,7 @@
     <!-- Calling code and formatting shared with 'US' -->
     <!-- http://www.itu.int/oth/T020200008F/en -->
     <territory id="MS" countryCode="1" leadingDigits="664" internationalPrefix="011"
-               nationalPrefix="1" nationalPrefixForParsing="1|([34]\d{6})$"
+               nationalPrefix="1" nationalPrefixForParsing="([34]\d{6})$|1"
                nationalPrefixTransformRule="664$1" mobileNumberPortableRegion="true">
       <generalDesc>
         <nationalNumberPattern>
@@ -20655,7 +20823,7 @@
           52[34][2-9]1[02-9]\d{4}|
           5(?:
             00|
-            2[125-7]|
+            2[125-9]|
             33|
             44|
             66|
@@ -20785,7 +20953,7 @@
           <format>$1 $2</format>
         </numberFormat>
         <numberFormat pattern="(\d{4})(\d{4})">
-          <leadingDigits>5</leadingDigits>
+          <leadingDigits>[57]</leadingDigits>
           <format>$1 $2</format>
         </numberFormat>
         <numberFormat pattern="(\d{5})(\d{5})">
@@ -20796,7 +20964,7 @@
       <generalDesc>
         <nationalNumberPattern>
           (?:
-            5|
+            [57]|
             8\d\d
           )\d{7}|
           [2-468]\d{6}
@@ -20840,12 +21008,18 @@
             )|
             87[15-8]
           )\d{4}|
-          5(?:
-            2[5-9]|
-            4[3-689]|
-            [57]\d|
-            8[0-689]|
-            9[0-8]
+          (?:
+            5(?:
+              2[5-9]|
+              4[3-689]|
+              [57]\d|
+              8[0-689]|
+              9[0-8]
+            )|
+            7(?:
+              01|
+              30
+            )
           )\d{5}
         </nationalNumberPattern>
       </mobile>
@@ -20882,10 +21056,7 @@
                internationalPrefix="0(?:0|19)">
       <availableFormats>
         <numberFormat pattern="(\d{3})(\d{4})">
-          <leadingDigits>
-            [3467]|
-            9[13-9]
-          </leadingDigits>
+          <leadingDigits>[34679]</leadingDigits>
           <format>$1-$2</format>
         </numberFormat>
         <!-- It's not clear whether 800 and 900 numbers have a leading zero; 900 numbers have been
@@ -20918,9 +21089,9 @@
               3[0-59]
             )|
             6(?:
-              [57][02468]|
+              [58][024689]|
               6[024-68]|
-              8[024689]
+              7[02468]
             )
           )\d{4}
         </nationalNumberPattern>
@@ -20931,11 +21102,10 @@
         <possibleLengths national="7"/>
         <exampleNumber>7712345</exampleNumber>
         <nationalNumberPattern>
-          46[46]\d{4}|
           (?:
-            7\d|
-            9[13-9]
-          )\d{5}
+            46[46]|
+            [79]\d\d
+          )\d{4}
         </nationalNumberPattern>
       </mobile>
       <tollFree>
@@ -20984,10 +21154,9 @@
       <generalDesc>
         <nationalNumberPattern>
           (?:
-            [129]\d|
+            [1289]\d|
             31|
-            77|
-            88
+            77
           )\d{7}|
           1\d{6}
         </nationalNumberPattern>
@@ -21013,8 +21182,7 @@
           (?:
             31|
             77|
-            88|
-            9[89]
+            [89][89]
           )\d{7}
         </nationalNumberPattern>
       </mobile>
@@ -21076,6 +21244,7 @@
         <nationalNumberPattern>
           1(?:
             (?:
+              [27]2|
               44|
               99
             )[1-9]|
@@ -21083,10 +21252,12 @@
           )\d{7}|
           (?:
             1(?:
-              [017]\d|
-              [235][1-9]|
+              [01]\d|
+              2[13-9]|
+              [35][1-9]|
               4[0-35-9]|
               6[0-46-9]|
+              7[013-9]|
               8[1-79]|
               9[1-8]
             )|
@@ -21100,11 +21271,11 @@
         <possibleLengths national="10" localOnly="7,8"/>
         <exampleNumber>2001234567</exampleNumber>
         <nationalNumberPattern>
-          6571\d{6}|
+          657[12]\d{6}|
           (?:
             2(?:
               0[01]|
-              2[1-9]|
+              2\d|
               3[1-35-8]|
               4[13-9]|
               7[1-689]|
@@ -21141,7 +21312,8 @@
               9[4-8]
             )|
             7(?:
-              [1-467][1-9]|
+              [13467][1-9]|
+              2\d|
               5[13-9]|
               8[1-69]|
               9[17]
@@ -21174,7 +21346,7 @@
         <possibleLengths national="10,11" localOnly="7,8"/>
         <exampleNumber>12221234567</exampleNumber>
         <nationalNumberPattern>
-          6571\d{6}|
+          657[12]\d{6}|
           (?:
             1(?:
               2(?:
@@ -21239,7 +21411,7 @@
               )
             )|
             2(?:
-              2[1-9]|
+              2\d|
               3[1-35-8]|
               4[13-9]|
               7[1-689]|
@@ -21276,7 +21448,8 @@
               9[4-8]
             )|
             7(?:
-              [1-467][1-9]|
+              [13467][1-9]|
+              2\d|
               5[13-9]|
               8[1-69]|
               9[17]
@@ -21346,7 +21519,20 @@
           <leadingDigits>
             1(?:
               [02469]|
-              [378][1-9]
+              [378][1-9]|
+              53
+            )|
+            8
+          </leadingDigits>
+          <leadingDigits>
+            1(?:
+              [02469]|
+              [37][1-9]|
+              53|
+              8(?:
+                [1-46-9]|
+                5[7-9]
+              )
             )|
             8
           </leadingDigits>
@@ -21359,7 +21545,12 @@
         </numberFormat>
         <!-- Variable cost (premium rate, toll free etc.) -->
         <numberFormat pattern="(\d)(\d{3})(\d{2})(\d{4})">
-          <leadingDigits>1[36-8]</leadingDigits>
+          <leadingDigits>
+            1(?:
+              [367]|
+              80
+            )
+          </leadingDigits>
           <format>$1-$2-$3-$4</format>
         </numberFormat>
         <!-- 10 digit mobile or voip ranges -->
@@ -21454,7 +21645,7 @@
         <exampleNumber>123456789</exampleNumber>
         <nationalNumberPattern>
           1(?:
-            1888[69]|
+            1888[689]|
             4400|
             8(?:
               47|
@@ -21481,18 +21672,22 @@
               )
             )|
             (?:
-              (?:
-                [269]|
-                59
-              )\d|
+              [269]\d|
               [37][1-9]|
               4[235-9]
             )\d|
+            5(?:
+              31|
+              9\d\d
+            )|
             8(?:
               1[23]|
               [236]\d|
               4[06]|
-              5[7-9]|
+              5(?:
+                46|
+                [7-9]
+              )|
               7[016-9]|
               8[01]|
               9[0-8]
@@ -22011,20 +22206,17 @@
         <nationalNumberPattern>
           (?:
             702[0-24-9]|
-            8(?:
-              01|
-              19
-            )[01]
+            819[01]
           )\d{6}|
           (?:
             70[13-689]|
             8(?:
-              0[2-9]|
+              0[1-9]|
               1[0-8]
             )|
             9(?:
               0[1-9]|
-              1[2356]
+              1[1-356]
             )
           )\d{7}
         </nationalNumberPattern>
@@ -22435,8 +22627,8 @@
             1[01]|
             [2-8]|
             9(?:
-              [1-579]|
-              6[2-6]
+              [1-59]|
+              [67][2-6]
             )
           </leadingDigits>
           <format>$1-$2</format>
@@ -22490,7 +22682,7 @@
         <nationalNumberPattern>
           9(?:
             6[0-3]|
-            7[24-6]|
+            7[024-6]|
             8[0-24-68]
           )\d{7}
         </nationalNumberPattern>
@@ -22615,7 +22807,7 @@
             7[2-57-9]|
             9[2-9]
           </leadingDigits>
-          <format>$1-$2 $3</format>
+          <format>$1 $2 $3</format>
         </numberFormat>
         <!-- 0274, 0210 and toll-free/premium-rate prefixes 0508/0800/0900. -->
         <numberFormat pattern="(\d{3})(\d{3})(\d{3,4})" nationalPrefixFormattingRule="$NP$FG">
@@ -22790,7 +22982,7 @@
           (?:
             7(?:
               [1289]\d|
-              7[0-4]
+              7[0-5]
             )|
             9(?:
               0[1-9]|
@@ -22874,7 +23066,7 @@
               5[05]|
               6[58]|
               7[0167]|
-              8[258]|
+              8[2358]|
               9[1389]
             )|
             2(?:
@@ -22995,8 +23187,9 @@
     <!-- http://www.itu.int/oth/T02020000A6/en -->
     <!-- http://en.wikipedia.org/wiki/+51 -->
     <!-- http://www.assistbook.com/South%20America/Peru/widecodes -->
-    <territory id="PE" countryCode="51" internationalPrefix="19(?:1[124]|77|90)00"
-               nationalPrefix="0" preferredExtnPrefix=" Anexo " mobileNumberPortableRegion="true">
+    <territory id="PE" countryCode="51" preferredInternationalPrefix="00"
+               internationalPrefix="00|19(?:1[124]|77|90)00" nationalPrefix="0"
+               preferredExtnPrefix=" Anexo " mobileNumberPortableRegion="true">
       <availableFormats>
         <numberFormat pattern="(\d{3})(\d{5})" nationalPrefixFormattingRule="($NP$FG)">
           <leadingDigits>80</leadingDigits>
@@ -23232,7 +23425,7 @@
         <exampleNumber>2751234</exampleNumber>
         <nationalNumberPattern>
           2(?:
-            0[0-47]|
+            0[0-57]|
             7[568]
           )\d{4}
         </nationalNumberPattern>
@@ -23725,6 +23918,7 @@
         <numberFormat pattern="(\d{3})(\d{3})">
           <leadingDigits>
             11|
+            20|
             64
           </leadingDigits>
           <format>$1 $2</format>
@@ -23799,13 +23993,14 @@
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
-          6\d{5}(?:
-            \d{2}
-          )?|
-          8\d{9}|
+          (?:
+            6|
+            8\d\d
+          )\d{7}|
           [1-9]\d{6}(?:
             \d{2}
-          )?
+          )?|
+          [26]\d{5}
         </nationalNumberPattern>
       </generalDesc>
       <!-- The plan says all geographical numbers are 9 digits; but we found customer service
@@ -24039,7 +24234,7 @@
           52[34][2-9]1[02-9]\d{4}|
           5(?:
             00|
-            2[125-7]|
+            2[125-9]|
             33|
             44|
             66|
@@ -24144,10 +24339,10 @@
         <nationalNumberPattern>
           2(?:
             [12]\d|
-            [35][1-689]|
+            3[1-689]|
             4[1-59]|
+            [57][1-9]|
             6[1-35689]|
-            7[1-9]|
             8[1-69]|
             9[1256]
           )\d{6}
@@ -24157,9 +24352,15 @@
         <possibleLengths national="9"/>
         <exampleNumber>912345678</exampleNumber>
         <nationalNumberPattern>
-          6[0356]92(?:
-            30|
-            9\d
+          6(?:
+            [06]92(?:
+              30|
+              9\d
+            )|
+            [35]92(?:
+              3[03]|
+              9\d
+            )
           )\d{3}|
           (?:
             (?:
@@ -24173,6 +24374,11 @@
           )\d{5}
         </nationalNumberPattern>
       </mobile>
+      <pager>
+        <possibleLengths national="9"/>
+        <exampleNumber>622212345</exampleNumber>
+        <nationalNumberPattern>6222\d{5}</nationalNumberPattern>
+      </pager>
       <tollFree>
         <possibleLengths national="9"/>
         <exampleNumber>800123456</exampleNumber>
@@ -24231,7 +24437,10 @@
       <voicemail>
         <possibleLengths national="9"/>
         <exampleNumber>600110000</exampleNumber>
-        <nationalNumberPattern>600\d{6}</nationalNumberPattern>
+        <nationalNumberPattern>
+          600\d{6}|
+          6[06]9233\d{3}
+        </nationalNumberPattern>
       </voicemail>
     </territory>
 
@@ -24485,65 +24694,71 @@
       <availableFormats>
         <numberFormat pattern="(\d{3})(\d{4})">
           <leadingDigits>
-            2[126]|
+            2[16]|
             8
           </leadingDigits>
           <format>$1 $2</format>
         </numberFormat>
         <numberFormat pattern="(\d{4})(\d{4})">
-          <leadingDigits>[2-7]</leadingDigits>
+          <leadingDigits>[3-7]</leadingDigits>
           <format>$1 $2</format>
         </numberFormat>
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
-          [2-7]\d{7}|
-          800\d{4}(?:
-            \d{2}
-          )?|
-          2\d{6}
+          800\d{4}|
+          (?:
+            2|
+            800
+          )\d{6}|
+          (?:
+            0080|
+            [3-7]
+          )\d{7}
         </nationalNumberPattern>
       </generalDesc>
-      <!-- The prefix 40 has now been allocated, based on numbers seen online. -->
+      <!-- The prefix 40 has now been allocated, based on numbers seen online.
+           Prefix 414[1-4] is added based on user report and online numbers. -->
       <fixedLine>
         <possibleLengths national="8"/>
         <exampleNumber>44123456</exampleNumber>
         <nationalNumberPattern>
-          4141\d{4}|
-          (?:
-            23|
-            4[04]
-          )\d{6}
+          4(?:
+            1111|
+            2022
+          )\d{3}|
+          4(?:
+            [04]\d\d|
+            14[0-6]|
+            999
+          )\d{4}
         </nationalNumberPattern>
       </fixedLine>
       <mobile>
         <possibleLengths national="8"/>
         <exampleNumber>33123456</exampleNumber>
-        <nationalNumberPattern>
-          (?:
-            2[89]|
-            [35-7]\d
-          )\d{6}
-        </nationalNumberPattern>
+        <nationalNumberPattern>[35-7]\d{7}</nationalNumberPattern>
       </mobile>
       <pager>
         <possibleLengths national="7"/>
         <exampleNumber>2123456</exampleNumber>
         <nationalNumberPattern>
           2(?:
-            [12]\d|
+            1\d|
             61
           )\d{4}
         </nationalNumberPattern>
       </pager>
       <!-- Prefix 800 with 9 digit length is added based on user report. -->
       <tollFree>
-        <possibleLengths national="7,9"/>
+        <possibleLengths national="7,9,11"/>
         <exampleNumber>8001234</exampleNumber>
         <nationalNumberPattern>
-          800\d{4}(?:
-            \d{2}
-          )?
+          800\d{4}|
+          (?:
+            0080[01]|
+            800
+          )\d{6}
         </nationalNumberPattern>
       </tollFree>
     </territory>
@@ -24552,8 +24767,8 @@
     <!-- Main region for 'YT' -->
     <!-- http://www.itu.int/oth/T020200004B/en -->
     <!-- http://www.arcep.fr/index.php?id=2137&bloc=0596&CMD=RESULTS_NUMEROTATION -->
-    <territory id="RE" mainCountryForCode="true" countryCode="262" leadingDigits="26[23]|69|[89]"
-               internationalPrefix="00" nationalPrefix="0">
+    <territory id="RE" mainCountryForCode="true" countryCode="262" internationalPrefix="00"
+               nationalPrefix="0">
       <availableFormats>
         <numberFormat pattern="(\d{3})(\d{2})(\d{2})(\d{2})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>[2689]</leadingDigits>
@@ -24562,10 +24777,9 @@
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
-          9769\d{5}|
           (?:
             26|
-            [68]\d
+            [689]\d
           )\d{7}
         </nationalNumberPattern>
       </generalDesc>
@@ -24576,7 +24790,10 @@
         <nationalNumberPattern>
           26(?:
             2\d\d|
-            30[0-5]
+            3(?:
+              0\d|
+              1[0-3]
+            )
           )\d{4}
         </nationalNumberPattern>
       </fixedLine>
@@ -24600,7 +24817,15 @@
                 9[0-479]
               )
             )|
-            9769\d
+            9(?:
+              399[0-2]|
+              4790|
+              76(?:
+                2[27]|
+                3[0-37]|
+                9\d
+              )
+            )
           )\d{4}
         </nationalNumberPattern>
       </mobile>
@@ -24704,7 +24929,7 @@
             1[0-3]|
             [2-7]\d|
             8[03-8]|
-            9[019]
+            9[0-29]
           )\d{6}
         </nationalNumberPattern>
       </mobile>
@@ -24862,7 +25087,8 @@
           <leadingDigits>
             7(?:
               1(?:
-                [0-6]2|
+                [0-356]2|
+                4[29]|
                 7|
                 8[27]
               )|
@@ -24875,7 +25101,8 @@
           <leadingDigits>
             7(?:
               1(?:
-                [0-6]2|
+                [0-356]2|
+                4[29]|
                 7|
                 8[27]
               )|
@@ -25703,7 +25930,7 @@
           <leadingDigits>
             [369]|
             8(?:
-              0[1-5]|
+              0[1-6]|
               [1-9]
             )
           </leadingDigits>
@@ -25746,18 +25973,18 @@
           )\d{5}
         </nationalNumberPattern>
       </fixedLine>
-      <!-- 802[23] and 804[1467] are added based on user report.  -->
+      <!-- 802[23] ,804[1467] and 8055 are added based on user report.  -->
       <mobile>
         <possibleLengths national="8"/>
         <exampleNumber>81234567</exampleNumber>
         <nationalNumberPattern>
           8(?:
-            051|
+            06[0-6]|
             95[0-2]
           )\d{4}|
           (?:
             8(?:
-              0[1-4]|
+              0[1-5]|
               [1-8]\d|
               9[0-4]
             )|
@@ -25907,9 +26134,9 @@
         <exampleNumber>31234567</exampleNumber>
         <nationalNumberPattern>
           65(?:
-            1\d|
-            55|
-            [67]0
+            [178]\d|
+            5[56]|
+            6[01]
           )\d{4}|
           (?:
             [37][01]|
@@ -26333,16 +26560,20 @@
         <possibleLengths national="9"/>
         <exampleNumber>701234567</exampleNumber>
         <nationalNumberPattern>
-          75(?:
-            01|
-            [38]3
-          )\d{5}|
           7(?:
-            [06-8]\d|
-            21|
-            5[4-7]|
-            90
-          )\d{6}
+            (?:
+              [06-8]\d|
+              21|
+              90
+            )\d|
+            5(?:
+              01|
+              [19]0|
+              25|
+              [38]3|
+              [4-7]\d
+            )
+          )\d{5}
         </nationalNumberPattern>
       </mobile>
       <tollFree>
@@ -26411,7 +26642,10 @@
         </numberFormat>
         <numberFormat pattern="(\d)(\d{7})">
           <leadingDigits>
-            24|
+            (?:
+              2|
+              90
+            )4|
             [67]
           </leadingDigits>
           <format>$1 $2</format>
@@ -26499,9 +26733,9 @@
             )
           )\d{5}|
           (?:
-            6\d|
-            7[1-9]
-          )\d{6}
+            [67]\d\d|
+            904
+          )\d{5}
         </nationalNumberPattern>
       </mobile>
     </territory>
@@ -26714,7 +26948,7 @@
     <!-- http://www.nanpa.com/pdf/PL_429.pdf -->
     <!-- http://www.itu.int/oth/T02020000F7/en -->
     <territory id="SX" countryCode="1" leadingDigits="721" internationalPrefix="011"
-               nationalPrefix="1" nationalPrefixForParsing="1|(5\d{6})$"
+               nationalPrefix="1" nationalPrefixForParsing="(5\d{6})$|1"
                nationalPrefixTransformRule="721$1" mobileNumberPortableRegion="true">
       <generalDesc>
         <nationalNumberPattern>
@@ -26804,7 +27038,7 @@
           52[34][2-9]1[02-9]\d{4}|
           5(?:
             00|
-            2[125-7]|
+            2[125-9]|
             33|
             44|
             66|
@@ -26939,7 +27173,7 @@
     <!-- Calling code and formatting shared with 'US' -->
     <!-- http://www.itu.int/oth/T02020000D8/en -->
     <territory id="TC" countryCode="1" leadingDigits="649" internationalPrefix="011"
-               nationalPrefix="1" nationalPrefixForParsing="1|([2-479]\d{6})$"
+               nationalPrefix="1" nationalPrefixForParsing="([2-479]\d{6})$|1"
                nationalPrefixTransformRule="649$1" mobileNumberPortableRegion="true">
       <generalDesc>
         <nationalNumberPattern>
@@ -27033,7 +27267,7 @@
           52[34][2-9]1[02-9]\d{4}|
           5(?:
             00|
-            2[125-7]|
+            2[125-9]|
             33|
             44|
             66|
@@ -27094,7 +27328,7 @@
         <exampleNumber>63012345</exampleNumber>
         <nationalNumberPattern>
           (?:
-            6[023568]|
+            6[0235689]|
             77|
             9\d
           )\d{6}
@@ -27134,7 +27368,7 @@
         <exampleNumber>90112345</exampleNumber>
         <nationalNumberPattern>
           (?:
-            7[09]|
+            7[019]|
             9[0-36-9]
           )\d{6}
         </nationalNumberPattern>
@@ -27302,10 +27536,11 @@
           41[18]\d{6}|
           (?:
             [034]0|
-            [17][017]|
+            1[017]|
             2[02]|
             5[05]|
-            8[08]|
+            7[0178]|
+            8[078]|
             9\d
           )\d{7}
         </nationalNumberPattern>
@@ -27634,7 +27869,7 @@
       </voip>
     </territory>
 
-    <!-- Turkey (TR) -->
+    <!-- Türkiye (TR) -->
     <!-- http://en.wikipedia.org/wiki/%2B90 -->
     <!-- http://www.itu.int/oth/T02020000D6/en -->
     <!-- https://eng.btk.gov.tr/en-US/Pages/National-Numbering-Plan -->
@@ -27827,7 +28062,7 @@
     <!-- Calling code and formatting shared with 'US' -->
     <!-- http://www.itu.int/oth/T02020000D4/en -->
     <territory id="TT" countryCode="1" leadingDigits="868" internationalPrefix="011"
-               nationalPrefix="1" nationalPrefixForParsing="1|([2-46-8]\d{6})$"
+               nationalPrefix="1" nationalPrefixForParsing="([2-46-8]\d{6})$|1"
                nationalPrefixTransformRule="868$1" mobileNumberPortableRegion="true">
       <generalDesc>
         <nationalNumberPattern>
@@ -27845,8 +28080,8 @@
         <nationalNumberPattern>
           868(?:
             2(?:
-              0[13]|
-              1[89]|
+              01|
+              1[5-9]|
               [23]\d|
               4[0-2]
             )|
@@ -27945,7 +28180,7 @@
           52[34][2-9]1[02-9]\d{4}|
           5(?:
             00|
-            2[125-7]|
+            2[125-9]|
             33|
             44|
             66|
@@ -28240,6 +28475,11 @@
           <leadingDigits>[24]</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
+        <!-- ITU format: +255 5X XXXXXXX -->
+        <numberFormat pattern="(\d{2})(\d{7})">
+          <leadingDigits>5</leadingDigits>
+          <format>$1 $2</format>
+        </numberFormat>
         <numberFormat pattern="(\d{3})(\d{3})(\d{3})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>[67]</leadingDigits>
           <format>$1 $2 $3</format>
@@ -28248,7 +28488,7 @@
       <generalDesc>
         <nationalNumberPattern>
           (?:
-            [26-8]\d|
+            [25-8]\d|
             41|
             90
           )\d{7}
@@ -28277,8 +28517,8 @@
         <nationalNumberPattern>
           77[2-9]\d{6}|
           (?:
-            6[1-9]|
-            7[1-689]
+            6[125-9]|
+            7[13-689]
           )\d{7}
         </nationalNumberPattern>
       </mobile>
@@ -28353,53 +28593,55 @@
           </leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
+        <!-- Fixed line (4-digit area code). -->
+        <numberFormat pattern="(\d{4})(\d{5})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>
+            3[1-8]|
+            4(?:
+              [1367]|
+              [45][6-9]|
+              8[4-6]
+            )|
+            5(?:
+              [1-5]|
+              6[0135689]|
+              7[4-6]
+            )|
+            6(?:
+              [12][3-7]|
+              [459]
+            )
+          </leadingDigits>
+          <leadingDigits>
+            3[1-8]|
+            4(?:
+              [1367]|
+              [45][6-9]|
+              8[4-6]
+            )|
+            5(?:
+              [1-5]|
+              6(?:
+                [015689]|
+                3[02389]
+              )|
+              7[4-6]
+            )|
+            6(?:
+              [12][3-7]|
+              [459]
+            )
+          </leadingDigits>
+          <format>$1 $2</format>
+        </numberFormat>
         <!-- General format (fixed line, mobile, voip etc.) -->
         <numberFormat pattern="(\d{2})(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>
-            4[45][0-5]|
-            5(?:
-              0|
-              6[37]
-            )|
-            6(?:
-              [12][018]|
-              [36-8]
-            )|
-            7|
+            [3-7]|
             89|
-            9[1-9]|
-            (?:
-              48|
-              57
-            )[0137-9]
-          </leadingDigits>
-          <leadingDigits>
-            4[45][0-5]|
-            5(?:
-              0|
-              6(?:
-                3[14-7]|
-                7
-              )
-            )|
-            6(?:
-              [12][018]|
-              [36-8]
-            )|
-            7|
-            89|
-            9[1-9]|
-            (?:
-              48|
-              57
-            )[0137-9]
+            9[1-9]
           </leadingDigits>
           <format>$1 $2 $3</format>
-        </numberFormat>
-        <!-- Fixed line (4-digit area code). -->
-        <numberFormat pattern="(\d{4})(\d{5})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>[3-6]</leadingDigits>
-          <format>$1 $2</format>
         </numberFormat>
         <!-- Premium Rate and Toll Free -->
         <numberFormat pattern="(\d{3})(\d{3})(\d{3,4})" nationalPrefixFormattingRule="$NP$FG">
@@ -28436,6 +28678,7 @@
         <exampleNumber>501234567</exampleNumber>
         <nationalNumberPattern>
           (?:
+            39|
             50|
             6[36-8]|
             7[1-3]|
@@ -28514,10 +28757,7 @@
         <nationalNumberPattern>
           20(?:
             (?:
-              (?:
-                24|
-                81
-              )0|
+              240|
               30[67]
             )\d|
             6(?:
@@ -28612,54 +28852,17 @@
         <possibleLengths national="10" localOnly="7"/>
         <exampleNumber>2015550123</exampleNumber>
         <nationalNumberPattern>
-          5(?:
-            05(?:
-              [2-57-9]\d\d|
-              6(?:
-                [0-35-9]\d|
-                44
-              )
-            )|
-            82(?:
-              2(?:
-                0[0-3]|
-                [268]2
+          (?:
+            47220[01]|
+            5(?:
+              05(?:
+                [2-57-9]\d\d|
+                6(?:
+                  [0-35-9]\d|
+                  4[46]
+                )
               )|
-              3(?:
-                0[02]|
-                22|
-                33
-              )|
-              4(?:
-                00|
-                4[24]|
-                65|
-                82
-              )|
-              5(?:
-                00|
-                29|
-                58|
-                83
-              )|
-              6(?:
-                00|
-                66|
-                82
-              )|
-              7(?:
-                58|
-                77
-              )|
-              8(?:
-                00|
-                42|
-                88
-              )|
-              9(?:
-                00|
-                9[89]
-              )
+              57200
             )
           )\d{4}|
           (?:
@@ -28680,7 +28883,7 @@
               2[01356]|
               3[0-24679]|
               4[167]|
-              5[12]|
+              5[0-2]|
               6[014]|
               8[056]
             )|
@@ -28704,7 +28907,7 @@
               5[19]|
               6[1-47]|
               7[0-5]|
-              8[056]
+              8[0256]
             )|
             6(?:
               0[1-35-9]|
@@ -28730,8 +28933,8 @@
             8(?:
               0[1-68]|
               1[02-8]|
-              2[08]|
-              3[0-289]|
+              2[068]|
+              3[0-2589]|
               4[03578]|
               5[046-9]|
               6[02-5]|
@@ -28742,7 +28945,7 @@
               1[02-9]|
               2[0589]|
               3[0146-8]|
-              4[0157-9]|
+              4[01357-9]|
               5[12469]|
               7[0-389]|
               8[04-69]
@@ -28754,54 +28957,17 @@
         <possibleLengths national="10" localOnly="7"/>
         <exampleNumber>2015550123</exampleNumber>
         <nationalNumberPattern>
-          5(?:
-            05(?:
-              [2-57-9]\d\d|
-              6(?:
-                [0-35-9]\d|
-                44
-              )
-            )|
-            82(?:
-              2(?:
-                0[0-3]|
-                [268]2
+          (?:
+            47220[01]|
+            5(?:
+              05(?:
+                [2-57-9]\d\d|
+                6(?:
+                  [0-35-9]\d|
+                  4[46]
+                )
               )|
-              3(?:
-                0[02]|
-                22|
-                33
-              )|
-              4(?:
-                00|
-                4[24]|
-                65|
-                82
-              )|
-              5(?:
-                00|
-                29|
-                58|
-                83
-              )|
-              6(?:
-                00|
-                66|
-                82
-              )|
-              7(?:
-                58|
-                77
-              )|
-              8(?:
-                00|
-                42|
-                88
-              )|
-              9(?:
-                00|
-                9[89]
-              )
+              57200
             )
           )\d{4}|
           (?:
@@ -28822,7 +28988,7 @@
               2[01356]|
               3[0-24679]|
               4[167]|
-              5[12]|
+              5[0-2]|
               6[014]|
               8[056]
             )|
@@ -28846,7 +29012,7 @@
               5[19]|
               6[1-47]|
               7[0-5]|
-              8[056]
+              8[0256]
             )|
             6(?:
               0[1-35-9]|
@@ -28872,8 +29038,8 @@
             8(?:
               0[1-68]|
               1[02-8]|
-              2[08]|
-              3[0-289]|
+              2[068]|
+              3[0-2589]|
               4[03578]|
               5[046-9]|
               6[02-5]|
@@ -28884,7 +29050,7 @@
               1[02-9]|
               2[0589]|
               3[0146-8]|
-              4[0157-9]|
+              4[01357-9]|
               5[12469]|
               7[0-389]|
               8[04-69]
@@ -28946,7 +29112,7 @@
           52[34][2-9]1[02-9]\d{4}|
           5(?:
             00|
-            2[125-7]|
+            2[125-9]|
             33|
             44|
             66|
@@ -28989,10 +29155,18 @@
           <leadingDigits>4</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
+        <!-- 13 digit toll free numbers -->
+        <numberFormat pattern="(\d{3})(\d{3})(\d{3})(\d{4})">
+          <leadingDigits>0</leadingDigits>
+          <format>$1 $2 $3 $4</format>
+        </numberFormat>
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
-          4\d{9}|
+          (?:
+            0004|
+            4
+          )\d{9}|
           [1249]\d{7}|
           (?:
             [49]\d|
@@ -29023,11 +29197,14 @@
         <nationalNumberPattern>9[1-9]\d{6}</nationalNumberPattern>
       </mobile>
       <tollFree>
-        <possibleLengths national="7,10"/>
+        <possibleLengths national="7,10,13"/>
         <exampleNumber>8001234</exampleNumber>
         <nationalNumberPattern>
           (?:
-            4\d{5}|
+            (?:
+              0004|
+              4
+            )\d{5}|
             80[05]
           )\d{4}|
           405\d{4}
@@ -29056,8 +29233,7 @@
         <nationalNumberPattern>
           (?:
             33|
-            55|
-            [679]\d|
+            [5-79]\d|
             88
           )\d{7}
         </nationalNumberPattern>
@@ -29069,6 +29245,7 @@
         <exampleNumber>669050123</exampleNumber>
         <nationalNumberPattern>
           (?:
+            55\d\d|
             6(?:
               1(?:
                 22|
@@ -29155,13 +29332,10 @@
           (?:
             (?:
               33|
+              50|
               88|
               9[0-57-9]
             )\d{3}|
-            55(?:
-              50[013]|
-              90\d
-            )|
             6(?:
               1(?:
                 2(?:
@@ -29538,7 +29712,7 @@
     <!-- Calling code and formatting shared with 'US' -->
     <!-- http://www.itu.int/oth/T02020000B3/en -->
     <territory id="VC" countryCode="1" leadingDigits="784" internationalPrefix="011"
-               nationalPrefix="1" nationalPrefixForParsing="1|([2-7]\d{6})$"
+               nationalPrefix="1" nationalPrefixForParsing="([2-7]\d{6})$|1"
                nationalPrefixTransformRule="784$1" mobileNumberPortableRegion="true">
       <generalDesc>
         <nationalNumberPattern>
@@ -29651,7 +29825,7 @@
           52[34][2-9]1[02-9]\d{4}|
           5(?:
             00|
-            2[125-7]|
+            2[125-9]|
             33|
             44|
             66|
@@ -29739,7 +29913,7 @@
     <!-- Calling code and formatting shared with 'US' -->
     <!-- http://www.itu.int/oth/T020200001E/en -->
     <territory id="VG" countryCode="1" leadingDigits="284" internationalPrefix="011"
-               nationalPrefix="1" nationalPrefixForParsing="1|([2-578]\d{6})$"
+               nationalPrefix="1" nationalPrefixForParsing="([2-578]\d{6})$|1"
                nationalPrefixTransformRule="284$1" mobileNumberPortableRegion="true">
       <generalDesc>
         <nationalNumberPattern>
@@ -29756,7 +29930,6 @@
         <possibleLengths national="10" localOnly="7"/>
         <exampleNumber>2842291234</exampleNumber>
         <nationalNumberPattern>
-          284496[0-5]\d{3}|
           284(?:
             229|
             4(?:
@@ -29777,7 +29950,6 @@
         <possibleLengths national="10" localOnly="7"/>
         <exampleNumber>2843001234</exampleNumber>
         <nationalNumberPattern>
-          284496[6-9]\d{3}|
           284(?:
             245|
             3(?:
@@ -29789,7 +29961,7 @@
             4(?:
               4[0-6]|
               68|
-              99
+              9[69]
             )|
             5(?:
               4[0-7]|
@@ -29853,7 +30025,7 @@
           52[34][2-9]1[02-9]\d{4}|
           5(?:
             00|
-            2[125-7]|
+            2[125-9]|
             33|
             44|
             66|
@@ -29868,7 +30040,7 @@
     <!-- Calling code and formatting shared with 'US' -->
     <!-- http://www.itu.int/oth/T02020000DF/en -->
     <territory id="VI" countryCode="1" leadingDigits="340" internationalPrefix="011"
-               nationalPrefix="1" nationalPrefixForParsing="1|([2-9]\d{6})$"
+               nationalPrefix="1" nationalPrefixForParsing="([2-9]\d{6})$|1"
                nationalPrefixTransformRule="340$1">
       <generalDesc>
         <nationalNumberPattern>
@@ -29888,7 +30060,7 @@
         <nationalNumberPattern>
           340(?:
             2(?:
-              0[0-38]|
+              0[0-368]|
               2[06-8]|
               4[49]|
               77
@@ -29929,7 +30101,7 @@
         <nationalNumberPattern>
           340(?:
             2(?:
-              0[0-38]|
+              0[0-368]|
               2[06-8]|
               4[49]|
               77
@@ -30018,7 +30190,7 @@
           52[34][2-9]1[02-9]\d{4}|
           5(?:
             00|
-            2[125-7]|
+            2[125-9]|
             33|
             44|
             66|
@@ -30111,12 +30283,11 @@
             0[3-9]|
             1[0-689]|
             2[0-25-9]|
-            3[2-9]|
+            [38][2-9]|
             4[2-8]|
             5[124-9]|
             6[0-39]|
             7[0-7]|
-            8[2-79]|
             9[0-4679]
           )\d{7}
         </nationalNumberPattern>
@@ -30133,7 +30304,7 @@
               2[238]|
               59
             )|
-            89[689]|
+            89[6-9]|
             99[013-9]
           )\d{6}|
           (?:
@@ -30447,7 +30618,10 @@
         <numberFormat pattern="(\d)(\d{3})(\d{3,4})" nationalPrefixFormattingRule="$NP$FG">
           <leadingDigits>
             [1-6]|
-            7[24-68]
+            7(?:
+              [24-6]|
+              8[0-7]
+            )
           </leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
@@ -30485,7 +30659,7 @@
       <mobile>
         <possibleLengths national="9"/>
         <exampleNumber>712345678</exampleNumber>
-        <nationalNumberPattern>7[0137]\d{7}</nationalNumberPattern>
+        <nationalNumberPattern>7[01378]\d{7}</nationalNumberPattern>
       </mobile>
     </territory>
 
@@ -30496,15 +30670,20 @@
     <!-- http://en.wikipedia.org/wiki/Telephone_numbers_in_France -->
     <!-- http://www.comores-online.com/mwezinet/internet/262 -->
     <!-- http://www.arcep.fr/index.php?id=2137&bloc=0596&CMD=RESULTS_NUMEROTATION -->
-    <territory id="YT" countryCode="262" leadingDigits="269|63" internationalPrefix="00"
+    <territory id="YT" countryCode="262" leadingDigits="269|63|9398" internationalPrefix="00"
                nationalPrefix="0">
       <generalDesc>
         <nationalNumberPattern>
-          80\d{7}|
           (?:
-            26|
-            63
-          )9\d{6}
+            (?:
+              (?:
+                26|
+                63
+              )9|
+              80\d
+            )\d\d|
+            93980
+          )\d{4}
         </nationalNumberPattern>
       </generalDesc>
       <fixedLine>
@@ -30512,7 +30691,7 @@
         <exampleNumber>269601234</exampleNumber>
         <nationalNumberPattern>
           269(?:
-            0[0-367]|
+            0[0-467]|
             5[0-3]|
             6\d|
             [78]0
@@ -30523,14 +30702,17 @@
         <possibleLengths national="9"/>
         <exampleNumber>639012345</exampleNumber>
         <nationalNumberPattern>
-          639(?:
-            0[0-79]|
-            1[019]|
-            [267]\d|
-            3[09]|
-            40|
-            5[05-9]|
-            9[04-79]
+          (?:
+            639(?:
+              0[0-79]|
+              1[019]|
+              [267]\d|
+              3[09]|
+              40|
+              5[05-9]|
+              9[04-79]
+            )|
+            93980
           )\d{4}
         </nationalNumberPattern>
       </mobile>
@@ -30754,7 +30936,7 @@
         <exampleNumber>955123456</exampleNumber>
         <nationalNumberPattern>
           (?:
-            7[679]|
+            7[5-79]|
             9[5-8]
           )\d{7}
         </nationalNumberPattern>
@@ -31160,21 +31342,22 @@
       <generalDesc>
         <nationalNumberPattern>
           (?:
-            005|
-            [1-9]\d\d
-          )\d{5}
+            00|
+            [1-9]\d
+          )\d{6}
         </nationalNumberPattern>
       </generalDesc>
-      <!-- SN number starting with '0' is added based on number mentioned in
-           https://www.lectra.com/en/contact and it is diallable from France (Orange network) -->
+      <!-- SN number starting with '00' is added based on number mentioned in
+           https://www.lectra.com/en/contact and it is diallable from France (Orange network)
+           https://www.bio-rad.com/contact-us?field_custom_metadata_country=39&field_custom_metadata_vertical_code=All (country = France) -->
       <tollFree>
         <possibleLengths national="8"/>
         <exampleNumber>12345678</exampleNumber>
         <nationalNumberPattern>
           (?:
-            005|
-            [1-9]\d\d
-          )\d{5}
+            00|
+            [1-9]\d
+          )\d{6}
         </nationalNumberPattern>
       </tollFree>
     </territory>
@@ -31299,12 +31482,15 @@
         </numberFormat>
         <!-- For 8 digit mobile numbers. -->
         <numberFormat pattern="(\d{2})(\d{6})">
-          <leadingDigits>4</leadingDigits>
+          <leadingDigits>49</leadingDigits>
           <format>$1 $2</format>
         </numberFormat>
         <!-- For 8 digit VOIP numbers. -->
         <numberFormat pattern="(\d{2})(\d{2})(\d{4})">
-          <leadingDigits>[19]</leadingDigits>
+          <leadingDigits>
+            1[36]|
+            9
+          </leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
         <!-- For 9 digit mobile numbers. -->
@@ -31314,12 +31500,21 @@
         </numberFormat>
         <!-- For 9 and 10 digit VOIP numbers. -->
         <numberFormat pattern="(\d{2})(\d{3,4})(\d{4})">
-          <leadingDigits>1</leadingDigits>
+          <leadingDigits>16</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
         <!-- For 10 digit numbers in general. -->
         <numberFormat pattern="(\d{2})(\d{4})(\d{4})">
-          <leadingDigits>34[57]</leadingDigits>
+          <leadingDigits>
+            10|
+            23|
+            3(?:
+              [15]|
+              4[57]
+            )|
+            4|
+            51
+          </leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
         <!-- For voice mail numbers. -->
@@ -31329,7 +31524,7 @@
         </numberFormat>
         <!-- For 11 and 12 digit numbers except voice mail. -->
         <numberFormat pattern="(\d{2})(\d{4,5})(\d{5})">
-          <leadingDigits>[1-3]</leadingDigits>
+          <leadingDigits>[1-35]</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
       </availableFormats>
@@ -31338,11 +31533,13 @@
           [13]\d{6}(?:
             \d{2,5}
           )?|
-          285\d{9}|
+          [19]\d{7}|
           (?:
-            [19]\d|
-            49
-          )\d{6}
+            [25]\d\d|
+            4
+          )\d{7}(?:
+            \d{2}
+          )?
         </nationalNumberPattern>
       </generalDesc>
       <!-- Bebbicell Mobile numbers, MCP and Oration. We are guessing the number length for
@@ -31357,10 +31554,13 @@
             337|
             49
           )\d{6}|
-          3(?:
-            2|
-            47|
-            7\d{3}
+          (?:
+            3(?:
+              2|
+              47|
+              7\d{3}
+            )|
+            50\d{3}
           )\d{7}
         </nationalNumberPattern>
       </mobile>
@@ -31385,15 +31585,22 @@
             6\d{5,10}
           )|
           (?:
-            (?:
-              285\d\d|
-              3(?:
-                45|
-                [69]\d{3}
-              )
-            )\d|
+            345\d|
             9[89]
-          )\d{6}
+          )\d{6}|
+          (?:
+            10|
+            2(?:
+              3|
+              85\d
+            )|
+            3(?:
+              [15]|
+              [69]\d\d
+            )|
+            4[15-8]|
+            51
+          )\d{8}
         </nationalNumberPattern>
       </voip>
       <voicemail>
@@ -31411,12 +31618,21 @@
     <!-- http://www.itu.int/oth/T02020000F3/en -->
     <territory id="001" countryCode="883">
       <availableFormats>
+        <numberFormat pattern="(\d{3})(\d{3})(\d{2,8})">
+          <leadingDigits>
+            [14]|
+            2[24-689]|
+            3[02-689]|
+            51[24-9]
+          </leadingDigits>
+          <format>$1 $2 $3</format>
+        </numberFormat>
         <numberFormat pattern="(\d{3})(\d{3})(\d{3})">
           <leadingDigits>510</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
         <numberFormat pattern="(\d{3})(\d{3})(\d{4})">
-          <leadingDigits>2</leadingDigits>
+          <leadingDigits>21</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
         <!-- When only 8 digits follow the area code formatting as XXXX XXXX
@@ -31426,33 +31642,42 @@
           <format>$1 $2 $3</format>
         </numberFormat>
         <numberFormat pattern="(\d{3})(\d{3})(\d{3})(\d{3})">
-          <leadingDigits>[35]</leadingDigits>
+          <leadingDigits>[235]</leadingDigits>
           <format>$1 $2 $3 $4</format>
         </numberFormat>
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
           (?:
-            210|
-            370\d\d
-          )\d{7}|
-          51\d{7}(?:
-            \d{3}
-          )?
+            [1-4]\d|
+            51
+          )\d{6,10}
         </nationalNumberPattern>
       </generalDesc>
       <voip>
-        <possibleLengths national="9,10,12"/>
+        <possibleLengths national="[8-12]"/>
         <exampleNumber>510012345</exampleNumber>
         <nationalNumberPattern>
           (?:
-            210|
+            2(?:
+              00\d\d|
+              10
+            )|
             (?:
               370[1-9]|
-              51[013]0
+              51\d0
             )\d
           )\d{7}|
-          5100\d{5}
+          51(?:
+            00\d{5}|
+            [24-9]0\d{4,7}
+          )|
+          (?:
+            1[013-79]|
+            2[24-689]|
+            3[02-689]|
+            4[0-4]
+          )0\d{5,9}
         </nationalNumberPattern>
       </voip>
     </territory>

--- a/resources/PhoneNumberMetadataForTesting.xml
+++ b/resources/PhoneNumberMetadataForTesting.xml
@@ -3,7 +3,7 @@
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.
      You may obtain a copy of the License at
-
+     
      http://www.apache.org/licenses/LICENSE-2.0
 
      Unless required by applicable law or agreed to in writing, software
@@ -372,6 +372,50 @@
         </nationalNumberPattern>
         <possibleLengths national="11"/>
         <exampleNumber>13123456789</exampleNumber>
+      </mobile>
+    </territory>
+
+    <!-- Colombia (CO) -->
+    <!-- Data is here to check formatForMobileDialling() API is no more considering CO as special
+         i.e it returns regular E.164 format rather than using the 03 carrier code. -->
+    <territory id="CO" countryCode="57" nationalPrefix="0"
+               nationalPrefixForParsing="0(4(?:[14]4|56)|[579])?" mobileNumberPortableRegion="true">
+      <availableFormats>
+        <numberFormat pattern="(\d{3})(\d{7})" nationalPrefixFormattingRule="($FG)"
+                      carrierCodeFormattingRule="$NP$CC $FG">
+          <leadingDigits>6</leadingDigits>
+          <format>$1 $2</format>
+        </numberFormat>
+        <numberFormat pattern="(\d{3})(\d{7})" carrierCodeFormattingRule="$NP$CC $FG">
+          <leadingDigits>3</leadingDigits>
+          <format>$1 $2</format>
+        </numberFormat>
+      </availableFormats>
+      <generalDesc>
+        <nationalNumberPattern>
+          (?:
+            60|
+            3\d
+          )\d{8}
+        </nationalNumberPattern>
+      </generalDesc>
+      <fixedLine>
+        <possibleLengths national="10"/>
+        <exampleNumber>6012345678</exampleNumber>
+        <nationalNumberPattern>60\d{8}</nationalNumberPattern>
+      </fixedLine>
+      <mobile>
+        <possibleLengths national="10"/>
+        <exampleNumber>3211234567</exampleNumber>
+        <nationalNumberPattern>
+          3(?:
+            0[0-5]|
+            1\d|
+            2[0-3]|
+            5[01]|
+            70
+          )\d{7}
+        </nationalNumberPattern>
       </mobile>
     </territory>
 


### PR DESCRIPTION
This PR updates the phone metadata to version 8.13.7 -- the latest version on LibPhoneNumber.